### PR TITLE
Add the RTLS BSDF model to the eradiate plugins

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,17 @@
             "MI_ENABLE_EMBREE": "OFF",
             "MI_DEFAULT_VARIANTS": "scalar_mono;scalar_mono_double;scalar_rgb;scalar_spectral;llvm_rgb"
         }
+    },{
+        "name": "eradiate_debug",
+        "displayName": "Eradiate Debug Config",
+        "description": "Eradiate kernel (mitsuba3) build using Ninja generator with debug symbols and no optimisation flags",
+        "generator": "Ninja",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Debug",
+            "CMAKE_CXX_FLAGS": "-O0 -g3",
+            "MI_ENABLE_EMBREE": "OFF",
+            "MI_DEFAULT_VARIANTS": "scalar_mono;scalar_mono_double;scalar_rgb;scalar_spectral;llvm_rgb;llvm_ad_rgb"
+        }
     }],
     "buildPresets": [{
         "name": "eradiate",

--- a/src/eradiate_plugins/bsdfs/CMakeLists.txt
+++ b/src/eradiate_plugins/bsdfs/CMakeLists.txt
@@ -3,5 +3,6 @@ set(MI_PLUGIN_PREFIX "bsdfs")
 add_plugin(bilambertian bilambertian.cpp)
 add_plugin(mqdiffuse mqdiffuse.cpp)
 add_plugin(rpv rpv.cpp)
+add_plugin(rtls rtls.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/bsdfs/rtls.cpp
+++ b/src/eradiate_plugins/bsdfs/rtls.cpp
@@ -33,12 +33,28 @@ Ross-Thick Li-Sparse reflection model (:monosp:`rtls`)
    - :math:`f_{vol}`. Default: 0.004140
    - |exposed| |differentiable|
 
+ * - h
+   - |float|
+   - :math:`h`. Default: 2.f
+   - |exposed|
+
+ * - r
+   - |float|
+   - :math:`r`. Default: 1.f
+   - |exposed|
+
+ * - b
+   - |float|
+   - :math:`b`. Default: 1.f
+   - |exposed|
+
 The RTLS plugin implement the Ross-Thick, Li-Sparse model proposed by
 (Strahler et al, 1999) for the MODIS operational the BRDF model Version 5.0
 
 Default parameters for :math:`f_k` parameters are taken from the RAMI4ATM
 benchmark test cases defined by the JRC, for measures done using the Sentinel-2A
-MSI band 8A spectral region (centered around 865nm).
+MSI band 8A spectral region (centered around 865nm):
+https://rami-benchmark.jrc.ec.europa.eu
 
 */
 
@@ -58,9 +74,9 @@ public:
          * Algorithm Theoretical Basis Document
          * Version 5.0"
          */
-        m_h     = props.get<ScalarFloat>("h", 2.0f);
-        m_r     = props.get<ScalarFloat>("r", 1.0f);
-        m_b     = props.get<ScalarFloat>("b", 1.0f);
+        m_h     = props.get<ScalarFloat>("h", 2.f);
+        m_r     = props.get<ScalarFloat>("r", 1.f);
+        m_b     = props.get<ScalarFloat>("b", 1.f);
         m_flags = BSDFFlags::GlossyReflection | BSDFFlags::FrontSide;
         dr::set_attr(this, "flags", m_flags);
         m_components.push_back(m_flags);
@@ -186,19 +202,6 @@ public:
         Float cos_d_phi = cos_phi_i * cos_phi_o + sin_phi_i * sin_phi_o;
         Float sin_d_phi = sin_phi_i * cos_phi_o - cos_phi_i * sin_phi_o;
 
-        std::ostringstream oss;
-        oss << "Geometrical setup" << std::endl
-            << "  phi_i: " << dr::asin(sin_phi_i) << std::endl
-            << "    sin(phi_i): " << sin_phi_i << std::endl
-            << "    cos(phi_i): " << cos_phi_i << std::endl
-            << "  phi_o: " << dr::asin(sin_phi_o) << std::endl
-            << "    sin(phi_o): " << sin_phi_o << std::endl
-            << "    cos(phi_o): " << cos_phi_o << std::endl
-            << "  d_phi: " << dr::asin(sin_d_phi) << std::endl
-            << "    sin(d_phi): " << sin_d_phi << std::endl
-            << "    cos(d_phi): " << cos_d_phi << std::endl;
-        Log(Trace, oss.str().c_str());
-
         const Float cos_psi =
             cos_theta_i * cos_theta_o + sin_theta_i * sin_theta_o * cos_d_phi;
 
@@ -236,7 +239,7 @@ public:
                                tan_theta_o, cos_d_phi, sin_d_phi, cos_psi);
         }
 
-        oss = std::ostringstream();
+        std::ostringstream oss = std::ostringstream();
         oss << "Results" << std::endl
             << "  K_iso: " << K_iso << std::endl
             << "  K_vol:" << K_vol << std::endl
@@ -246,7 +249,7 @@ public:
         const UnpolarizedSpectrum value =
             (f_iso * K_iso + f_vol * K_vol + f_geo * K_geo);
 
-        return depolarizer<Spectrum>(dr::select(value > 0.0, value, dr::NaN<ScalarFloat>));
+        return depolarizer<Spectrum>(value);
     }
 
     Spectrum eval(const BSDFContext & /*ctx*/, const SurfaceInteraction3f &si,
@@ -297,9 +300,9 @@ public:
         oss << "RTLSBSDF[" << std::endl
             << "  f_iso = " << string::indent(m_f_iso) << "," << std::endl
             << "  f_vol = " << string::indent(m_f_vol) << "," << std::endl
-            << "  f_geo = " << string::indent(m_f_geo) << std::endl
-            << "  h = " << string::indent(m_h) << std::endl
-            << "  r = " << string::indent(m_r) << std::endl
+            << "  f_geo = " << string::indent(m_f_geo) << "," << std::endl
+            << "  h = " << string::indent(m_h) << "," << std::endl
+            << "  r = " << string::indent(m_r) << "," << std::endl
             << "  b = " << string::indent(m_b) << std::endl
             << "]";
         return oss.str();

--- a/src/eradiate_plugins/bsdfs/rtls.cpp
+++ b/src/eradiate_plugins/bsdfs/rtls.cpp
@@ -239,12 +239,10 @@ public:
                                tan_theta_o, cos_d_phi, sin_d_phi, cos_psi);
         }
 
-        std::ostringstream oss = std::ostringstream();
-        oss << "Results" << std::endl
-            << "  K_iso: " << K_iso << std::endl
-            << "  K_vol:" << K_vol << std::endl
-            << "  K_geo: " << K_geo << std::endl;
-        Log(Trace, oss.str().c_str());
+        Log(
+            Trace, "Intermediate kernel outputs:\n  K_iso: %s\n  K_vol: %s\n  K_geo: %s",
+            K_iso, K_vol, K_geo
+        );
 
         const UnpolarizedSpectrum value =
             (f_iso * K_iso + f_vol * K_vol + f_geo * K_geo);

--- a/src/eradiate_plugins/bsdfs/rtls.cpp
+++ b/src/eradiate_plugins/bsdfs/rtls.cpp
@@ -33,12 +33,13 @@ Ross-Thick Li-Sparse reflection model (:monosp:`rtls`)
    - :math:`f_{vol}`. Default: 0.004140
    - |exposed| |differentiable|
 
-The RTLS plugin implement the Ross-Thick, Li-Sparse reflection model proposed by
-(Strahler et al, 1999) [TODO properly cite].
+The RTLS plugin implement the Ross-Thick, Li-Sparse model proposed by
+(Strahler et al, 1999) for the MODIS operational the BRDF model Version 5.0
 
 Default parameters for :math:`f_k` parameters are taken from the RAMI4ATM
 benchmark test cases defined by the JRC, for measures done using the Sentinel-2A
-MSI band 8A spectral region (centered around 865nm). [TODO properly cite]
+MSI band 8A spectral region (centered around 865nm).
+
 */
 
 MI_VARIANT
@@ -242,10 +243,10 @@ public:
             << "  K_geo: " << K_geo << std::endl;
         Log(Trace, oss.str().c_str());
 
-        UnpolarizedSpectrum value =
+        const UnpolarizedSpectrum value =
             (f_iso * K_iso + f_vol * K_vol + f_geo * K_geo);
 
-        return depolarizer<Spectrum>(value);
+        return depolarizer<Spectrum>(dr::select(value > 0.0, value, dr::NaN<ScalarFloat>));
     }
 
     Spectrum eval(const BSDFContext & /*ctx*/, const SurfaceInteraction3f &si,
@@ -256,7 +257,7 @@ public:
               cos_theta_o = Frame3f::cos_theta(wo);
 
         active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
-        Spectrum value = eval_rtls(si, wo, active);
+        const Spectrum value = eval_rtls(si, wo, active);
 
         return dr::select(
             active, depolarizer<Spectrum>(value) * dr::abs(cos_theta_o), 0.f);

--- a/src/eradiate_plugins/bsdfs/rtls.cpp
+++ b/src/eradiate_plugins/bsdfs/rtls.cpp
@@ -1,0 +1,321 @@
+#include <mitsuba/core/frame.h>
+#include <mitsuba/core/fwd.h>
+#include <mitsuba/core/math.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/bsdf.h>
+#include <mitsuba/render/texture.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _plugin-bsdf-rtls:
+
+Ross-Thick Li-Sparse reflection model (:monosp:`rtls`)
+--------------------------------------------------------
+
+.. pluginparameters::
+
+ * - f_iso
+   - |spectrum| or |texture|
+   - :math:`f_{iso}`. Default: 0.209741
+   - |exposed| |differentiable|
+
+ * - f_geo
+   - |spectrum| or |texture|
+   - :math:`f_{geo}`. Default: 0.081384
+   - |exposed| |differentiable|
+
+ * - f_vol
+   - |spectrum| or |texture|
+   - :math:`f_{vol}`. Default: 0.004140
+   - |exposed| |differentiable|
+
+The RTLS plugin implement the Ross-Thick, Li-Sparse reflection model proposed by
+(Strahler et al, 1999) [TODO properly cite].
+
+Default parameters for :math:`f_k` parameters are taken from the RAMI4ATM
+benchmark test cases defined by the JRC, for measures done using the Sentinel-2A
+MSI band 8A spectral region (centered around 865nm). [TODO properly cite]
+*/
+
+MI_VARIANT
+class RTLSBSDF final : public BSDF<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(BSDF, m_flags, m_components)
+    MI_IMPORT_TYPES(Texture)
+
+    RTLSBSDF(const Properties &props) : Base(props) {
+        m_f_iso = props.texture<Texture>("f_iso", 0.209741f);
+        m_f_vol = props.texture<Texture>("f_vol", 0.081384f);
+        m_f_geo = props.texture<Texture>("f_geo", 0.004140f);
+
+        /*
+         * Values from: "MODIS BRDF/Albedo Product:
+         * Algorithm Theoretical Basis Document
+         * Version 5.0"
+         */
+        m_h     = props.get<ScalarFloat>("h", 2.0f);
+        m_r     = props.get<ScalarFloat>("r", 1.0f);
+        m_b     = props.get<ScalarFloat>("b", 1.0f);
+        m_flags = BSDFFlags::GlossyReflection | BSDFFlags::FrontSide;
+        dr::set_attr(this, "flags", m_flags);
+        m_components.push_back(m_flags);
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_object("f_iso", m_f_iso.get(),
+                             +ParamFlags::Differentiable);
+        callback->put_object("f_vol", m_f_vol.get(),
+                             +ParamFlags::Differentiable);
+        callback->put_object("f_geo", m_f_geo.get(),
+                             +ParamFlags::Differentiable);
+    }
+
+    std::pair<BSDFSample3f, Spectrum> sample(const BSDFContext &ctx,
+                                             const SurfaceInteraction3f &si,
+                                             Float /* position_sample */,
+                                             const Point2f &direction_sample,
+                                             Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFSample, active);
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi);
+        BSDFSample3f bs   = dr::zeros<BSDFSample3f>();
+
+        active &= cos_theta_i > 0.f;
+        if (unlikely(dr::none_or<false>(active) ||
+                     !ctx.is_enabled(BSDFFlags::GlossyReflection)))
+            return { bs, 0.f };
+
+        bs.wo           = warp::square_to_cosine_hemisphere(direction_sample);
+        bs.pdf          = warp::square_to_cosine_hemisphere_pdf(bs.wo);
+        bs.eta          = 1.f;
+        bs.sampled_type = +BSDFFlags::GlossyReflection;
+        bs.sampled_component = 0;
+
+        UnpolarizedSpectrum value =
+            eval_rtls(si, bs.wo, active) * Frame3f::cos_theta(bs.wo) / bs.pdf;
+
+        return { bs, depolarizer<Spectrum>(value) & (active && bs.pdf > 0.f) };
+    }
+
+    inline const UnpolarizedSpectrum eval_K_iso() const { return 1.0f; }
+
+    inline const UnpolarizedSpectrum eval_K_vol(const Float &cos_theta_i,
+                                                const Float &cos_theta_o,
+                                                const Float &cos_psi,
+                                                const Float &sin_psi,
+                                                const Float &psi) const {
+        return ((dr::Pi<Float> / 2.f - psi) * cos_psi + sin_psi) /
+                   (cos_theta_i + cos_theta_o) -
+               (dr::Pi<Float> / 4.f);
+    }
+
+    inline const UnpolarizedSpectrum eval_D(const Float &tan_theta_i,
+                                            const Float &tan_theta_o,
+                                            const Float &cos_d_phi) const {
+        return dr::sqrt(dr::sqr(tan_theta_i) + dr::sqr(tan_theta_o) -
+                        2.f * tan_theta_i * tan_theta_o * cos_d_phi);
+    }
+
+    inline const UnpolarizedSpectrum eval_O(const Float &tan_theta_i,
+                                            const Float &tan_theta_o,
+                                            const Float &sec_theta_sum,
+                                            const Float &cos_d_phi,
+                                            const Float &sin_d_phi) const {
+
+        const UnpolarizedSpectrum D =
+            eval_D(tan_theta_i, tan_theta_o, cos_d_phi);
+        Log(Trace, "D: %s", D);
+
+        const Float tan_sin_prod = tan_theta_i * tan_theta_o * sin_d_phi;
+        UnpolarizedSpectrum cos_t =
+            (m_h / m_b) * dr::sqrt(dr::sqr(D) + dr::sqr(tan_sin_prod)) /
+            sec_theta_sum;
+
+        // Clip cos(t) values outside of [-1; 1]
+        cos_t = dr::minimum(cos_t, 1.f);
+        cos_t = dr::maximum(cos_t, -1.f);
+        Log(Trace, "cos_t: %s", cos_t);
+
+        const UnpolarizedSpectrum t     = dr::acos(cos_t);
+        const UnpolarizedSpectrum sin_t = dr::sin(t);
+
+        return (1.f / dr::Pi<Float>) *(t - sin_t * cos_t) * sec_theta_sum;
+    }
+
+    inline const UnpolarizedSpectrum
+    eval_K_geo(const Float &cos_theta_i, const Float &cos_theta_o,
+               const Float &tan_theta_i, const Float &tan_theta_o,
+               const Float &cos_d_phi, const Float &sin_d_phi,
+               const Float &cos_psi) const {
+        const Float sec_theta_i = 1.f / cos_theta_i;
+        const Float sec_theta_o = 1.f / cos_theta_o;
+
+        const Float sec_theta_sum = sec_theta_i + sec_theta_o;
+
+        const UnpolarizedSpectrum O = eval_O(
+            tan_theta_i, tan_theta_o, sec_theta_sum, cos_d_phi, sin_d_phi);
+
+        Log(Trace, "O: %s", O);
+
+        return O - sec_theta_sum +
+               0.5 * (1.f + cos_psi) * sec_theta_i * sec_theta_o;
+    }
+
+    const UnpolarizedSpectrum eval_rtls(const SurfaceInteraction3f &si,
+                                        const Vector3f &wo, Mask active) const {
+
+        const UnpolarizedSpectrum f_iso = m_f_iso->eval(si, active);
+        const UnpolarizedSpectrum f_vol = m_f_vol->eval(si, active);
+        const UnpolarizedSpectrum f_geo = m_f_geo->eval(si, active);
+
+        auto [sin_phi_i, cos_phi_i] = Frame3f::sincos_phi(si.wi);
+        auto [sin_phi_o, cos_phi_o] = Frame3f::sincos_phi(wo);
+
+        const Float sin_theta_i = Frame3f::sin_theta(si.wi);
+        const Float cos_theta_i = Frame3f::cos_theta(si.wi);
+        const Float tan_theta_i = Frame3f::tan_theta(si.wi);
+        const Float sin_theta_o = Frame3f::sin_theta(wo);
+        const Float cos_theta_o = Frame3f::cos_theta(wo);
+        const Float tan_theta_o = Frame3f::tan_theta(wo);
+
+        Float cos_d_phi = cos_phi_i * cos_phi_o + sin_phi_i * sin_phi_o;
+        Float sin_d_phi = sin_phi_i * cos_phi_o - cos_phi_i * sin_phi_o;
+
+        std::ostringstream oss;
+        oss << "Geometrical setup" << std::endl
+            << "  phi_i: " << dr::asin(sin_phi_i) << std::endl
+            << "    sin(phi_i): " << sin_phi_i << std::endl
+            << "    cos(phi_i): " << cos_phi_i << std::endl
+            << "  phi_o: " << dr::asin(sin_phi_o) << std::endl
+            << "    sin(phi_o): " << sin_phi_o << std::endl
+            << "    cos(phi_o): " << cos_phi_o << std::endl
+            << "  d_phi: " << dr::asin(sin_d_phi) << std::endl
+            << "    sin(d_phi): " << sin_d_phi << std::endl
+            << "    cos(d_phi): " << cos_d_phi << std::endl;
+        Log(Trace, oss.str().c_str());
+
+        const Float cos_psi =
+            cos_theta_i * cos_theta_o + sin_theta_i * sin_theta_o * cos_d_phi;
+
+        const Float sin_psi = dr::sqrt(1 - dr::sqr(cos_psi));
+        const Float psi     = dr::acos(cos_psi);
+
+        const UnpolarizedSpectrum K_iso = eval_K_iso();
+        const UnpolarizedSpectrum K_vol =
+            eval_K_vol(cos_theta_i, cos_theta_o, cos_psi, sin_psi, psi);
+
+        UnpolarizedSpectrum K_geo;
+        if (unlikely(m_r - m_b > dr::Epsilon<ScalarFloat>)) {
+            Log(Debug, "Using different b and r values forcing extra angles "
+                       "calculations");
+
+            const Float tan_theta_i_prim = m_b / m_r * tan_theta_i;
+            const Float tan_theta_o_prim = m_b / m_r * tan_theta_o;
+            const Float theta_i_prim     = dr::atan(tan_theta_i_prim);
+            const Float theta_o_prim     = dr::atan(tan_theta_o_prim);
+            const Float cos_theta_i_prim = dr::cos(theta_i_prim);
+            const Float cos_theta_o_prim = dr::cos(theta_o_prim);
+            const Float sin_theta_i_prim = dr::sin(theta_i_prim);
+            const Float sin_theta_o_prim = dr::sin(theta_o_prim);
+            const Float cos_psi_prim =
+                cos_theta_i_prim * cos_theta_o_prim +
+                sin_theta_i_prim * sin_theta_o_prim * cos_d_phi;
+
+            K_geo = eval_K_geo(cos_theta_i_prim, cos_theta_o_prim,
+                               tan_theta_i_prim, tan_theta_o_prim, cos_d_phi,
+                               sin_d_phi, cos_psi_prim);
+        } else {
+            Log(Trace, "Using similar b and r values, skipping extra angles "
+                       "calculations");
+            K_geo = eval_K_geo(cos_theta_i, cos_theta_o, tan_theta_i,
+                               tan_theta_o, cos_d_phi, sin_d_phi, cos_psi);
+        }
+
+        oss = std::ostringstream();
+        oss << "Results" << std::endl
+            << "  K_iso: " << K_iso << std::endl
+            << "  K_vol:" << K_vol << std::endl
+            << "  K_geo: " << K_geo << std::endl;
+        Log(Trace, oss.str().c_str());
+
+        UnpolarizedSpectrum value =
+            (f_iso * K_iso + f_vol * K_vol + f_geo * K_geo);
+
+        return depolarizer<Spectrum>(value);
+    }
+
+    Spectrum eval(const BSDFContext & /*ctx*/, const SurfaceInteraction3f &si,
+                  const Vector3f &wo, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi),
+              cos_theta_o = Frame3f::cos_theta(wo);
+
+        active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
+        Spectrum value = eval_rtls(si, wo, active);
+
+        return dr::select(
+            active, depolarizer<Spectrum>(value) * dr::abs(cos_theta_o), 0.f);
+    }
+
+    Float pdf(const BSDFContext &, const SurfaceInteraction3f &si,
+              const Vector3f &wo, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi),
+              cos_theta_o = Frame3f::cos_theta(wo);
+
+        Float pdf = warp::square_to_cosine_hemisphere_pdf(wo);
+
+        return dr::select(cos_theta_i > 0.f && cos_theta_o > 0.f, pdf, 0.f);
+    }
+
+    std::pair<Spectrum, Float> eval_pdf(const BSDFContext &,
+                                        const SurfaceInteraction3f &si,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi),
+              cos_theta_o = Frame3f::cos_theta(wo);
+
+        active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
+        Spectrum value = eval_rtls(si, wo, active);
+        Float pdf      = warp::square_to_cosine_hemisphere_pdf(wo);
+
+        return { depolarizer<Spectrum>(value) * dr::abs(cos_theta_o) & active,
+                 dr::select(active, pdf, 0.f) };
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "RTLSBSDF[" << std::endl
+            << "  f_iso = " << string::indent(m_f_iso) << "," << std::endl
+            << "  f_vol = " << string::indent(m_f_vol) << "," << std::endl
+            << "  f_geo = " << string::indent(m_f_geo) << std::endl
+            << "  h = " << string::indent(m_h) << std::endl
+            << "  r = " << string::indent(m_r) << std::endl
+            << "  b = " << string::indent(m_b) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS();
+
+private:
+    ref<Texture> m_f_iso;
+    ref<Texture> m_f_vol;
+    ref<Texture> m_f_geo;
+
+    ScalarFloat m_h;
+    ScalarFloat m_r;
+    ScalarFloat m_b;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(RTLSBSDF, BSDF)
+MI_EXPORT_PLUGIN(RTLSBSDF, "Ross-Thick-Li-Sparse BSDF")
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/tests/bsdfs/test_rpv.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_rpv.py
@@ -3,7 +3,7 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
-from eradiate.test_tools.plugin import sample_eval_pdf_bsdf
+from ..tools import sample_eval_pdf_bsdf
 
 
 def test_create_rpv3(variant_scalar_rgb):

--- a/src/eradiate_plugins/tests/bsdfs/test_rtls.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_rtls.py
@@ -3,7 +3,71 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
-#from ..tools import sample_eval_pdf_bsdf
+from ..tools import sample_eval_pdf_bsdf
+
+
+def rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h=2., r=1., b=1.):
+
+    #
+    # Ross-Thick, Li-Sparse BRDF
+    #
+    # Model from:
+    # MODIS BRDF/Albedo Product: Algorithm Theoretical Basis Document Version 5.0
+    # MODIS Product ID: MOD43
+    # (Strahler et al, 1999)
+    #
+    # Implementation by Christian Lanconelli and Fabrizio Cappucci, JRC
+    #
+
+    phi = phi_i - phi_o
+
+    cos_phi = np.cos(phi)
+    sin_phi = np.sin(phi)
+    cos_sun = np.cos(theta_i)
+    cos_view = np.cos(theta_o)
+    sin_sun = np.sin(theta_i)
+    sin_view = np.sin(theta_o)
+
+    cos_psi = cos_sun * cos_view + sin_sun * sin_view * cos_phi
+    sin_psi = np.sqrt(1. - cos_psi * cos_psi)
+    psi = np.arccos(cos_psi)
+
+    thv_p = np.arctan(b / r * sin_view / cos_view)
+    ths_p = np.arctan(b / r * sin_sun / cos_sun)
+    phi_p = np.arctan(b / r * sin_phi / cos_phi)
+
+    sec_thv_p = 1. / np.cos(thv_p)
+    sec_ths_p = 1. / np.cos(ths_p)
+
+    big_d = np.sqrt(np.square(np.tan(ths_p)) + np.square(np.tan(thv_p)) -
+                            2. * np.tan(ths_p) * np.tan(thv_p) * cos_phi)
+
+    cos_t = h / b * np.sqrt(np.square(big_d) + np.square(np.tan(thv_p) * np.tan(ths_p) * sin_phi)
+                                    ) / (sec_ths_p + sec_thv_p)
+
+    # Constrain cos_t to [-1, 1]
+    cos_t = np.array(cos_t)
+    if np.count_nonzero(cos_t < -1):
+        cos_t[cos_t < -1] = -1
+    if np.count_nonzero(cos_t > 1):
+        cos_t[cos_t > 1] = 1
+
+    t = np.arccos(cos_t)
+    sin_t = np.sqrt(1. - cos_t * cos_t)
+    big_o = 1./np.pi * (t - sin_t * cos_t) * (sec_thv_p + sec_ths_p)
+
+    cos_psi_p = (np.cos(ths_p) * np.cos(thv_p)) + \
+                        (np.sin(ths_p) * np.sin(thv_p) * cos_phi)
+
+    k_tick = (((np.pi / 2. - psi) * cos_psi + sin_psi) / (cos_sun + cos_view)) - np.pi / 4.
+    k_sparse = big_o - sec_ths_p - sec_thv_p + 0.5 * (1 + cos_psi_p) * sec_thv_p * \
+                                                                  sec_ths_p
+
+    brdf = f_iso + f_geo * k_sparse + f_vol * k_tick
+
+    brdf[brdf < 0.0] = np.nan
+
+    return brdf, k_tick, k_sparse
 
 
 def test_create_rtls(variant_scalar_rgb):
@@ -33,18 +97,89 @@ def eval_bsdf(bsdf, wi, wo):
     ctx = mi.BSDFContext()
     return bsdf.eval(ctx, si, wo, True)[0]
 
-def test_defaults_and_print(variant_llvm_ad_rgb):
+
+def test_defaults_and_print(variant_scalar_mono):
     rtls = mi.load_dict({"type": "rtls"})
     value = str(rtls)
-    print(value)
+    reference = "\n".join(["RTLSBSDF[",
+    "  f_iso = UniformSpectrum[value=0.209741],",
+    "  f_vol = UniformSpectrum[value=0.081384],",
+    "  f_geo = UniformSpectrum[value=0.004140]",
+    "  h = 2",
+    "  r = 1",
+    "  b = 1",
+    "]"])
+    assert reference == value
+
+
+regnsion_test_geometries = [
+    (0.18430089, 1.46592582, 3.92553451, 0.39280281),
+]
+
+
+@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regnsion_test_geometries)
+def test_k_vol_angles(variant_scalar_mono, theta_i, theta_o, phi_i, phi_o):
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": 0.0, "f_vol": 1.0, "f_geo": 0.0})
+
+    wi = angles_to_directions(theta_i, phi_i)
+    wo = angles_to_directions(theta_o, phi_o)
+    value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
+
+    reference, k_vol, k_geo = rtls_reference(0.0, 1.0, 0.0,
+        np.array([theta_i]), np.array([phi_i]), np.array([theta_o]), np.array([phi_o]))
+
+    assert dr.allclose(value, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
+
+
+@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regnsion_test_geometries)
+def test_k_geo_angles(variant_scalar_mono, theta_i, theta_o, phi_i, phi_o):
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": 0.0, "f_vol": 0.0, "f_geo": 1.0})
+
+    wi = angles_to_directions(theta_i, phi_i)
+    wo = angles_to_directions(theta_o, phi_o)
+    value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
+
+    reference, k_vol, k_geo = rtls_reference(0.0, 0.0, 1.0,
+        np.array([theta_i]), np.array([phi_i]), np.array([theta_o]), np.array([phi_o]))
+
+    assert dr.allclose(value, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
+
+
+@pytest.mark.parametrize("f_iso", [0.0, 1.0])
+@pytest.mark.parametrize("f_vol", [0.0, 1.0])
+@pytest.mark.parametrize("f_geo", [0.0, 1.0])
+def test_rtls_scalar_combinations(variant_scalar_mono, f_iso, f_vol, f_geo):
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    num_samples = 100
+
+    theta_i = np.random.rand(num_samples) * np.pi / 2.0
+    theta_o = np.random.rand(num_samples) * np.pi / 2.0
+    phi_i = np.random.rand(num_samples) * np.pi * 2.0
+    phi_o = np.random.rand(num_samples) * np.pi * 2.0
+
+    values = []
+    for j in range(num_samples):
+        wi = angles_to_directions(theta_i[j], phi_i[j])
+        wo = angles_to_directions(theta_o[j], phi_o[j])
+        value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o[j])
+        values.append(value)
+
+    values = np.asarray(values)
+
+    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o)
+
+    assert dr.allclose(values, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
 
 
 @pytest.mark.parametrize("f_iso", [0.004, 0.1, 0.497])
-@pytest.mark.parametrize("f_geo", [0.543, 0.634, 0.851])
 @pytest.mark.parametrize("f_vol", [0.29, 0.086, 0.2])
-def test_rtls(variant_llvm_ad_rgb, f_iso, f_geo, f_vol):
+@pytest.mark.parametrize("f_geo", [0.543, 0.634, 0.851])
+def test_rtls_vect(variant_llvm_ad_rgb, f_iso, f_vol, f_geo):
 
-    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_geo": f_geo, "f_vol": f_vol})
+    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
     num_samples = 100
 
     theta_i = np.random.rand(num_samples) * np.pi / 2.0
@@ -54,6 +189,178 @@ def test_rtls(variant_llvm_ad_rgb, f_iso, f_geo, f_vol):
 
     wi = angles_to_directions(theta_i, phi_i)
     wo = angles_to_directions(theta_o, phi_o)
+    values = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
+
+    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o)
+    assert dr.allclose(values, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
+
+
+@pytest.mark.parametrize("R", [0.0, 0.5, 1.0])
+def test_eval_diffuse(variant_scalar_mono, R):
+    """
+    Compare a degenerate RTLS case with a diffuse BRDF.
+    """
+
+    f_iso = R / np.pi
+    f_vol = 0.0
+    f_geo = 0.0
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    diffuse = mi.load_dict({"type": "diffuse", "reflectance": R})
+
+    theta_i = np.random.rand(1) * np.pi / 2.0
+    theta_o = np.random.rand(1) * np.pi / 2.0
+    phi_i = np.random.rand(1) * np.pi * 2.0
+    phi_o = np.random.rand(1) * np.pi * 2.0
+
+    wi = angles_to_directions(theta_i, phi_i)
+    wo = angles_to_directions(theta_o, phi_o)
+    values = eval_bsdf(rtls, wi, wo)
+    reference = eval_bsdf(diffuse, wi, wo)
+
+    assert np.allclose(values, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
+
+
+def test_chi2_rtls(variant_llvm_ad_rgb):
+    from mitsuba.chi2 import BSDFAdapter, ChiSquareTest, SphericalDomain
+
+    sample_func, pdf_func = BSDFAdapter("rtls", "")
+
+    chi2 = ChiSquareTest(
+        domain=SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+    )
+
+    assert chi2.run()
+
+
+@pytest.mark.parametrize("wi", [[0, 0, 1], [0, 1, 1], [1, 1, 1]])
+def test_sampling_weights_rpv(variant_scalar_mono, wi):
+    """
+    Sampling weights are correctly computed, i.e. equal to eval() / pdf().
+    """
+    rtls = mi.load_dict({"type": "rtls"})
+    (_, weight), eval, pdf = sample_eval_pdf_bsdf(
+        rtls, dr.normalize(mi.ScalarVector3f(wi))
+    )
+    assert dr.allclose(weight, eval / pdf)
+
+
+rami4atm_RLI_parameters = [
+    (0.024950, 	-0.002250, 	0.001513), # S2A MSI B02
+    (0.050877, 	-0.004504, 	0.003073), # S2A MSI B03
+    (0.032171, 	-0.002886, 	0.001949), # S2A MSI B04
+    (0.209741, 	0.081384, 	0.004140), # S2A MSI B8A
+    (0.095761, 	0.035598, 	0.002086), # S2A MSI B11
+    (0.046899, 	0.017130, 	0.001060), # S2A MSI B12
+]
+
+
+@pytest.mark.parametrize("f_iso,f_vol,f_geo", rami4atm_RLI_parameters)
+def test_rami4atm_sanity_check(variant_llvm_ad_rgb, f_iso, f_geo, f_vol, np_rng):
+
+    # Given a set of parameters taken from the RAMI4ATM benchmark, assumed to be
+    # physically correct, test the BRDF common properties:
+    #  - Take positive values
+    #  - Conserve energy
+    #  - Obey the Helmholtz reciprocity relationship
+    # Please refer to the RAMI4ATM scenario description by the JRC
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+
+    num_samples = 1000
+
+    # Use RAMI4ATM angle limits
+    theta_i = np.deg2rad(np_rng.random(num_samples) * 80)
+    theta_o = np.deg2rad(np_rng.random(num_samples) * 80)
+    phi_i = np_rng.random(num_samples) * np.pi * 2.0
+    phi_o = np_rng.random(num_samples) * np.pi * 2.0
+
+    wi = angles_to_directions(theta_i, phi_i)
+    wo = angles_to_directions(theta_o, phi_o)
     values = eval_bsdf(rtls, wi, wo)
 
-    raise RuntimeError(values)
+    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo,
+        theta_i, phi_i, theta_o, phi_o
+    )
+
+    # Sanity check against the reference implementation
+    assert dr.allclose(values  / np.cos(theta_o), reference, rtol=1e-3, atol=1e-3)
+
+    # Check all positives
+    problematic_geometries = np.concatenate([
+        np.rad2deg(theta_i.reshape(-1, 1)),
+        np.rad2deg(theta_o.reshape(-1, 1)),
+        np.rad2deg(phi_i.reshape(-1, 1)),
+        np.rad2deg(phi_o.reshape(-1, 1)),
+        np.array(values).reshape(-1, 1)
+    ], axis=1)[values / np.cos(theta_o) < 0.0]
+
+    if len(problematic_geometries):
+        print("Found negative values in RTLS evaluation: [theta_i, theta_o, phi_i, phi_o, rtls_bsdf]")
+        print(problematic_geometries)
+
+    return
+    assert len(problematic_geometries) == 0
+
+    # Checking Helmholtz reciprocity
+    reciprocal_values = eval_bsdf(rtls, wo, wi)
+    assert dr.allclose(values / np.cos(theta_o), reciprocal_values / np.cos(theta_i), rtol=1e-3, atol=1e-3)
+
+    # Checking the integral over the hemisphere is lower than 1
+    def sph_to_dir(theta, phi):
+        """Map spherical to Euclidean coordinates"""
+        st, ct = dr.sincos(theta)
+        sp, cp = dr.sincos(phi)
+        return mi.Vector3f(cp * st, sp * st, ct)
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.wi = sph_to_dir(dr.deg2rad(45.0), 0.0)
+    n = 1000
+    theta_o, phi_o = dr.meshgrid(
+        dr.linspace(mi.Float, 0,     dr.pi,     n),
+        dr.linspace(mi.Float, 0, 2 * dr.pi, 2 * n)
+    )
+    wo = sph_to_dir(theta_o, phi_o)
+    rho_wi = np.array(rtls.eval(mi.BSDFContext(), si, wo))
+    diff_wo = np.sin(theta_o) * (np.pi / n) * (np.pi / n)
+    diff_wo = diff_wo.reshape(diff_wo.shape[0], 1) @ np.ones((1, rho_wi.shape[1]))
+    rho_wi = rho_wi * diff_wo
+    assert all(np.sum(rho_wi, axis=0) <= 1.0)
+
+
+#check other values of h, r and b
+@pytest.mark.parametrize("h,r,b", [
+    (2., 1.5, 1.),
+    (2., 1., 0.5),
+    (1.8, 0.8, 0.5),
+])
+@pytest.mark.parametrize("f_iso,f_vol,f_geo", rami4atm_RLI_parameters)
+def test_hrb_parameters(variant_scalar_mono, f_iso, f_geo, f_vol, h, r, b):
+
+    rtls = mi.load_dict({
+        "type": "rtls",
+        "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo,
+        "h": h,
+        "r": r,
+        "b": b,
+    })
+    num_samples =100
+
+    theta_i = np.random.rand(num_samples) * np.pi / 2.0
+    theta_o = np.random.rand(num_samples) * np.pi / 2.0
+    phi_i = np.random.rand(num_samples) * np.pi * 2.0
+    phi_o = np.random.rand(num_samples) * np.pi * 2.0
+
+    values = []
+    for j in range(num_samples):
+        wi = angles_to_directions(theta_i[j], phi_i[j])
+        wo = angles_to_directions(theta_o[j], phi_o[j])
+        value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o[j])
+        values.append(value)
+
+    values = np.asarray(values)
+
+    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h, r, b)
+    assert dr.allclose(values, reference, rtol=1e-2, atol=1e-2, equal_nan=True)

--- a/src/eradiate_plugins/tests/bsdfs/test_rtls.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_rtls.py
@@ -6,8 +6,9 @@ import pytest
 from ..tools import sample_eval_pdf_bsdf
 
 
-def rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h=2., r=1., b=1.):
-
+def rtls_reference(
+    f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h=2.0, r=1.0, b=1.0
+):
     #
     # Ross-Thick, Li-Sparse BRDF
     #
@@ -29,21 +30,28 @@ def rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h=2., r=
     sin_view = np.sin(theta_o)
 
     cos_psi = cos_sun * cos_view + sin_sun * sin_view * cos_phi
-    sin_psi = np.sqrt(1. - cos_psi * cos_psi)
+    sin_psi = np.sqrt(1.0 - cos_psi * cos_psi)
     psi = np.arccos(cos_psi)
 
     thv_p = np.arctan(b / r * sin_view / cos_view)
     ths_p = np.arctan(b / r * sin_sun / cos_sun)
     phi_p = np.arctan(b / r * sin_phi / cos_phi)
 
-    sec_thv_p = 1. / np.cos(thv_p)
-    sec_ths_p = 1. / np.cos(ths_p)
+    sec_thv_p = 1.0 / np.cos(thv_p)
+    sec_ths_p = 1.0 / np.cos(ths_p)
 
-    big_d = np.sqrt(np.square(np.tan(ths_p)) + np.square(np.tan(thv_p)) -
-                            2. * np.tan(ths_p) * np.tan(thv_p) * cos_phi)
+    big_d = np.sqrt(
+        np.square(np.tan(ths_p))
+        + np.square(np.tan(thv_p))
+        - 2.0 * np.tan(ths_p) * np.tan(thv_p) * cos_phi
+    )
 
-    cos_t = h / b * np.sqrt(np.square(big_d) + np.square(np.tan(thv_p) * np.tan(ths_p) * sin_phi)
-                                    ) / (sec_ths_p + sec_thv_p)
+    cos_t = (
+        h
+        / b
+        * np.sqrt(np.square(big_d) + np.square(np.tan(thv_p) * np.tan(ths_p) * sin_phi))
+        / (sec_ths_p + sec_thv_p)
+    )
 
     # Constrain cos_t to [-1, 1]
     cos_t = np.array(cos_t)
@@ -53,19 +61,21 @@ def rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h=2., r=
         cos_t[cos_t > 1] = 1
 
     t = np.arccos(cos_t)
-    sin_t = np.sqrt(1. - cos_t * cos_t)
-    big_o = 1./np.pi * (t - sin_t * cos_t) * (sec_thv_p + sec_ths_p)
+    sin_t = np.sqrt(1.0 - cos_t * cos_t)
+    big_o = 1.0 / np.pi * (t - sin_t * cos_t) * (sec_thv_p + sec_ths_p)
 
-    cos_psi_p = (np.cos(ths_p) * np.cos(thv_p)) + \
-                        (np.sin(ths_p) * np.sin(thv_p) * cos_phi)
+    cos_psi_p = (np.cos(ths_p) * np.cos(thv_p)) + (
+        np.sin(ths_p) * np.sin(thv_p) * cos_phi
+    )
 
-    k_tick = (((np.pi / 2. - psi) * cos_psi + sin_psi) / (cos_sun + cos_view)) - np.pi / 4.
-    k_sparse = big_o - sec_ths_p - sec_thv_p + 0.5 * (1 + cos_psi_p) * sec_thv_p * \
-                                                                  sec_ths_p
+    k_tick = (
+        ((np.pi / 2.0 - psi) * cos_psi + sin_psi) / (cos_sun + cos_view)
+    ) - np.pi / 4.0
+    k_sparse = (
+        big_o - sec_ths_p - sec_thv_p + 0.5 * (1 + cos_psi_p) * sec_thv_p * sec_ths_p
+    )
 
     brdf = f_iso + f_geo * k_sparse + f_vol * k_tick
-
-    brdf[brdf < 0.0] = np.nan
 
     return brdf, k_tick, k_sparse
 
@@ -101,48 +111,64 @@ def eval_bsdf(bsdf, wi, wo):
 def test_defaults_and_print(variant_scalar_mono):
     rtls = mi.load_dict({"type": "rtls"})
     value = str(rtls)
-    reference = "\n".join(["RTLSBSDF[",
-    "  f_iso = UniformSpectrum[value=0.209741],",
-    "  f_vol = UniformSpectrum[value=0.081384],",
-    "  f_geo = UniformSpectrum[value=0.004140]",
-    "  h = 2",
-    "  r = 1",
-    "  b = 1",
-    "]"])
+    reference = "\n".join(
+        [
+            "RTLSBSDF[",
+            "  f_iso = UniformSpectrum[value=0.209741],",
+            "  f_vol = UniformSpectrum[value=0.081384],",
+            "  f_geo = UniformSpectrum[value=0.004140],",
+            "  h = 2,",
+            "  r = 1,",
+            "  b = 1",
+            "]",
+        ]
+    )
     assert reference == value
 
 
-regnsion_test_geometries = [
+regression_test_geometries = [
     (0.18430089, 1.46592582, 3.92553451, 0.39280281),
 ]
 
 
-@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regnsion_test_geometries)
+@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regression_test_geometries)
 def test_k_vol_angles(variant_scalar_mono, theta_i, theta_o, phi_i, phi_o):
-
     rtls = mi.load_dict({"type": "rtls", "f_iso": 0.0, "f_vol": 1.0, "f_geo": 0.0})
 
     wi = angles_to_directions(theta_i, phi_i)
     wo = angles_to_directions(theta_o, phi_o)
     value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
 
-    reference, k_vol, k_geo = rtls_reference(0.0, 1.0, 0.0,
-        np.array([theta_i]), np.array([phi_i]), np.array([theta_o]), np.array([phi_o]))
+    reference, k_vol, k_geo = rtls_reference(
+        0.0,
+        1.0,
+        0.0,
+        np.array([theta_i]),
+        np.array([phi_i]),
+        np.array([theta_o]),
+        np.array([phi_o]),
+    )
 
     assert dr.allclose(value, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
 
 
-@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regnsion_test_geometries)
+@pytest.mark.parametrize("theta_i,theta_o,phi_i,phi_o", regression_test_geometries)
 def test_k_geo_angles(variant_scalar_mono, theta_i, theta_o, phi_i, phi_o):
-
     rtls = mi.load_dict({"type": "rtls", "f_iso": 0.0, "f_vol": 0.0, "f_geo": 1.0})
 
     wi = angles_to_directions(theta_i, phi_i)
     wo = angles_to_directions(theta_o, phi_o)
     value = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
 
-    reference, k_vol, k_geo = rtls_reference(0.0, 0.0, 1.0,
-        np.array([theta_i]), np.array([phi_i]), np.array([theta_o]), np.array([phi_o]))
+    reference, k_vol, k_geo = rtls_reference(
+        0.0,
+        0.0,
+        1.0,
+        np.array([theta_i]),
+        np.array([phi_i]),
+        np.array([theta_o]),
+        np.array([phi_o]),
+    )
 
     assert dr.allclose(value, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
 
@@ -151,8 +177,9 @@ def test_k_geo_angles(variant_scalar_mono, theta_i, theta_o, phi_i, phi_o):
 @pytest.mark.parametrize("f_vol", [0.0, 1.0])
 @pytest.mark.parametrize("f_geo", [0.0, 1.0])
 def test_rtls_scalar_combinations(variant_scalar_mono, f_iso, f_vol, f_geo):
-
-    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    rtls = mi.load_dict(
+        {"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo}
+    )
     num_samples = 100
 
     theta_i = np.random.rand(num_samples) * np.pi / 2.0
@@ -169,7 +196,9 @@ def test_rtls_scalar_combinations(variant_scalar_mono, f_iso, f_vol, f_geo):
 
     values = np.asarray(values)
 
-    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o)
+    reference, k_vol, k_geo = rtls_reference(
+        f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o
+    )
 
     assert dr.allclose(values, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
 
@@ -178,8 +207,9 @@ def test_rtls_scalar_combinations(variant_scalar_mono, f_iso, f_vol, f_geo):
 @pytest.mark.parametrize("f_vol", [0.29, 0.086, 0.2])
 @pytest.mark.parametrize("f_geo", [0.543, 0.634, 0.851])
 def test_rtls_vect(variant_llvm_ad_rgb, f_iso, f_vol, f_geo):
-
-    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    rtls = mi.load_dict(
+        {"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo}
+    )
     num_samples = 100
 
     theta_i = np.random.rand(num_samples) * np.pi / 2.0
@@ -191,7 +221,9 @@ def test_rtls_vect(variant_llvm_ad_rgb, f_iso, f_vol, f_geo):
     wo = angles_to_directions(theta_o, phi_o)
     values = eval_bsdf(rtls, wi, wo) / np.cos(theta_o)
 
-    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o)
+    reference, k_vol, k_geo = rtls_reference(
+        f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o
+    )
     assert dr.allclose(values, reference, rtol=1e-3, atol=1e-3, equal_nan=True)
 
 
@@ -205,7 +237,9 @@ def test_eval_diffuse(variant_scalar_mono, R):
     f_vol = 0.0
     f_geo = 0.0
 
-    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    rtls = mi.load_dict(
+        {"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo}
+    )
     diffuse = mi.load_dict({"type": "diffuse", "reflectance": R})
 
     theta_i = np.random.rand(1) * np.pi / 2.0
@@ -249,18 +283,17 @@ def test_sampling_weights_rpv(variant_scalar_mono, wi):
 
 
 rami4atm_RLI_parameters = [
-    (0.024950, 	-0.002250, 	0.001513), # S2A MSI B02
-    (0.050877, 	-0.004504, 	0.003073), # S2A MSI B03
-    (0.032171, 	-0.002886, 	0.001949), # S2A MSI B04
-    (0.209741, 	0.081384, 	0.004140), # S2A MSI B8A
-    (0.095761, 	0.035598, 	0.002086), # S2A MSI B11
-    (0.046899, 	0.017130, 	0.001060), # S2A MSI B12
+    (0.024950, -0.002250, 0.001513),  # S2A MSI B02
+    (0.050877, -0.004504, 0.003073),  # S2A MSI B03
+    (0.032171, -0.002886, 0.001949),  # S2A MSI B04
+    (0.209741, 0.081384, 0.004140),  # S2A MSI B8A
+    (0.095761, 0.035598, 0.002086),  # S2A MSI B11
+    (0.046899, 0.017130, 0.001060),  # S2A MSI B12
 ]
 
 
 @pytest.mark.parametrize("f_iso,f_vol,f_geo", rami4atm_RLI_parameters)
 def test_rami4atm_sanity_check(variant_llvm_ad_rgb, f_iso, f_geo, f_vol, np_rng):
-
     # Given a set of parameters taken from the RAMI4ATM benchmark, assumed to be
     # physically correct, test the BRDF common properties:
     #  - Take positive values
@@ -268,7 +301,9 @@ def test_rami4atm_sanity_check(variant_llvm_ad_rgb, f_iso, f_geo, f_vol, np_rng)
     #  - Obey the Helmholtz reciprocity relationship
     # Please refer to the RAMI4ATM scenario description by the JRC
 
-    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo})
+    rtls = mi.load_dict(
+        {"type": "rtls", "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo}
+    )
 
     num_samples = 1000
 
@@ -282,32 +317,41 @@ def test_rami4atm_sanity_check(variant_llvm_ad_rgb, f_iso, f_geo, f_vol, np_rng)
     wo = angles_to_directions(theta_o, phi_o)
     values = eval_bsdf(rtls, wi, wo)
 
-    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo,
-        theta_i, phi_i, theta_o, phi_o
+    reference, k_vol, k_geo = rtls_reference(
+        f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o
     )
 
     # Sanity check against the reference implementation
-    assert dr.allclose(values  / np.cos(theta_o), reference, rtol=1e-3, atol=1e-3)
+    assert dr.allclose(values / np.cos(theta_o), reference, rtol=1e-3, atol=1e-3)
 
     # Check all positives
-    problematic_geometries = np.concatenate([
-        np.rad2deg(theta_i.reshape(-1, 1)),
-        np.rad2deg(theta_o.reshape(-1, 1)),
-        np.rad2deg(phi_i.reshape(-1, 1)),
-        np.rad2deg(phi_o.reshape(-1, 1)),
-        np.array(values).reshape(-1, 1)
-    ], axis=1)[values / np.cos(theta_o) < 0.0]
+    problematic_geometries = np.concatenate(
+        [
+            np.rad2deg(theta_i.reshape(-1, 1)),
+            np.rad2deg(theta_o.reshape(-1, 1)),
+            np.rad2deg(phi_i.reshape(-1, 1)),
+            np.rad2deg(phi_o.reshape(-1, 1)),
+            np.array(values).reshape(-1, 1),
+        ],
+        axis=1,
+    )[values / np.cos(theta_o) < 0.0]
 
     if len(problematic_geometries):
-        print("Found negative values in RTLS evaluation: [theta_i, theta_o, phi_i, phi_o, rtls_bsdf]")
+        print(
+            "Found negative values in RTLS evaluation: [theta_i, theta_o, phi_i, phi_o, rtls_bsdf]"
+        )
         print(problematic_geometries)
 
-    return
     assert len(problematic_geometries) == 0
 
     # Checking Helmholtz reciprocity
     reciprocal_values = eval_bsdf(rtls, wo, wi)
-    assert dr.allclose(values / np.cos(theta_o), reciprocal_values / np.cos(theta_i), rtol=1e-3, atol=1e-3)
+    assert dr.allclose(
+        values / np.cos(theta_o),
+        reciprocal_values / np.cos(theta_i),
+        rtol=1e-3,
+        atol=1e-3,
+    )
 
     # Checking the integral over the hemisphere is lower than 1
     def sph_to_dir(theta, phi):
@@ -315,38 +359,44 @@ def test_rami4atm_sanity_check(variant_llvm_ad_rgb, f_iso, f_geo, f_vol, np_rng)
         st, ct = dr.sincos(theta)
         sp, cp = dr.sincos(phi)
         return mi.Vector3f(cp * st, sp * st, ct)
+
     si = dr.zeros(mi.SurfaceInteraction3f)
     si.wi = sph_to_dir(dr.deg2rad(45.0), 0.0)
-    n = 1000
+    n = 100
     theta_o, phi_o = dr.meshgrid(
-        dr.linspace(mi.Float, 0,     dr.pi,     n),
-        dr.linspace(mi.Float, 0, 2 * dr.pi, 2 * n)
+        dr.linspace(mi.Float, 0, dr.pi, n), dr.linspace(mi.Float, 0, 2 * dr.pi, 2 * n)
     )
     wo = sph_to_dir(theta_o, phi_o)
     rho_wi = np.array(rtls.eval(mi.BSDFContext(), si, wo))
     diff_wo = np.sin(theta_o) * (np.pi / n) * (np.pi / n)
     diff_wo = diff_wo.reshape(diff_wo.shape[0], 1) @ np.ones((1, rho_wi.shape[1]))
     rho_wi = rho_wi * diff_wo
-    assert all(np.sum(rho_wi, axis=0) <= 1.0)
+    assert all(np.nan_to_num(np.sum(rho_wi, axis=0)) <= 1.0)
 
 
-#check other values of h, r and b
-@pytest.mark.parametrize("h,r,b", [
-    (2., 1.5, 1.),
-    (2., 1., 0.5),
-    (1.8, 0.8, 0.5),
-])
+# check other values of h, r and b
+@pytest.mark.parametrize(
+    "h,r,b",
+    [
+        (2.0, 1.5, 1.0),
+        (2.0, 1.0, 0.5),
+        (1.8, 0.8, 0.5),
+    ],
+)
 @pytest.mark.parametrize("f_iso,f_vol,f_geo", rami4atm_RLI_parameters)
 def test_hrb_parameters(variant_scalar_mono, f_iso, f_geo, f_vol, h, r, b):
-
-    rtls = mi.load_dict({
-        "type": "rtls",
-        "f_iso": f_iso, "f_vol": f_vol, "f_geo": f_geo,
-        "h": h,
-        "r": r,
-        "b": b,
-    })
-    num_samples =100
+    rtls = mi.load_dict(
+        {
+            "type": "rtls",
+            "f_iso": f_iso,
+            "f_vol": f_vol,
+            "f_geo": f_geo,
+            "h": h,
+            "r": r,
+            "b": b,
+        }
+    )
+    num_samples = 100
 
     theta_i = np.random.rand(num_samples) * np.pi / 2.0
     theta_o = np.random.rand(num_samples) * np.pi / 2.0
@@ -362,5 +412,7 @@ def test_hrb_parameters(variant_scalar_mono, f_iso, f_geo, f_vol, h, r, b):
 
     values = np.asarray(values)
 
-    reference, k_vol, k_geo = rtls_reference(f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h, r, b)
+    reference, k_vol, k_geo = rtls_reference(
+        f_iso, f_vol, f_geo, theta_i, phi_i, theta_o, phi_o, h, r, b
+    )
     assert dr.allclose(values, reference, rtol=1e-2, atol=1e-2, equal_nan=True)

--- a/src/eradiate_plugins/tests/bsdfs/test_rtls.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_rtls.py
@@ -1,0 +1,59 @@
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import pytest
+
+#from ..tools import sample_eval_pdf_bsdf
+
+
+def test_create_rtls(variant_scalar_rgb):
+    # Test constructor of 3-parameter version of RPV
+    rtls = mi.load_dict({"type": "rtls"})
+
+    assert isinstance(rtls, mi.BSDF)
+    assert rtls.component_count() == 1
+    assert rtls.flags(0) == mi.BSDFFlags.GlossyReflection | mi.BSDFFlags.FrontSide
+    assert rtls.flags() == rtls.flags(0)
+
+    params = mi.traverse(rtls)
+    assert "f_iso.value" in params
+    assert "f_geo.value" in params
+    assert "f_vol.value" in params
+
+
+def angles_to_directions(theta, phi):
+    return mi.Vector3f(
+        np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi), np.cos(theta)
+    )
+
+
+def eval_bsdf(bsdf, wi, wo):
+    si = mi.SurfaceInteraction3f()
+    si.wi = wi
+    ctx = mi.BSDFContext()
+    return bsdf.eval(ctx, si, wo, True)[0]
+
+def test_defaults_and_print(variant_llvm_ad_rgb):
+    rtls = mi.load_dict({"type": "rtls"})
+    value = str(rtls)
+    print(value)
+
+
+@pytest.mark.parametrize("f_iso", [0.004, 0.1, 0.497])
+@pytest.mark.parametrize("f_geo", [0.543, 0.634, 0.851])
+@pytest.mark.parametrize("f_vol", [0.29, 0.086, 0.2])
+def test_rtls(variant_llvm_ad_rgb, f_iso, f_geo, f_vol):
+
+    rtls = mi.load_dict({"type": "rtls", "f_iso": f_iso, "f_geo": f_geo, "f_vol": f_vol})
+    num_samples = 100
+
+    theta_i = np.random.rand(num_samples) * np.pi / 2.0
+    theta_o = np.random.rand(num_samples) * np.pi / 2.0
+    phi_i = np.random.rand(num_samples) * np.pi * 2.0
+    phi_o = np.random.rand(num_samples) * np.pi * 2.0
+
+    wi = angles_to_directions(theta_i, phi_i)
+    wo = angles_to_directions(theta_o, phi_o)
+    values = eval_bsdf(rtls, wi, wo)
+
+    raise RuntimeError(values)

--- a/src/eradiate_plugins/tests/tools.py
+++ b/src/eradiate_plugins/tests/tools.py
@@ -1,0 +1,75 @@
+import drjit as dr
+import mitsuba as mi
+
+def sample_eval_pdf_bsdf(
+    plugin,
+    wi,
+    sample_count: int = 100000,
+    seed: int = 0,
+):
+    """
+    Sample a BSDF and get corresponding ``eval()`` and ``pdf()`` values.
+
+    Parameters
+    ----------
+    plugin : mitsuba.BSDF
+        A BSDF plugin to be evaluated.
+
+    wi : mitsuba.ScalarVector3f
+        An incoming direction.
+
+    sample_count : int, optional, default: 100000
+        The number of samples to generate.
+
+    seed : int, optional, default: 0
+        RNG seed to be used.
+
+    Returns
+    -------
+    sample
+        The result of a call to the plugin's ``sample()`` method.
+
+    eval
+        The result of a call to the plugin's ``eval()`` method.
+
+    pdf
+        The result of a call to the plugin's ``pdf()`` method.
+
+    Warnings
+    --------
+    This function requires a JIT active variant (*e.g.* ``llvm_ad_rgb``).
+    """
+
+    # Generate a table of uniform variates
+    idx = dr.arange(mi.UInt64, sample_count)
+    v0, v1 = mi.sample_tea_32(idx, seed)
+
+    # Scramble seed and stream index using TEA, a linearly increasing sequence
+    # does not produce a sufficiently statistically independent set of streams
+    rng = mi.PCG32(initstate=v0, initseq=v1)
+
+    sample = mi.Vector3f()
+    for i in range(3):
+        sample[i] = rng.next_float32() if mi.Float is mi.Float32 else rng.next_float64()
+
+    # Invoke sampling strategy
+    n = dr.width(sample)
+    ctx = mi.BSDFContext()
+    si = dr.zeros(mi.SurfaceInteraction3f, n)
+    si.wi = wi
+    bs, weight = plugin.sample(ctx, si, sample[0], [sample[1], sample[2]])
+
+    # Get corresponding eval() and pdf() calls
+    eval = plugin.eval(ctx, si, bs.wo)
+    pdf = plugin.pdf(ctx, si, bs.wo)
+
+    del ctx
+    del sample
+    del n
+    del si
+    del rng
+    del v0
+    del v1
+    del idx
+
+    return (bs, weight), eval, pdf


### PR DESCRIPTION
## Description

Implement the Ross Thick Li Sparse (RTLS) BSDF model as defined per the [MODIS operational ATBD](https://modis.gsfc.nasa.gov/data/atbd/atbd_mod09.pdf)

## Testing

Tests are implemented in the `src/eradiate_plugins/tests/bsdfs/test_rtls.py` file. These tests include:
 - A RTLS reference implementation
 - basic bsdf class construction
 - string conversion
 - regression test boilerplate for problematic geometries
 - vectorized and scalar variants tests
 - bsdf definition sanity checks using the RAMI4ATM parameters

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for ~`cuda_*`~ and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)