### PR TITLE
Increase the version of the Eradiate patch for Mitsuba to 0.1.0

### DIFF
--- a/include/mitsuba/mitsuba.h
+++ b/include/mitsuba/mitsuba.h
@@ -25,8 +25,8 @@
 #define MI_YEAR "2023"
 
 #define ERD_MI_VERSION_MAJOR 0
-#define ERD_MI_VERSION_MINOR 0
-#define ERD_MI_VERSION_PATCH 2
+#define ERD_MI_VERSION_MINOR 1
+#define ERD_MI_VERSION_PATCH 0
 
 /// Current release of the Eradiate patch for Mitsuba
 #define ERD_MI_VERSION                                                             \


### PR DESCRIPTION
Ready for release 0.1.0 of the Eradiate modifications for Mitsuba, including the RTLS plugin. This is a minor, backward-compatible release of a new feature.
