### PR TITLE
mpdistant sensor

### DIFF
--- a/src/eradiate_plugins/sensors/CMakeLists.txt
+++ b/src/eradiate_plugins/sensors/CMakeLists.txt
@@ -4,5 +4,6 @@ add_plugin(mradiancemeter mradiancemeter.cpp)
 add_plugin(hdistant hdistant.cpp)
 add_plugin(distantflux distantflux.cpp)
 add_plugin(mdistant mdistant.cpp)
+add_plugin(mpdistant mpdistant.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/sensors/mpdistant.cpp
+++ b/src/eradiate_plugins/sensors/mpdistant.cpp
@@ -1,0 +1,343 @@
+#include <mitsuba/core/bbox.h>
+#include <mitsuba/core/bsphere.h>
+#include <mitsuba/core/math.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/transform.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/scene.h>
+#include <mitsuba/render/sensor.h>
+#include <mitsuba/render/shape.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+enum class RayTargetType { Shape, Point, None };
+
+// Forward declaration of specialized DistantSensor
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+class MultiPixelDistantSensorImpl;
+
+/**!
+
+.. _sensor-mpdistant:
+
+Multi-pixel distant radiancemeter sensor (:monosp:`mpdistant`)
+--------------------------------------------------------------
+
+.. pluginparameters::
+
+ * - to_world
+   - |transform|
+   - Sensor-to-world transformation matrix.
+
+ * - direction
+   - |vector|
+   - Alternative (and exclusive) to ``to_world``. Direction orienting the
+     sensor's reference hemisphere.
+
+ * - target
+   - |point| or nested :paramtype:`shape` plugin
+   - *Optional.* Define the ray target sampling strategy.
+     If this parameter is unset, ray target points are sampled uniformly on
+     the cross section of the scene's bounding sphere.
+     If a |point| is passed, rays will target it.
+     If a shape plugin is passed, ray target points will be sampled from its
+     surface.
+
+ * - target_radius
+   - |float|
+   - *Optional.* If a point target is used, setting this parameter to a positive
+     value will turn the sensor into a distant radiometer with a fixed field of
+     view defined as the cross section of a sphere of radius ``target_radius``
+     and centered at ``target``. Otherwise, the single point ``target`` is
+     targeted.
+
+ * - srf
+   - |spectrum|
+   - Sensor Response Function that defines the
+     :ref:`spectral sensitivity <explanation_srf_sensor>` of the sensor
+     (Default: :monosp:`none`)
+
+This sensor plugin implements a distant directional sensor which records
+radiation leaving the scene in a given direction. It records the spectral
+radiance leaving the scene in the specified direction. In its default version,
+it is the adjoint to the ``directional`` emitter.
+
+By default, ray target points are sampled from the cross section of the scene's
+bounding sphere. The ``target`` parameter can be set to restrict ray target
+sampling to a specific subregion of the scene.
+
+Ray origins are positioned outside of the scene's geometry.
+
+If the film size is larger than 1×1, film coordinates are mapped to the (u,v)
+coordinates of the target shape.
+
+.. warning::
+
+   If this sensor is used with a targeting strategy leading to rays not hitting
+   the scene's geometry (*e.g.* default targeting strategy), it will pick up
+   ambient emitter radiance samples (or zero values if no ambient emitter is
+   defined). Therefore, it is almost always preferable to use a non-default
+   targeting strategy.
+*/
+
+template <typename Float, typename Spectrum>
+class MultiPixelDistantSensor final : public Sensor<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Sensor, m_to_world, m_film)
+    MI_IMPORT_TYPES(Scene, Shape)
+
+    MultiPixelDistantSensor(const Properties &props) : Base(props), m_props(props) {
+
+        // Get target
+        if (props.has_property("target")) {
+            if (props.type("target") == Properties::Type::Array3f) {
+                props.get<ScalarPoint3f>("target");
+                m_target_type = RayTargetType::Point;
+            } else if (props.type("target") == Properties::Type::Object) {
+                // We assume it's a shape
+                m_target_type = RayTargetType::Shape;
+            } else {
+                Throw("Unsupported 'target' parameter type");
+            }
+        } else {
+            m_target_type = RayTargetType::None;
+        }
+
+        props.mark_queried("direction");
+        props.mark_queried("to_world");
+        props.mark_queried("target");
+        props.mark_queried("target_radius");
+        props.mark_queried("ray_offset");
+    }
+
+    // This must be implemented. However, it won't be used in practice:
+    // instead, MultiPixelDistantSensorImpl::bbox() is used when the plugin is
+    // instantiated.
+    ScalarBoundingBox3f bbox() const override { return ScalarBoundingBox3f(); }
+
+
+    template <RayTargetType TargetType>
+    using Impl = MultiPixelDistantSensorImpl<Float, Spectrum, TargetType>;
+
+    // Recursively expand into an implementation specialized to the target
+    // specification.
+    std::vector<ref<Object>> expand() const override {
+        ref<Object> result;
+        switch (m_target_type) {
+            case RayTargetType::Shape:
+                result = (Object *) new Impl<RayTargetType::Shape>(m_props);
+                break;
+            case RayTargetType::Point:
+                result = (Object *) new Impl<RayTargetType::Point>(m_props);
+                break;
+            case RayTargetType::None:
+                result = (Object *) new Impl<RayTargetType::None>(m_props);
+                break;
+            default:
+                Throw("Unsupported ray target type!");
+        }
+        return { result };
+    }
+
+    MI_DECLARE_CLASS()
+
+protected:
+    Properties m_props;
+    RayTargetType m_target_type;
+};
+
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+class MultiPixelDistantSensorImpl final : public Sensor<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Sensor, m_to_world, m_film, sample_wavelengths,
+                   m_needs_sample_2)
+    MI_IMPORT_TYPES(Scene, Shape)
+
+    MultiPixelDistantSensorImpl(const Properties &props) : Base(props) {
+        // Compute transform, possibly based on direction parameter
+        if (props.has_property("direction")) {
+            if (props.has_property("to_world")) {
+                Throw("Only one of the parameters 'direction' and 'to_world'"
+                      "can be specified at the same time!'");
+            }
+
+            ScalarVector3f direction(normalize(props.get<ScalarVector3f>("direction")));
+            ScalarVector3f up;
+
+            std::tie(std::ignore, up) = coordinate_system(direction);
+
+            m_to_world = ScalarTransform4f::look_at(
+                ScalarPoint3f(0.0f), ScalarPoint3f(direction), up);
+        }
+
+        // Collect ray offset value
+        // Default is -1, overridden upon set_scene() call
+        m_ray_offset = props.get<ScalarFloat>("ray_offset", -1);
+
+        // Collect target cross section if relevant (i.e. if point target is defined)
+        m_target_radius = props.get<ScalarFloat>("target_radius", -1);
+
+        // Set ray target if relevant
+        if constexpr (TargetType == RayTargetType::Point) {
+            m_target_point = props.get<ScalarPoint3f>("target");
+        } else if constexpr (TargetType == RayTargetType::Shape) {
+            auto obj       = props.object("target");
+            m_target_shape = dynamic_cast<Shape *>(obj.get());
+
+            if (!m_target_shape)
+                Throw(
+                    "Invalid parameter target, must be a Point3f or a Shape.");
+        } else {
+            Log(Debug, "No target specified.");
+        }
+
+        m_needs_sample_2 = true;
+    }
+
+    void set_scene(const Scene *scene) override {
+        m_bsphere = scene->bbox().bounding_sphere();
+        m_bsphere.radius =
+            dr::maximum(math::RayEpsilon<Float>,
+                    m_bsphere.radius * (1.f + math::RayEpsilon<Float>));
+        if (m_ray_offset == -1)
+            m_ray_offset = 2.f * m_bsphere.radius;
+    }
+
+    std::pair<Ray3f, Spectrum>
+    sample_ray(Float time, Float wavelength_sample,
+                    const Point2f &film_sample,
+                    const Point2f &/*aperture_sample*/, Mask active) const override {
+        MI_MASK_ARGUMENT(active);
+
+        Ray3f ray;
+        ray.time = time;
+
+        // Sample spectrum
+        auto [wavelengths, wav_weight] =
+            sample_wavelengths(dr::zeros<SurfaceInteraction3f>(),
+                               wavelength_sample,
+                               active);
+        ray.wavelengths = wavelengths;
+
+        // Sample ray origin
+        Spectrum ray_weight = 0.f;
+
+        // Set ray direction
+        ray.d = m_to_world.value().transform_affine(Vector3f{ 0.f, 0.f, 1.f });
+
+        // Sample target point and position ray origin
+        if constexpr (TargetType == RayTargetType::Shape) {
+            // Use area-based sampling of shape
+            PositionSample3f ps =
+                m_target_shape->sample_position(time, film_sample, active);
+            ray.o = ps.p - ray.d * m_ray_offset;
+            ray_weight = wav_weight / (ps.pdf * m_target_shape->surface_area());
+        } else {
+            if constexpr (TargetType == RayTargetType::Point) {
+                if (m_target_radius < 0.f)
+                    ray.o = m_target_point - ray.d * m_ray_offset;
+                else {
+                    Point2f offset =
+                        warp::square_to_uniform_disk_concentric(film_sample);
+                    Vector3f perp_offset =
+                        m_to_world.value().transform_affine(Vector3f(offset.x(), offset.y(), 0.f));
+                    ray.o = m_target_point + perp_offset * m_target_radius - ray.d * m_ray_offset;
+                }
+            } else { // if constexpr (TargetType == RayTargetType::None
+                // Sample target uniformly on bounding sphere cross section
+                Point2f offset =
+                    warp::square_to_uniform_disk_concentric(film_sample);
+                Vector3f perp_offset =
+                    m_to_world.value().transform_affine(Vector3f(offset.x(), offset.y(), 0.f));
+                ray.o = m_bsphere.center + perp_offset * m_bsphere.radius - ray.d * m_ray_offset;
+            }
+            ray_weight = wav_weight;
+        }
+
+        return { ray, ray_weight & active };
+    }
+
+    std::pair<RayDifferential3f, Spectrum> sample_ray_differential(
+        Float time, Float wavelength_sample, const Point2f &film_sample,
+        const Point2f &aperture_sample, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::EndpointSampleRay, active);
+
+        RayDifferential3f ray;
+        Spectrum ray_weight;
+
+        std::tie(ray, ray_weight) = sample_ray(
+            time, wavelength_sample, film_sample, aperture_sample, active);
+
+        // No differentials [TODO: Should we add this?]
+        ray.has_differentials = false;
+
+        return { ray, ray_weight & active };
+    }
+
+    // This sensor does not occupy any particular region of space, return an
+    // invalid bounding box
+    ScalarBoundingBox3f bbox() const override { return ScalarBoundingBox3f(); }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "MultiPixelDistantSensor[" << std::endl
+            << "  to_world = " << string::indent(m_to_world, 13) << "," << std::endl
+            << "  film = " << string::indent(m_film) << "," << std::endl
+            << "  ray_offset = " << m_ray_offset << "," << std::endl;
+
+        if constexpr (TargetType == RayTargetType::Point)
+            oss << "  target = " << m_target_point << "," << std::endl
+                << "  target_radius = " << m_target_radius << std::endl;
+        else if constexpr (TargetType == RayTargetType::Shape)
+            oss << "  target = " << string::indent(m_target_shape) << std::endl;
+        else // if constexpr (TargetType == RayTargetType::None)
+            oss << "  target = none" << "," << std::endl
+                << "  bsphere = " << string::indent(m_bsphere) << std::endl;
+
+        oss << "]";
+
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS()
+
+protected:
+    // Scene bounding sphere
+    ScalarBoundingSphere3f m_bsphere;
+    // Target shape if any
+    ref<Shape> m_target_shape;
+    // Target point if any
+    Point3f m_target_point;
+    // Target cross section radius when using a point target (-1 means "target a single point")
+    ScalarFloat m_target_radius;
+    // Ray offset distance (-1 means "distant")
+    ScalarFloat m_ray_offset;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(MultiPixelDistantSensor, Sensor)
+MI_EXPORT_PLUGIN(MultiPixelDistantSensor, "MultiPixelDistantSensor")
+
+NAMESPACE_BEGIN(detail)
+template <RayTargetType TargetType>
+constexpr const char *distant_sensor_class_name() {
+    if constexpr (TargetType == RayTargetType::Shape) {
+        return "MultiPixelDistantSensor_Shape";
+    } else if constexpr (TargetType == RayTargetType::Point) {
+        return "MultiPixelDistantSensor_Point";
+    } else if constexpr (TargetType == RayTargetType::None) {
+        return "MultiPixelDistantSensor_NoTarget";
+    }
+}
+NAMESPACE_END(detail)
+
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+Class *MultiPixelDistantSensorImpl<Float, Spectrum, TargetType>::m_class = new Class(
+    detail::distant_sensor_class_name<TargetType>(), "Sensor",
+    ::mitsuba::detail::get_variant<Float, Spectrum>(), nullptr, nullptr);
+
+template <typename Float, typename Spectrum, RayTargetType TargetType>
+const Class *MultiPixelDistantSensorImpl<Float, Spectrum, TargetType>::class_() const {
+    return m_class;
+}
+
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/tests/sensors/test_mpdistant.py
+++ b/src/eradiate_plugins/tests/sensors/test_mpdistant.py
@@ -1,0 +1,353 @@
+import drjit as dr
+import mitsuba as mi
+import pytest
+
+
+def sensor_dict(target=None, direction=None):
+    result = {
+        "type": "mpdistant",
+        "film": {
+            "type": "hdrfilm",
+            "width": 2,
+            "height": 2,
+            "rfilter": {"type": "box"},
+        },
+    }
+
+    if direction is not None:
+        result["direction"] = direction
+
+    if target == "point":
+        result.update({"target": [0, 0, 0]})
+
+    elif target == "shape":
+        result.update({"target": {"type": "rectangle"}})
+
+    elif isinstance(target, dict):
+        result.update({"target": target})
+
+    return result
+
+
+def make_sensor(d):
+    return mi.load_dict(d)
+
+
+def test_construct(variant_scalar_rgb):
+    # Constructing with arbitrary film size works
+    sensor = make_sensor(
+        {
+            "type": "mpdistant",
+            "film": {"type": "hdrfilm", "width": 2, "height": 2},
+        }
+    )
+    assert sensor is not None
+    assert not sensor.bbox().valid()  # Degenerate bounding box
+
+    # Constructing with 1x1 film works
+    sensor = make_sensor(
+        {
+            "type": "mpdistant",
+            "film": {"type": "hdrfilm", "width": 1, "height": 1},
+        }
+    )
+    assert sensor is not None
+    assert not sensor.bbox().valid()  # Degenerate bounding box
+
+    # Construct with direction, check transform setup correctness
+    for direction, expected in [
+        ([0, 0, -1], [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+        ([0, 0, -2], [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+    ]:
+        sensor = make_sensor(sensor_dict(direction=direction))
+        result = sensor.world_transform().matrix
+        assert dr.allclose(result, expected)
+
+    # Test different combinations of target and origin values
+    # -- No target
+    sensor = make_sensor(sensor_dict())
+    assert sensor is not None
+
+    # -- Point target
+    sensor = make_sensor(sensor_dict(target="point"))
+    assert sensor is not None
+
+    # -- Shape target
+    sensor = make_sensor(sensor_dict(target="shape"))
+    assert sensor is not None
+
+    # -- Random object target (we expect to raise)
+    with pytest.raises(RuntimeError):
+        make_sensor(sensor_dict(target={"type": "constant"}))
+
+
+@pytest.mark.parametrize(
+    "direction", [[0.0, 0.0, -1.0], [-1.0, -1.0, 0.0], [-2.0, 0.0, 0.0]]
+)
+def test_sample_ray_direction(variant_scalar_rgb, direction):
+    sensor = make_sensor(sensor_dict(direction=direction))
+
+    # Check that directions are appropriately set
+    for sample1, sample2 in [
+        [[0.32, 0.87], [0.16, 0.44]],
+        [[0.17, 0.44], [0.22, 0.81]],
+        [[0.12, 0.82], [0.99, 0.42]],
+        [[0.72, 0.40], [0.01, 0.61]],
+    ]:
+        ray, _ = sensor.sample_ray(1.0, 1.0, sample1, sample2, True)
+
+        # Check that ray direction is what is expected
+        assert dr.allclose(ray.d, dr.normalize(mi.ScalarVector3f(direction)))
+
+
+@pytest.mark.parametrize(
+    "sensor_setup",
+    [
+        "default",
+        "target_square",
+        "target_square_small",
+        "target_square_large",
+        "target_disk",
+        "target_point",
+    ],
+)
+@pytest.mark.parametrize("w_e", [[0, 0, -1], [0, 1, -1]])
+@pytest.mark.parametrize("w_o", [[0, 0, -1], [0, -1, -1]])
+@pytest.mark.slow
+def test_sample_target(variant_scalar_rgb, sensor_setup, w_e, w_o):
+    """
+    This test checks if targeting works as intended by rendering a basic scene
+    """
+
+    # Basic illumination and sensing parameters
+    l_e = 1.0  # Emitted radiance
+    w_e = dr.normalize(mi.Vector3f(w_e))  # Emitter direction
+    w_o = dr.normalize(mi.Vector3f(w_o))  # Sensor direction
+    cos_theta_e = abs(dr.dot(w_e, [0, 0, 1]))
+    cos_theta_o = abs(dr.dot(w_o, [0, 0, 1]))
+
+    # Reflecting surface specification
+    surface_scale = 1.0
+    rho = 1.0  # Surface reflectance
+
+    # Sensor definitions
+    sensors = {
+        "default": {  # No target
+            "type": "mpdistant",
+            "direction": w_o,
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+        "target_square": {  # Targeting square
+            "type": "mpdistant",
+            "direction": w_o,
+            "target": {
+                "type": "rectangle",
+                "to_world": mi.ScalarTransform4f.scale(surface_scale),
+            },
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+        "target_square_small": {  # Targeting small square
+            "type": "mpdistant",
+            "direction": w_o,
+            "target": {
+                "type": "rectangle",
+                "to_world": mi.ScalarTransform4f.scale(0.5 * surface_scale),
+            },
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+        "target_square_large": {  # Targeting large square
+            "type": "mpdistant",
+            "direction": w_o,
+            "target": {
+                "type": "rectangle",
+                "to_world": mi.ScalarTransform4f.scale(2.0 * surface_scale),
+            },
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+        "target_point": {  # Targeting point
+            "type": "mpdistant",
+            "direction": w_o,
+            "target": [0, 0, 0],
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+        "target_disk": {  # Targeting disk
+            "type": "mpdistant",
+            "direction": w_o,
+            "target": {
+                "type": "disk",
+                "to_world": mi.ScalarTransform4f.scale(surface_scale),
+            },
+            "sampler": {
+                "type": "independent",
+                "sample_count": 100000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "component_format": "float16",
+                "height": 1,
+                "width": 1,
+                "rfilter": {"type": "box"},
+            },
+        },
+    }
+
+    # Scene setup
+    scene_dict = {
+        "type": "scene",
+        "shape": {
+            "type": "rectangle",
+            "to_world": mi.ScalarTransform4f.scale(surface_scale),
+            "bsdf": {
+                "type": "diffuse",
+                "reflectance": rho,
+            },
+        },
+        "emitter": {"type": "directional", "direction": w_e, "irradiance": l_e},
+        "integrator": {"type": "path"},
+    }
+
+    scene = mi.load_dict({**scene_dict, "sensor": sensors[sensor_setup]})
+
+    # Run simulation
+    scene.integrator().render(scene, seed=0)
+
+    # Check result
+    result = mi.TensorXf(
+        scene.sensors()[0]
+        .film()
+        .bitmap()
+        .convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.Float32, False)
+    )
+
+    surface_area = 4.0 * surface_scale**2  # Area of square surface
+    l_o = l_e * cos_theta_e * rho / dr.pi
+    expected = {  # Special expected values for some cases (when rays are "lost")
+        "default": l_o * (2.0 / dr.pi) * cos_theta_o,
+        "target_square_large": l_o * 0.25,
+    }
+    expected_value = expected.get(sensor_setup, l_o)
+
+    rtol = {  # Special tolerance values for some cases
+        "target_square_large": 1e-2,
+    }
+    rtol_value = rtol.get(sensor_setup, 5e-3)
+
+    assert dr.allclose(result, expected_value, rtol=rtol_value)
+
+
+def test_checkerboard(variants_all_rgb):
+    """
+    Very basic render test with checkerboard texture and square target.
+    """
+
+    l_o = 1.0
+    rho0 = 0.5
+    rho1 = 1.0
+
+    # Scene setup
+    scene_dict = {
+        "type": "scene",
+        "shape": {
+            "type": "rectangle",
+            "bsdf": {
+                "type": "diffuse",
+                "reflectance": {
+                    "type": "checkerboard",
+                    "color0": rho0,
+                    "color1": rho1,
+                    "to_uv": mi.ScalarTransform4f.scale(2),
+                },
+            },
+        },
+        "emitter": {"type": "directional", "direction": [0, 0, -1], "irradiance": 1.0},
+        "sensor0": {
+            "type": "mpdistant",
+            "direction": [0, 0, -1],
+            "target": {"type": "rectangle"},
+            "sampler": {
+                "type": "independent",
+                "sample_count": 50000,
+            },
+            "film": {
+                "type": "hdrfilm",
+                "height": 1,
+                "width": 1,
+                "pixel_format": "luminance",
+                "component_format": "float32",
+                "rfilter": {"type": "box"},
+            },
+        },
+        # "sensor1": {  # In case one would like to check what the scene looks like
+        #     "type": "perspective",
+        #     "to_world": mi.ScalarTransform4f.look_at(origin=[0, 0, 5], target=[0, 0, 0], up=[0, 1, 0]),
+        #     "sampler": {
+        #         "type": "independent",
+        #         "sample_count": 10000,
+        #     },
+        #     "film": {
+        #         "type": "hdrfilm",
+        #         "height": 256,
+        #         "width": 256,
+        #         "pixel_format": "luminance",
+        #         "component_format": "float32",
+        #         "rfilter": {"type": "box"},
+        #     },
+        # },
+        "integrator": {"type": "path"},
+    }
+
+    scene = mi.load_dict(scene_dict)
+    data = mi.render(scene)
+
+    expected = l_o * 0.5 * (rho0 + rho1) / dr.pi
+    assert dr.allclose(data, expected, atol=1e-3)


### PR DESCRIPTION
## Description

This PR adds a multi-pixel version of the `distant` sensor. This one accepts a film with more than 1x1 dimensions and maps film coordinates to the target shape's (u,v) coordinates (or, more precisely, to the surface sampling coordinates). I tested this only with a rectangle as the target shape, which is the only useful use case I can think of.

## Testing

I added unit tests and checked visually the shape-to-film coordinate mapping.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)