### PR TITLE
[Feature] Add 1D piecewise medium and piecewise integrator plugins 

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4298,6 +4298,8 @@ static const char *__doc_mitsuba_Medium_Medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_class = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_eval_transmittance_pdf_real = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium_get_majorant = R"doc(Returns the medium's majorant used for delta tracking)doc";
 
 static const char *__doc_mitsuba_Medium_get_scattering_coefficients =
@@ -4354,6 +4356,8 @@ Returns:
     This method returns a MediumInteraction. The MediumInteraction
     will always be valid, except if the ray missed the Medium's
     bounding box.)doc";
+
+static const char *__doc_mitsuba_Medium_sample_interaction_real = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_set_id = R"doc(Set a string identifier)doc";
 

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -70,6 +70,17 @@ public:
                            const SurfaceInteraction3f &si,
                            Mask active) const;
 
+// #RAY_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+    virtual std::tuple<MediumInteraction3f, Float, Float> 
+    sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
+                            Float sample, UInt32 channel, Mask active) const;
+    
+    virtual std::tuple<Float, Float, Mask>
+    eval_transmittance_pdf_real(const Ray3f &ray, 
+                                    const SurfaceInteraction3f &si,
+                                    UInt32 channel, Mask active) const;
+// #RAY_CHANGE_END
+
     /// Return the phase function of this medium
     MI_INLINE const PhaseFunction *phase_function() const {
         return m_phase_function.get();
@@ -129,6 +140,8 @@ DRJIT_VCALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_VCALL_METHOD(intersect_aabb)
     DRJIT_VCALL_METHOD(sample_interaction)
     DRJIT_VCALL_METHOD(transmittance_eval_pdf)
+    DRJIT_VCALL_METHOD(sample_interaction_real)
+    DRJIT_VCALL_METHOD(eval_transmittance_pdf_real)
     DRJIT_VCALL_METHOD(get_scattering_coefficients)
 DRJIT_VCALL_TEMPLATE_END(mitsuba::Medium)
 

--- a/include/mitsuba/render/volume.h
+++ b/include/mitsuba/render/volume.h
@@ -63,6 +63,11 @@ public:
     /// Returns the bounding box of the volume
     ScalarBoundingBox3f bbox() const { return m_bbox; }
 
+// #RAY_CHANGE_BEGIN, NM 24/05/2024 : Add util functions to the volume class
+    /// If applicable, returns the dimensions of one grid cell in world space.
+    ScalarVector3f voxel_size() const;
+// #RAY_CHANGE_END
+
     /**
      * \brief Returns the resolution of the volume, assuming that it is based
      * on a discrete representation.

--- a/src/eradiate_plugins/CMakeLists.txt
+++ b/src/eradiate_plugins/CMakeLists.txt
@@ -6,5 +6,7 @@ add_subdirectory(phase)
 add_subdirectory(sensors)
 add_subdirectory(volumes)
 add_subdirectory(emitters)
+add_subdirectory(media)
+add_subdirectory(integrators)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/integrators/CMakeLists.txt
+++ b/src/eradiate_plugins/integrators/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(MI_PLUGIN_PREFIX "integrators")
+
+add_plugin(piecewise_volpath piecewise_volpath.cpp)
+
+set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/integrators/piecewise_volpath.cpp
+++ b/src/eradiate_plugins/integrators/piecewise_volpath.cpp
@@ -1,0 +1,502 @@
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/ray.h>
+#include <mitsuba/render/bsdf.h>
+#include <mitsuba/render/emitter.h>
+#include <mitsuba/render/integrator.h>
+#include <mitsuba/render/medium.h>
+#include <mitsuba/render/phase.h>
+#include <mitsuba/render/records.h>
+#include <random>
+#include <tuple>
+
+#include <chrono>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _integrator-piecewise_volpath:
+
+Piecewise volumetric path tracer (:monosp:`volpath`)
+-------------------------------------------
+
+.. pluginparameters::
+
+ * - max_depth
+   - |int|
+   - Specifies the longest path depth in the generated output image (where -1
+corresponds to :math:`\infty`). A value of 1 will only render directly visible
+light sources. 2 will lead to single-bounce (direct-only) illumination, and so
+on. (Default: -1)
+
+ * - rr_depth
+   - |int|
+   - Specifies the minimum path depth, after which the implementation will start
+to use the *russian roulette* path termination criterion. (Default: 5)
+
+ * - hide_emitters
+   - |bool|
+   - Hide directly visible emitters. (Default: no, i.e. |false|)
+
+This plugin provides a piecewise volumetric path tracer that can be used to
+compute approximate solutions of the radiative transfer equation for plane
+parallel geometry. Its implementation makes use of multiple importance sampling
+to combine BSDF and phase function sampling with direct illumination sampling
+strategies. On surfaces, it behaves exactly like the standard path tracer.
+
+This integrator only works with piecewise media. It uses assumptions on the
+medium's geometry to accelerate the sampling and transmission calculations.
+
+This integrator has special support for index-matched transmission events (i.e.
+surface scattering events that do not change the direction of light). As a
+consequence, participating media enclosed by a stencil shape are rendered
+considerably more efficiently when this shape has a :ref:`null <bsdf-null>` or
+:ref:`thin dielectric <bsdf-thindielectric>` BSDF assigned to it (as compared
+to, say, a :ref:`dielectric <bsdf-dielectric>` or :ref:`roughdielectric
+<bsdf-roughdielectric>` BSDF).
+
+.. note:: This integrator does not implement good sampling strategies to render
+    participating media with a spectrally varying extinction coefficient. For
+    these cases, it is better to use the more advanced :ref:`volumetric path tracer
+    with spectral MIS <integrator-volpathmis>`, which will produce in a
+    significantly less noisy rendered image.
+
+.. warning:: This integrator does not support forward-mode differentiation.
+
+.. tabs::
+    .. code-tab::  xml
+
+        <integrator type="piecewise_volpath">
+            <integer name="max_depth" value="8"/>
+        </integrator>
+
+    .. code-tab:: python
+
+        'type': 'piecewise_volpath',
+        'max_depth': 8
+
+*/
+template <typename Float, typename Spectrum>
+class PiecewiseVolumetricPathIntegrator
+    : public MonteCarloIntegrator<Float, Spectrum> {
+
+public:
+    MI_IMPORT_BASE(MonteCarloIntegrator, m_max_depth, m_rr_depth,
+                   m_hide_emitters)
+    MI_IMPORT_TYPES(Scene, Sampler, Emitter, EmitterPtr, BSDF, BSDFPtr, Medium,
+                    MediumPtr, PhaseFunctionContext)
+
+    PiecewiseVolumetricPathIntegrator(const Properties &props) : Base(props) {}
+
+    MI_INLINE
+    Float index_spectrum(const UnpolarizedSpectrum &spec,
+                         const UInt32 &idx) const {
+        Float m = spec[0];
+        if constexpr (is_rgb_v<Spectrum>) { // Handle RGB rendering
+            dr::masked(m, dr::eq(idx, 1u)) = spec[1];
+            dr::masked(m, dr::eq(idx, 2u)) = spec[2];
+        } else {
+            DRJIT_MARK_USED(idx);
+        }
+        return m;
+    }
+
+    std::pair<Spectrum, Mask> sample(const Scene *scene, Sampler *sampler,
+                                     const RayDifferential3f &ray_,
+                                     const Medium *initial_medium,
+                                     Float * /* aovs */,
+                                     Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::SamplingIntegratorSample, active);
+
+        // If there is an environment emitter and emitters are visible: all rays
+        // will be valid Otherwise, it will depend on whether a valid
+        // interaction is sampled
+        Mask valid_ray =
+            !m_hide_emitters && dr::neq(scene->environment(), nullptr);
+
+        // For now, don't use ray differentials
+        Ray3f ray = ray_;
+
+        // Tracks radiance scaling due to index of refraction changes
+        Float eta(1.f);
+
+        Spectrum throughput(1.f), result(0.f);
+        MediumPtr medium        = initial_medium;
+        MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
+        Mask specular_chain     = active && !m_hide_emitters;
+        UInt32 depth            = 0;
+
+        UInt32 channel = 0;
+        if (is_rgb_v<Spectrum>) {
+            uint32_t n_channels = (uint32_t) dr::array_size_v<Spectrum>;
+            channel             = (UInt32) dr::minimum(
+                sampler->next_1d(active) * n_channels, n_channels - 1);
+        }
+
+        SurfaceInteraction3f si          = dr::zeros<SurfaceInteraction3f>();
+        Mask needs_intersection          = true;
+        Interaction3f last_scatter_event = dr::zeros<Interaction3f>();
+        Float last_scatter_direction_pdf = 1.f;
+
+        /* Set up a Dr.Jit loop (optimizes away to a normal loop in scalar mode,
+           generates wavefront or megakernel renderer based on configuration).
+           Register everything that changes as part of the loop here */
+        dr::Loop<Mask> loop("Volpath integrator",
+                            /* loop state: */ active, depth, ray, throughput,
+                            result, si, mei, medium, eta, last_scatter_event,
+                            last_scatter_direction_pdf, needs_intersection,
+                            specular_chain, valid_ray, sampler);
+
+        while (loop(active)) {
+            // ----------------- Handle termination of paths ------------------
+            // Russian roulette: try to keep path weights equal to one, while
+            // accounting for the solid angle compression at refractive index
+            // boundaries. Stop with at least some probability to avoid  getting
+            // stuck (e.g. due to total internal reflection)
+            active &= dr::any(dr::neq(unpolarized_spectrum(throughput), 0.f));
+            Float q = dr::minimum(
+                dr::max(unpolarized_spectrum(throughput)) * dr::sqr(eta), .95f);
+            Mask perform_rr = (depth > (uint32_t) m_rr_depth);
+            active &= sampler->next_1d(active) < q || !perform_rr;
+            dr::masked(throughput, perform_rr) *= dr::rcp(dr::detach(q));
+
+            active &= depth < (uint32_t) m_max_depth;
+            if (dr::none_or<false>(active))
+                break;
+
+            // ----------------------- Sampling the RTE -----------------------
+            Mask active_medium    = active && dr::neq(medium, nullptr);
+            Mask active_surface   = active && !active_medium;
+            Mask act_null_scatter = false, act_medium_scatter = false,
+                 escaped_medium = false;
+
+            // If the medium does not have a spectrally varying extinction,
+            // we can perform a few optimizations to speed up rendering
+            Mask is_spectral  = active_medium;
+            Mask not_spectral = false;
+            if (dr::any_or<true>(active_medium)) {
+                is_spectral &= medium->has_spectral_extinction();
+                not_spectral = !is_spectral && active_medium;
+            }
+
+            if (dr::any_or<true>(active_medium)) {
+                Float tr  = dr::zeros<Float>();
+                Float pdf = dr::zeros<Float>();
+
+                Mask intersect = needs_intersection && active_medium;
+                if (dr::any_or<true>(intersect))
+                    dr::masked(si, intersect) =
+                        scene->ray_intersect(ray, intersect);
+                needs_intersection &= !active_medium;
+
+                std::tie(mei, tr, pdf) = medium->sample_interaction_real(
+                    ray, si, sampler->next_1d(active_medium), channel,
+                    active_medium);
+                dr::masked(ray.maxt, active_medium &&
+                                         medium->is_homogeneous() &&
+                                         mei.is_valid()) = mei.t;
+
+                dr::masked(mei.t, active_medium && (si.t < mei.t)) =
+                    dr::Infinity<Float>;
+                if (dr::any_or<true>(is_spectral)) {
+                    Float tr_pdf = index_spectrum(pdf, channel);
+                    dr::masked(throughput, is_spectral) *=
+                        dr::select(tr_pdf > 0.f, tr / tr_pdf, 0.f);
+                }
+
+                escaped_medium = active_medium && !mei.is_valid();
+                active_medium &= mei.is_valid();
+
+                act_medium_scatter |= !act_null_scatter && active_medium;
+
+                dr::masked(depth, act_medium_scatter) += 1;
+                dr::masked(last_scatter_event, act_medium_scatter) = mei;
+            }
+
+            // Dont estimate lighting if we exceeded number of bounces
+            active &= depth < (uint32_t) m_max_depth;
+            act_medium_scatter &= active;
+
+            if (dr::any_or<true>(act_null_scatter)) {
+                dr::masked(ray.o, act_null_scatter) = mei.p;
+                dr::masked(si.t, act_null_scatter)  = si.t - mei.t;
+            }
+
+            if (dr::any_or<true>(act_medium_scatter)) {
+                if (dr::any_or<true>(is_spectral))
+                    dr::masked(throughput, is_spectral && act_medium_scatter) *=
+                        mei.sigma_s *
+                        index_spectrum(mei.combined_extinction, channel) /
+                        index_spectrum(mei.sigma_t, channel);
+                if (dr::any_or<true>(not_spectral))
+                    dr::masked(throughput,
+                               not_spectral && act_medium_scatter) *=
+                        mei.sigma_s / mei.sigma_t;
+
+                PhaseFunctionContext phase_ctx(sampler);
+                auto phase = mei.medium->phase_function();
+
+                // --------------------- Emitter sampling ---------------------
+                Mask sample_emitters = mei.medium->use_emitter_sampling();
+                valid_ray |= act_medium_scatter;
+                specular_chain &= !act_medium_scatter;
+                specular_chain |= act_medium_scatter && !sample_emitters;
+
+                Mask active_e = act_medium_scatter && sample_emitters;
+                if (dr::any_or<true>(active_e)) {
+                    auto [emitted, ds] = sample_emitter(
+                        mei, scene, sampler, medium, channel, active_e);
+                    auto [phase_val, phase_pdf] =
+                        phase->eval_pdf(phase_ctx, mei, ds.d, active_e);
+                    dr::masked(result, active_e) +=
+                        throughput * phase_val * emitted *
+                        mis_weight(ds.pdf,
+                                   dr::select(ds.delta, 0.f, phase_pdf));
+                }
+
+                // ------------------ Phase function sampling -----------------
+                dr::masked(phase, !act_medium_scatter) = nullptr;
+                auto [wo, phase_weight, phase_pdf]     = phase->sample(
+                    phase_ctx, mei, sampler->next_1d(act_medium_scatter),
+                    sampler->next_2d(act_medium_scatter), act_medium_scatter);
+                act_medium_scatter &= phase_pdf > 0.f;
+                Ray3f new_ray                       = mei.spawn_ray(wo);
+                dr::masked(ray, act_medium_scatter) = new_ray;
+                needs_intersection |= act_medium_scatter;
+                dr::masked(last_scatter_direction_pdf, act_medium_scatter) =
+                    phase_pdf;
+                dr::masked(throughput, act_medium_scatter) *= phase_weight;
+            }
+
+            // --------------------- Surface Interactions ---------------------
+            active_surface |= escaped_medium;
+            Mask intersect = active_surface && needs_intersection;
+            if (dr::any_or<true>(intersect))
+                dr::masked(si, intersect) =
+                    scene->ray_intersect(ray, intersect);
+
+            if (dr::any_or<true>(active_surface)) {
+                // ---------------- Intersection with emitters ----------------
+                Mask ray_from_camera = active_surface && dr::eq(depth, 0u);
+                Mask count_direct    = ray_from_camera || specular_chain;
+                EmitterPtr emitter   = si.emitter(scene);
+                Mask active_e = active_surface && dr::neq(emitter, nullptr) &&
+                                !(dr::eq(depth, 0u) && m_hide_emitters);
+                if (dr::any_or<true>(active_e)) {
+                    Float emitter_pdf = 1.0f;
+                    if (dr::any_or<true>(active_e && !count_direct)) {
+                        // Get the PDF of sampling this emitter using next event
+                        // estimation
+                        DirectionSample3f ds(scene, si, last_scatter_event);
+                        emitter_pdf = scene->pdf_emitter_direction(
+                            last_scatter_event, ds, active_e);
+                    }
+                    Spectrum emitted = emitter->eval(si, active_e);
+                    Spectrum contrib =
+                        dr::select(count_direct, throughput * emitted,
+                                   throughput *
+                                       mis_weight(last_scatter_direction_pdf,
+                                                  emitter_pdf) *
+                                       emitted);
+                    dr::masked(result, active_e) += contrib;
+                }
+            }
+            active_surface &= si.is_valid();
+            if (dr::any_or<true>(active_surface)) {
+                // --------------------- Emitter sampling ---------------------
+                BSDFContext ctx;
+                BSDFPtr bsdf  = si.bsdf(ray);
+                Mask active_e = active_surface &&
+                                has_flag(bsdf->flags(), BSDFFlags::Smooth) &&
+                                (depth + 1 < (uint32_t) m_max_depth);
+
+                if (likely(dr::any_or<true>(active_e))) {
+                    auto [emitted, ds] = sample_emitter(
+                        si, scene, sampler, medium, channel, active_e);
+
+                    // Query the BSDF for that emitter-sampled direction
+                    Vector3f wo       = si.to_local(ds.d);
+                    Spectrum bsdf_val = bsdf->eval(ctx, si, wo, active_e);
+                    bsdf_val = si.to_world_mueller(bsdf_val, -wo, si.wi);
+
+                    // Determine probability of having sampled that same
+                    // direction using BSDF sampling.
+                    Float bsdf_pdf = bsdf->pdf(ctx, si, wo, active_e);
+                    result[active_e] +=
+                        throughput * bsdf_val *
+                        mis_weight(ds.pdf,
+                                   dr::select(ds.delta, 0.f, bsdf_pdf)) *
+                        emitted;
+                }
+
+                // ----------------------- BSDF sampling ----------------------
+                auto [bs, bsdf_val] = bsdf->sample(
+                    ctx, si, sampler->next_1d(active_surface),
+                    sampler->next_2d(active_surface), active_surface);
+                bsdf_val = si.to_world_mueller(bsdf_val, -bs.wo, si.wi);
+
+                dr::masked(throughput, active_surface) *= bsdf_val;
+                dr::masked(eta, active_surface) *= bs.eta;
+
+                Ray3f bsdf_ray = si.spawn_ray(si.to_world(bs.wo));
+                dr::masked(ray, active_surface) = bsdf_ray;
+                needs_intersection |= active_surface;
+
+                Mask non_null_bsdf =
+                    active_surface &&
+                    !has_flag(bs.sampled_type, BSDFFlags::Null);
+                dr::masked(depth, non_null_bsdf) += 1;
+
+                // update the last scatter PDF event if we encountered a
+                // non-null scatter event
+                dr::masked(last_scatter_event, non_null_bsdf)         = si;
+                dr::masked(last_scatter_direction_pdf, non_null_bsdf) = bs.pdf;
+
+                valid_ray |= non_null_bsdf;
+                specular_chain |= non_null_bsdf &&
+                                  has_flag(bs.sampled_type, BSDFFlags::Delta);
+                specular_chain &=
+                    !(active_surface &&
+                      has_flag(bs.sampled_type, BSDFFlags::Smooth));
+                act_null_scatter |= active_surface &&
+                                    has_flag(bs.sampled_type, BSDFFlags::Null);
+                Mask has_medium_trans =
+                    active_surface && si.is_medium_transition();
+                dr::masked(medium, has_medium_trans) = si.target_medium(ray.d);
+            }
+
+            active &= (active_surface | active_medium);
+        }
+
+        return { result, valid_ray };
+    }
+
+    /// Samples an emitter in the scene and evaluates its attenuated
+    /// contribution
+    template <typename Interaction>
+    std::tuple<Spectrum, DirectionSample3f>
+    sample_emitter(const Interaction &ref_interaction, const Scene *scene,
+                   Sampler *sampler, MediumPtr medium, UInt32 channel,
+                   Mask active) const {
+
+        Spectrum transmittance(1.0f);
+
+        auto [ds, emitter_val] = scene->sample_emitter_direction(
+            ref_interaction, sampler->next_2d(active), false, active);
+        dr::masked(emitter_val, dr::eq(ds.pdf, 0.f)) = 0.f;
+        active &= dr::neq(ds.pdf, 0.f);
+
+        if (dr::none_or<false>(active)) {
+            return { emitter_val, ds };
+        }
+
+        Ray3f ray      = ref_interaction.spawn_ray_to(ds.p);
+        Float max_dist = ray.maxt;
+
+        // Potentially escaping the medium if this is the current medium's
+        // boundary
+        if constexpr (std::is_convertible_v<Interaction, SurfaceInteraction3f>)
+            dr::masked(medium, ref_interaction.is_medium_transition()) =
+                ref_interaction.target_medium(ray.d);
+
+        Float total_dist        = 0.f;
+        SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
+        Mask needs_intersection = true;
+
+        dr::Loop<Mask> loop("Volpath integrator emitter sampling");
+        loop.put(active, ray, total_dist, needs_intersection, medium, si,
+                 transmittance);
+        sampler->loop_put(loop);
+        loop.init();
+        while (loop(dr::detach(active))) {
+            Float remaining_dist = max_dist - total_dist;
+            ray.maxt             = remaining_dist;
+            active &= remaining_dist > 0.f;
+            if (dr::none_or<false>(active))
+                break;
+
+            dr::masked(si, active) = scene->ray_intersect(ray, active);
+
+            Mask escaped_medium = false;
+            Mask active_medium  = active && dr::neq(medium, nullptr);
+            Mask active_surface = active && si.is_valid();
+
+            // handle surface interaction that exceeds the sampled position
+            dr::masked(total_dist, active_medium) +=
+                dr::minimum(ray.maxt, si.t);
+            dr::masked(total_dist, active_surface && !active_medium) += si.t;
+
+            if (dr::any_or<true>(active_medium)) {
+
+                Mask is_spectral =
+                    medium->has_spectral_extinction() && active_medium;
+
+                if (dr::any_or<true>(is_spectral)) {
+                    UnpolarizedSpectrum tr = dr::zeros<UnpolarizedSpectrum>();
+                    UnpolarizedSpectrum free_flight_pdf =
+                        dr::zeros<UnpolarizedSpectrum>();
+
+                    std::tie(tr, free_flight_pdf, escaped_medium) =
+                        medium->eval_transmittance_pdf_real(ray, si, channel,
+                                                            active_medium);
+                    Float tr_pdf = index_spectrum(free_flight_pdf, channel);
+                    dr::masked(transmittance, is_spectral) *=
+                        dr::select(tr_pdf > 0.f, tr, 0.f); // exact estimation
+                }
+
+                active_medium &= !escaped_medium;
+            }
+
+            if (dr::any_or<true>(active_surface)) {
+                auto bsdf = si.bsdf(ray);
+                Spectrum bsdf_val =
+                    bsdf->eval_null_transmission(si, active_surface);
+                bsdf_val = si.to_world_mueller(bsdf_val, si.wi, si.wi);
+                dr::masked(transmittance, active_surface) *= bsdf_val;
+            }
+
+            // Update the ray with new origin & t parameter
+            dr::masked(ray, active_surface) = si.spawn_ray(ray.d);
+            ray.maxt                        = remaining_dist;
+
+            // Continue tracing through scene if non-zero weights exist
+            active &=
+                (active_medium || active_surface) &&
+                dr::any(dr::neq(unpolarized_spectrum(transmittance), 0.f));
+
+            // If a medium transition is taking place: Update the medium pointer
+            Mask has_medium_trans = active_surface && si.is_medium_transition();
+            if (dr::any_or<true>(has_medium_trans)) {
+                dr::masked(medium, has_medium_trans) = si.target_medium(ray.d);
+            }
+        }
+
+        return { transmittance * emitter_val, ds };
+    }
+
+    //! @}
+    // =============================================================
+
+    std::string to_string() const override {
+        return tfm::format("PiecewiseVolumetricSimplePathIntegrator[\n"
+                           "  max_depth = %i,\n"
+                           "  rr_depth = %i\n"
+                           "]",
+                           m_max_depth, m_rr_depth);
+    }
+
+    Float mis_weight(Float pdf_a, Float pdf_b) const {
+        pdf_a *= pdf_a;
+        pdf_b *= pdf_b;
+        Float w = pdf_a / (pdf_a + pdf_b);
+        return dr::select(dr::isfinite(w), w, 0.f);
+    };
+
+    MI_DECLARE_CLASS()
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(PiecewiseVolumetricPathIntegrator,
+                           MonteCarloIntegrator);
+MI_EXPORT_PLUGIN(PiecewiseVolumetricPathIntegrator,
+                 "Piecewise Volumetric Path Tracer integrator");
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/media/CMakeLists.txt
+++ b/src/eradiate_plugins/media/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(MI_PLUGIN_PREFIX "media")
+
+add_plugin(piecewise piecewise.cpp)
+
+set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -1,0 +1,578 @@
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/frame.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/interaction.h>
+#include <mitsuba/render/medium.h>
+#include <mitsuba/render/phase.h>
+#include <mitsuba/render/sampler.h>
+#include <mitsuba/render/scene.h>
+#include <mitsuba/render/volume.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _medium-piecewise:
+
+Piecewise medium (:monosp:`piecewise`)
+--------------------------------------
+
+.. pluginparameters::
+
+ * - albedo
+   - |float|, |spectrum| or |volume|
+   - Single-scattering albedo of the medium (Default: 0.75).
+   - |exposed|, |differentiable|
+
+ * - sigma_t
+   - |float|, |spectrum| or |volume|
+   - Extinction coefficient in inverse scene units (Default: 1).
+     The supplied grid must be of shape [1,1,n].
+   - |exposed|, |differentiable|
+
+ * - scale
+   - |float|
+   - Optional scale factor that will be applied to the extinction parameter.
+     It is provided for convenience when accommodating data based on different
+     units, or to simply tweak the density of the medium. (Default: 1)
+   - |exposed|
+
+ * - sample_emitters
+   - |bool|
+   - Flag to specify whether shadow rays should be cast from inside the volume
+    (Default: |true|) If the medium is enclosed in a :ref:`dielectric
+    <bsdf-dielectric>` boundary, shadow rays are ineffective and turning them off
+    will significantly reduce render time. This can reduce render time up to 50%
+    when rendering objects with subsurface scattering.
+
+ * - (Nested plugin)
+   - |phase|
+   - A nested phase function that describes the directional scattering
+    properties of the medium. When none is specified, the renderer will
+    automatically use an instance of isotropic.
+   - |exposed|, |differentiable|
+
+
+This plugin provides a 1D heterogenous medium implementation (plane parallel
+geometry), which acquires its data from nested volume instances. These can be
+constant, use a procedural function, or fetch data from disk, e.g. using a 3D
+grid, as long as the underlying grid has the shape [1,1,N], with N the number of
+layers on the vertical (z) axis.
+
+The medium is parametrized by the single scattering albedo and the extinction
+coefficient :math:`\sigma_t`. The extinction coefficient should be provided in
+inverse scene units. For instance, when a world-space distance of 1 unit
+corresponds to a meter, the extinction coefficient should have units of inverse
+meters. For convenience, the scale parameter can be used to correct the units.
+For instance, when the scene is in meters and the coefficients are in inverse
+millimeters, set scale to 1000.
+
+Both the albedo and the extinction coefficient can either be constant or
+textured, and both parameters are allowed to be spectrally varying.
+
+.. tabs::
+    .. code-tab:: xml
+        :name: lst-piecewise
+
+        <!-- Declare a piecewise participating medium named 'smoke' -->
+        <medium type="piecewise" id="smoke">
+            <!-- Acquire extinction values from an external data file -->
+            <volume name="sigma_t" type="gridvolume">
+                <string name="filename" value="frame_0150.vol"/>
+            </volume>
+
+            <!-- The albedo is constant and set to 0.9 -->
+            <float name="albedo" value="0.9"/>
+
+            <!-- Use an isotropic phase function -->
+            <phase type="isotropic"/>
+
+            <!-- Scale the density values as desired -->
+            <float name="scale" value="200"/>
+        </medium>
+
+        <!-- Attach the index-matched medium to a shape in the scene -->
+        <shape type="obj">
+            <!-- Load an OBJ file, which contains a mesh version
+                 of the axis-aligned box of the volume data file -->
+            <string name="filename" value="bounds.obj"/>
+
+            <!-- Reference the medium by ID -->
+            <ref name="interior" id="smoke"/>
+            <!-- If desired, this shape could also declare
+                a BSDF to create an index-mismatched
+                transition, e.g.
+                <bsdf type="dielectric"/>
+            -->
+        </shape>
+
+    .. code-tab:: python
+
+        # Declare a piecewise participating medium named 'smoke'
+        'smoke': {
+            'type': 'piecewise',
+
+            # Acquire extinction values from an external data file
+            'sigma_t': {
+                'type': 'gridvolume',
+                'filename': 'frame_0150.vol'
+            },
+
+            # The albedo is constant and set to 0.9
+            'albedo': 0.9,
+
+            # Use an isotropic phase function
+            'phase': {
+                'type': 'isotropic'
+            },
+
+            # Scale the density values as desired
+            'scale': 200
+        },
+
+        # Attach the index-matched medium to a shape in the scene
+        'shape': {
+            'type': 'obj',
+            # Load an OBJ file, which contains a mesh version
+            # of the axis-aligned box of the volume data file
+            'filename': 'bounds.obj',
+
+            # Reference the medium by ID
+            'interior': 'smoke',
+            # If desired, this shape could also declare
+            # a BSDF to create an index-mismatched
+            # transition, e.g.
+            # 'bsdf': {
+            #     'type': 'isotropic'
+            # },
+        }
+*/
+template <typename Float, typename Spectrum>
+class PiecewiseMedium final : public Medium<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
+                   m_phase_function)
+    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume)
+
+    // Use 32 bit indices to keep track of indices to conserve memory
+    using ScalarIndex     = uint32_t;
+    using ScalarSize      = uint32_t;
+    using FloatStorage    = DynamicBuffer<Float>;
+    using SpectrumStorage = DynamicBuffer<UnpolarizedSpectrum>;
+
+    PiecewiseMedium(const Properties &props) : Base(props) {
+
+        m_is_homogeneous = false;
+        m_albedo         = props.volume<Volume>("albedo", 0.75f);
+        m_sigmat         = props.volume<Volume>("sigma_t", 1.f);
+
+        m_scale = props.get<ScalarFloat>("scale", 1.0f);
+        m_has_spectral_extinction =
+            props.get<bool>("has_spectral_extinction", true);
+
+        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+
+        precompute_optical_thickness();
+
+        dr::set_attr(this, "is_homogeneous", m_is_homogeneous);
+        dr::set_attr(this, "has_spectral_extinction",
+                     m_has_spectral_extinction);
+    }
+
+    std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float,
+               Float>
+    sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
+                            Float sample, UInt32 channel,
+                            Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumSample, active);
+
+        using Index = dr::replace_scalar_t<Float, ScalarIndex>;
+
+        // Initial intersection with the medium
+        auto [aabb_its, mint, maxt] = intersect_aabb(ray);
+        aabb_its &= (dr::isfinite(mint) || dr::isfinite(maxt));
+        active &= aabb_its;
+        dr::masked(mint, !active) = 0.f;
+        dr::masked(maxt, !active) = dr::Infinity<Float>;
+
+        mint = dr::maximum(0.f, mint);
+        maxt = dr::minimum(si.t, dr::minimum(ray.maxt, maxt));
+
+        Mask escaped = !active;
+
+        // Initialize basic medium interaction fields
+        MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
+        mei.wi                  = -ray.d;
+        mei.sh_frame            = Frame3f(mei.wi);
+        mei.time                = ray.time;
+        mei.wavelengths         = ray.wavelengths;
+        mei.mint                = mint;
+        mei.t                   = mint;
+        mei.medium              = this;
+
+        const ScalarVector3i res            = m_sigmat->resolution();
+        const ScalarVector3f voxel_size     = m_sigmat->voxel_size();
+        const ScalarVector3f inv_voxel_size = dr::rcp(voxel_size);
+
+        const Vector3f step     = ScalarVector3f(0.f, 0.f, voxel_size.z());
+        const ScalarPoint3f min = m_sigmat->bbox().min;
+
+        const ScalarVector3f layer_norm(0.f, 0.f, 1.f);
+        Float cum_opt_thick = dr::zeros<Float>();
+        Float sampled_t     = dr::Infinity<Float>;
+        Float tr            = dr::zeros<Float>();
+        Float pdf           = dr::zeros<Float>();
+
+        // Calculate the distance between layers used as multiplication factor
+        // to the distance
+        const Float n_dot_d =
+            dr::abs(dr::dot(layer_norm, dr::normalize(ray.d)));
+        const Float delta = dr::select(dr::eq(n_dot_d, 0.), dr::Infinity<Float>,
+                                       voxel_size.z() / n_dot_d);
+        const Float idelta  = dr::rcp(delta);
+        const Mask going_up = ray.d.z() >= 0.f;
+
+        Int32 start_idx =
+            dr::clamp((Int32) dr::floor((ray(mint) - min) * inv_voxel_size).z(),
+                      0, res.z() - 1);
+        Int32 end_idx =
+            dr::clamp((Int32) dr::floor((ray(maxt) - min) * inv_voxel_size).z(),
+                      0, res.z() - 1);
+        Mask same_cell = start_idx == end_idx;
+
+        // make sure the index align with the array (reverse indices if going
+        // down)
+        Index opt_start_idx =
+            dr::select(going_up, start_idx, res.z() - 1 - start_idx);
+        Index opt_end_idx =
+            dr::select(going_up, end_idx, res.z() - 1 - end_idx);
+        Index index = opt_start_idx;
+
+        Float start_height =
+            (ray(mint + dr::Epsilon<Float>) - min).z() * inv_voxel_size.z() -
+            (Float) start_idx;
+        dr::masked(start_height, going_up) = 1.f - start_height;
+
+        MediumInteraction3f s_mei = dr::zeros<MediumInteraction3f>();
+        s_mei.p                   = ray(mint);
+        std::tie(s_mei.sigma_s, s_mei.sigma_n, s_mei.sigma_t) =
+            get_scattering_coefficients(s_mei, active);
+        Float sigma_t = extract_channel(s_mei.sigma_t[0], channel);
+
+        Float opt_thick_offset = dr::zeros<Float>();
+        opt_thick_offset       = dr::select(
+            going_up,
+            extract_channel(
+                dr::gather<Float>(m_cum_opt_thickness, opt_start_idx, active),
+                channel),
+            extract_channel(dr::gather<Float>(m_reverse_cum_opt_thickness,
+                                                    opt_start_idx, active),
+                                  channel));
+        opt_thick_offset -= start_height * sigma_t;
+
+        Float log_sample = dr::log(1.f - sample);
+        Mask sampled     = dr::zeros<Mask>();
+        Mask search      = active && !same_cell;
+
+        if (dr::any_or<true>(search)) {
+            UnpolarizedSpectrum spectral_value =
+                dr::zeros<UnpolarizedSpectrum>();
+
+            // Find the piecewise boundary in CDF space using binary search
+            dr::masked(index, search) = dr::binary_search<Index>(
+                opt_start_idx, opt_end_idx,
+                [&](Index index) DRJIT_INLINE_LAMBDA {
+                    spectral_value = dr::select(
+                        going_up,
+                        dr::gather<Float>(m_cum_opt_thickness, index, search),
+                        dr::gather<Float>(m_reverse_cum_opt_thickness, index,
+                                          search));
+                    Float value = extract_channel(spectral_value, channel);
+
+                    Float a = -log_sample * idelta;
+                    Float b = (value - opt_thick_offset);
+
+                    return a > b;
+                });
+        }
+
+        same_cell |= index == opt_start_idx;
+        search &= !same_cell;
+
+        Int32 index_minus_one = dr::select(!active || same_cell, 0, index - 1);
+        dr::masked(mei.t, search) +=
+            (start_height + (Float) (index - opt_start_idx - 1)) * delta;
+
+        Float cum_opt_at_index                 = dr::zeros<Float>();
+        dr::masked(cum_opt_at_index, going_up) = extract_channel(
+            dr::gather<Float>(m_cum_opt_thickness, index_minus_one, search),
+            channel);
+        dr::masked(cum_opt_at_index, !going_up) =
+            extract_channel(dr::gather<Float>(m_reverse_cum_opt_thickness,
+                                              index_minus_one, search),
+                            channel);
+        dr::masked(cum_opt_thick, search) =
+            (cum_opt_at_index - opt_thick_offset) * delta;
+
+        mei.p = min + voxel_size * 0.5 +
+                (Float) dr::select(going_up, index, res.z() - 1 - index) * step;
+
+        std::tie(mei.sigma_s, mei.sigma_n, mei.sigma_t) =
+            get_scattering_coefficients(mei, active && !same_cell);
+        dr::masked(sigma_t, !same_cell) = extract_channel(mei.sigma_t, channel);
+
+        escaped |= mei.t > maxt;
+        sampled |= !escaped;
+
+        dr::masked(sampled_t, sampled) =
+            -dr::rcp(sigma_t) * (log_sample + cum_opt_thick) + mei.t;
+
+        escaped |= (sampled && sampled_t > maxt);
+        sampled |= escaped;
+
+        // need to calculate transmittance and pdf for escaped rays too
+        dr::masked(sampled_t, sampled) = dr::select(escaped, maxt, sampled_t);
+        dr::masked(tr, sampled) =
+            dr::exp(-(sampled_t - mei.t) * sigma_t - cum_opt_thick);
+        dr::masked(pdf, sampled) =
+            dr::select(dr::eq(sampled_t, maxt), tr, tr * sigma_t);
+
+        mei.t = dr::select(!escaped, sampled_t, dr::Infinity<Float>);
+        dr::masked(mei.p, !escaped)                   = ray(mei.t);
+        dr::masked(mei.combined_extinction, !escaped) = mei.sigma_t;
+        dr::masked(mei.sigma_n, !escaped) = dr::zeros<UnpolarizedSpectrum>();
+
+        return { mei, tr, pdf };
+    }
+
+    std::tuple<Float, Float, Mask>
+    eval_transmittance_pdf_real(const Ray3f &ray,
+                                const SurfaceInteraction3f &si, UInt32 channel,
+                                Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+
+        // Initial intersection with the medium
+        auto [aabb_its, mint, maxt] = intersect_aabb(ray);
+        aabb_its &= (dr::isfinite(mint) || dr::isfinite(maxt));
+        active &= aabb_its;
+        mint         = dr::maximum(0.f, mint);
+        Mask escaped = active && ((maxt >= ray.maxt) || (maxt >= si.t));
+
+        maxt =
+            dr::select(active, dr::minimum(ray.maxt, dr::minimum(maxt, si.t)),
+                       dr::Infinity<Float>);
+        maxt = dr::maximum(0.f, maxt);
+
+        const ScalarVector3i res            = m_sigmat->resolution();
+        const ScalarVector3f voxel_size     = m_sigmat->voxel_size();
+        const ScalarVector3f inv_voxel_size = dr::rcp(voxel_size);
+
+        const Vector3f step     = ScalarVector3f(0.f, 0.f, voxel_size.z());
+        const ScalarPoint3f min = m_sigmat->bbox().min;
+
+        // Calculate the distance between layers used as multiplication factor
+        // to the distance
+        const ScalarVector3f layer_norm(0.f, 0.f, 1.f);
+        const Float n_dot_d =
+            dr::abs(dr::dot(layer_norm, dr::normalize(ray.d)));
+        const Float delta = dr::select(dr::eq(n_dot_d, 0.), dr::Infinity<Float>,
+                                       voxel_size.z() / n_dot_d);
+        const Mask going_up = ray.d.z() >= 0.f;
+
+        Int32 start_idx =
+            dr::clamp((Int32) dr::floor((ray(mint) - min) * inv_voxel_size).z(),
+                      0, res.z() - 1);
+        Int32 end_idx =
+            dr::clamp((Int32) dr::floor((ray(maxt) - min) * inv_voxel_size).z(),
+                      0, res.z() - 1);
+        Mask same_cell = start_idx == end_idx;
+
+        Float start_height =
+            (ray(mint) - min).z() * inv_voxel_size.z() - (Float) start_idx;
+        Float end_height =
+            (ray(maxt) - min).z() * inv_voxel_size.z() - (Float) end_idx;
+
+        dr::masked(start_height, going_up) = 1.f - start_height;
+        dr::masked(end_height, !going_up)  = 1.f - end_height;
+
+        MediumInteraction3f s_mei = dr::zeros<MediumInteraction3f>();
+        MediumInteraction3f e_mei = dr::zeros<MediumInteraction3f>();
+
+        s_mei.p = min + voxel_size * 0.5 + start_idx * step;
+        e_mei.p = min + voxel_size * 0.5 + end_idx * step;
+        std::tie(s_mei.sigma_s, s_mei.sigma_n, s_mei.sigma_t) =
+            get_scattering_coefficients(s_mei, active);
+        std::tie(e_mei.sigma_s, e_mei.sigma_n, e_mei.sigma_t) =
+            get_scattering_coefficients(e_mei, active);
+        Float s_sigma_t = extract_channel(s_mei.sigma_t, channel);
+        Float e_sigma_t = extract_channel(e_mei.sigma_t, channel);
+
+        Int32 max_idx = dr::select(
+            active, dr::maximum(dr::maximum(start_idx, end_idx) - 1, 0), 0);
+        Int32 min_idx = dr::select(
+            active, dr::maximum(dr::minimum(start_idx, end_idx), 0), 0);
+        Mask use_precomputed = active && max_idx > min_idx;
+
+        Float opt_thick     = dr::zeros<Float>();
+        Float cum_opt_thick = dr::zeros<Float>();
+        Float start_cum_opt = dr::zeros<Float>();
+        Float end_cum_opt   = dr::zeros<Float>();
+
+        dr::masked(start_cum_opt, use_precomputed) = extract_channel(
+            dr::gather<Float>(m_cum_opt_thickness, min_idx, use_precomputed),
+            channel);
+        dr::masked(end_cum_opt, use_precomputed) = extract_channel(
+            dr::gather<Float>(m_cum_opt_thickness, max_idx, use_precomputed),
+            channel);
+        dr::masked(cum_opt_thick, use_precomputed) =
+            end_cum_opt - start_cum_opt;
+
+        cum_opt_thick += s_sigma_t * start_height + e_sigma_t * end_height;
+        cum_opt_thick *= delta;
+
+        dr::masked(opt_thick, active) =
+            dr::select(same_cell, (maxt - mint) * s_sigma_t, cum_opt_thick);
+
+        Float tr               = dr::zeros<Float>();
+        Float pdf              = dr::zeros<Float>();
+        dr::masked(tr, active) = dr::exp(-opt_thick);
+        dr::masked(pdf, active) =
+            dr::select(si.t < maxt || ray.maxt < maxt, tr, tr * e_sigma_t);
+
+        return { tr, pdf, escaped };
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_parameter("scale", m_scale,
+                                +ParamFlags::NonDifferentiable);
+        callback->put_object("albedo", m_albedo.get(),
+                             +ParamFlags::Differentiable);
+        callback->put_object("sigma_t", m_sigmat.get(),
+                             +ParamFlags::Differentiable);
+        Base::traverse(callback);
+    }
+
+    void parameters_changed(
+        const std::vector<std::string> & /*keys*/ = {}) override {
+        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        Log(Info, "Medium Parameters changed!");
+        precompute_optical_thickness();
+    }
+
+    void precompute_optical_thickness() {
+        // Check that the first two dimensions are equal to 1 and that z is one
+        // or more.
+        const ScalarVector3i resolution = m_sigmat->resolution();
+        const ScalarVector3f voxel_size = m_sigmat->voxel_size();
+        if (resolution.x() > 1 || resolution.y() > 1)
+            Throw("PiecewiseMedium: x or y resolution bigger than one, assumed "
+                  "shape is [1,1,n]");
+
+        MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
+        ScalarPoint3f min       = m_sigmat->bbox().min;
+        ScalarVector3f step     = ScalarVector3f(0.f, 0.f, voxel_size.z());
+
+        UnpolarizedSpectrum cumulative = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum reverse_cumulative =
+            dr::zeros<UnpolarizedSpectrum>();
+        std::vector<UnpolarizedSpectrum> cum_opt_thickness(resolution.z());
+        std::vector<UnpolarizedSpectrum> reverse_cum_opt_thickness(
+            resolution.z());
+
+        // loop through the layers and accumulate the "unscaled" optical
+        // thickness
+        for (int32_t i = 0; i < (int32_t) resolution.z(); ++i) {
+            mei.p = min + voxel_size * 0.5 + (ScalarFloat) i * step;
+            std::tie(mei.sigma_s, mei.sigma_n, mei.sigma_t) =
+                get_scattering_coefficients(mei, true);
+
+            cumulative += mei.sigma_t;
+            cum_opt_thickness[i] = cumulative;
+        }
+
+        for (int32_t i = (int32_t) resolution.z() - 1; i >= 0; --i) {
+            mei.p = min + voxel_size * 0.5 + (ScalarFloat) i * step;
+            std::tie(mei.sigma_s, mei.sigma_n, mei.sigma_t) =
+                get_scattering_coefficients(mei, true);
+
+            reverse_cumulative += mei.sigma_t;
+            reverse_cum_opt_thickness[(int32_t) resolution.z() - 1 - i] =
+                reverse_cumulative;
+        }
+
+        m_cum_opt_thickness =
+            dr::load<SpectrumStorage>(cum_opt_thickness.data(), resolution.z());
+        m_reverse_cum_opt_thickness = dr::load<SpectrumStorage>(
+            reverse_cum_opt_thickness.data(), resolution.z());
+    }
+
+    UnpolarizedSpectrum get_majorant(const MediumInteraction3f &mi,
+                                     Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+
+        auto sigmat = m_sigmat->eval(mi) * m_scale;
+        if (has_flag(m_phase_function->flags(), PhaseFunctionFlags::Microflake))
+            sigmat *= m_phase_function->projected_area(mi, active);
+
+        return m_max_density;
+        return sigmat & active;
+    }
+
+    std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum, UnpolarizedSpectrum>
+    get_scattering_coefficients(const MediumInteraction3f &mi,
+                                Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+
+        auto sigmat = m_scale * m_sigmat->eval(mi, active);
+        if (has_flag(m_phase_function->flags(), PhaseFunctionFlags::Microflake))
+            sigmat *= m_phase_function->projected_area(mi, active);
+
+        auto sigmas = sigmat * m_albedo->eval(mi, active);
+        auto sigman = m_max_density - sigmat;
+        ;
+        return { sigmas, sigman, sigmat };
+    }
+
+    std::tuple<Mask, Float, Float>
+    intersect_aabb(const Ray3f &ray) const override {
+        return m_sigmat->bbox().ray_intersect(ray);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "PiecewiseMedium[" << std::endl
+            << "  albedo        = " << string::indent(m_albedo) << std::endl
+            << "  sigma_t       = " << string::indent(m_sigmat) << std::endl
+            << "  scale         = " << string::indent(m_scale) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    static Float extract_channel(Spectrum value, UInt32 channel) {
+        Float result = value[0];
+        if constexpr (is_rgb_v<Spectrum>) { // Handle RGB rendering
+            dr::masked(result, dr::eq(channel, 1u)) = value[1];
+            dr::masked(result, dr::eq(channel, 2u)) = value[2];
+        } else {
+            DRJIT_MARK_USED(channel);
+        }
+
+        return result;
+    }
+
+    MI_DECLARE_CLASS()
+
+private:
+    ref<Volume> m_sigmat, m_albedo;
+    ScalarFloat m_scale;
+
+    Float m_max_density;
+    SpectrumStorage m_cum_opt_thickness;
+    SpectrumStorage m_reverse_cum_opt_thickness;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(PiecewiseMedium, Medium)
+MI_EXPORT_PLUGIN(PiecewiseMedium, "Piecewise Medium")
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/tests/media/test_piecewise.py
+++ b/src/eradiate_plugins/tests/media/test_piecewise.py
@@ -1,0 +1,287 @@
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+
+def gen_sigma_grid(medium_height, num_layers, integral, lbd):
+    scale = integral / lbd
+    z = np.linspace(0.0, medium_height, num_layers, False)
+    ext_coefs = scale * np.exp(-z / lbd)
+    ext_coefs = np.reshape(ext_coefs, (num_layers, 1, 1))
+    return ext_coefs
+
+
+# Mitsuba dictionary
+def create_medium_dict():
+    medium_height = 100000
+    num_layers = 10
+    integral = 3.0
+    lbd_dist = 8300
+
+    ext_coefs = gen_sigma_grid(medium_height, num_layers, integral, lbd_dist)
+    exp_volume_grid = mi.VolumeGrid(ext_coefs)
+    sigma_scale = 1.0
+
+    medium_transform = mi.ScalarTransform4f.translate(
+        [-100000 / 2, -100000 / 2, 0.0]
+    ).scale([100000.0, 100000.0, 100000.0])
+
+    return mi.load_dict(
+        {
+            "type": "piecewise",
+            "albedo": 0.8,
+            "sigma_t": {
+                "type": "gridvolume",
+                "grid": exp_volume_grid,
+                "use_grid_bbox": True,
+                "filter_type": "nearest",
+                "to_world": medium_transform,
+            },
+            "scale": sigma_scale,
+        }
+    )
+
+
+def test01_sample_distances_down(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_dists = [0.0, 74578.93910366, 82117.51365975, 88515.28423884, 98460.51859237]
+    gt_trs = [1.0, 0.75, 0.5, 0.25, 0.01]
+    gt_pdfs = [
+        7.06034444e-09,
+        2.43563215e-05,
+        5.41709938e-05,
+        2.70854969e-05,
+        3.61445783e-06,
+    ]
+
+    samples = [0.0, 0.25, 0.5, 0.75, 0.99]
+    si = mi.SurfaceInteraction3f()
+
+    origins = mi.Point3f([0.0, 0.0, 100000.0])
+    directions = mi.Vector3f([0.0, 0.0, -1.0])
+    ray = mi.Ray3f(origins, directions)
+
+    dists = []
+    trs = []
+    pdfs = []
+    for idx, sample in enumerate(samples):
+        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        dists.append(mei.t)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    assert dr.allclose(dists, gt_dists)
+    assert dr.allclose(trs, gt_trs)
+    assert dr.allclose(pdfs, gt_pdfs)
+
+
+def test02_sample_distances_up(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_dists = [0.0, 7.95920400e02, 1.91770720e03, 3.83541440e03, 1.91443066e04]
+    gt_trs = [1.0, 0.75, 0.5, 0.25, 0.01]
+    gt_pdfs = [
+        3.61445783e-04,
+        2.71084337e-04,
+        1.80722892e-04,
+        9.03614458e-05,
+        1.08341988e-06,
+    ]
+
+    samples = [0.0, 0.25, 0.5, 0.75, 0.99]
+    si = mi.SurfaceInteraction3f()
+
+    origins = mi.Point3f([0.0, 0.0, 0.0])
+    directions = mi.Vector3f([0.0, 0.0, 1.0])
+    ray = mi.Ray3f(origins, directions)
+
+    dists = []
+    trs = []
+    pdfs = []
+    for idx, sample in enumerate(samples):
+        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+
+        dists.append(mei.t)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    assert dr.allclose(dists, gt_dists)
+    assert dr.allclose(trs, gt_trs)
+    assert dr.allclose(pdfs, gt_pdfs)
+
+
+def test03_sample_distances_horizontal(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_dists = [0.0, 2655.31469158, 6397.77055374, 12795.54110748, 42505.86749422]
+    gt_trs = [1.0, 0.75, 0.5, 0.25, 0.01]
+    gt_pdfs = [
+        1.08341988e-04,
+        8.12564910e-05,
+        5.41709940e-05,
+        2.70854970e-05,
+        1.08341988e-06,
+    ]
+
+    samples = [0.0, 0.25, 0.5, 0.75, 0.99]
+    si = mi.SurfaceInteraction3f()
+
+    origins = mi.Point3f([0.0, 0.0, 15000.0])
+    directions = mi.Vector3f([0.0, 1.0, 0.0])
+    ray = mi.Ray3f(origins, directions)
+
+    dists = []
+    trs = []
+    pdfs = []
+    for idx, sample in enumerate(samples):
+        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+
+        dists.append(mei.t)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    assert dr.allclose(dists, gt_dists)
+    assert dr.allclose(trs, gt_trs)
+    assert dr.allclose(pdfs, gt_pdfs)
+
+
+def test04_sample_distances_diag(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_dists = [9.23464998e00, 2.65531470e03, 6.39777058e03, 2.24562174e04, dr.inf]
+
+    samples = [0.001, 0.25, 0.5, 0.75, 0.99]
+    si = mi.SurfaceInteraction3f()
+
+    origins = mi.Point3f([0.0, 0.0, 15000.0])
+    directions = mi.Vector3f([0.5, 0.5, 0.5])
+    ray = mi.Ray3f(origins, directions)
+
+    dists = []
+    trs = []
+    pdfs = []
+    for idx, sample in enumerate(samples):
+        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        dists.append(mei.t)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    for idx in range(len(gt_dists)):
+        if dr.isinf(gt_dists[idx]) and dr.isinf(gt_dists[idx]) == dr.isinf(dists[idx]):
+            gt_dists[idx] = 0.0
+            dists[idx] = 0.0
+
+    assert dr.allclose(dists, gt_dists)
+
+
+def test05_sample_distances_heights(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_dists = [
+        986.80067823,
+        2824.88988516,
+        3292.12110592,
+        dr.inf,
+        dr.inf,
+        dr.inf,
+        dr.inf,
+    ]
+
+    heights = [0.0, 9800.0, 10100.0, 27500.0, 40020.0, 75000, 98000.0]
+    sample = 0.3
+    direction = mi.Vector3f([0.0, 0.0, 1.0])
+    rays = []
+
+    si = mi.SurfaceInteraction3f()
+
+    for h in heights:
+        origin = mi.Point3f([0.0, 0.0, h])
+        rays.append(mi.Ray3f(origin, direction))
+
+    dists = []
+    trs = []
+    pdfs = []
+    for idx, ray in enumerate(rays):
+        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        dists.append(mei.t)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    for idx in range(len(gt_dists)):
+        if dr.isinf(gt_dists[idx]) and dr.isinf(gt_dists[idx]) == dr.isinf(dists[idx]):
+            gt_dists[idx] = 0.0
+            dists[idx] = 0.0
+
+    assert dr.allclose(dists, gt_dists)
+
+
+def test06_eval_transmittance_up(variant_scalar_mono_double):
+    medium = create_medium_dict()
+
+    gt_trs = [
+        0.00573247,
+        0.03493101,
+        0.36588307,
+        0.7398143,
+        0.97331388,
+        0.99930119,
+        1.0,
+    ]
+
+    heights = [0.0, 5000.0, 15000.0, 25000.0, 45000.0, 75000, 100000.0]
+    direction = [0.0, 0.0, 1.0]
+    rays = []
+    si = dr.zeros(mi.SurfaceInteraction3f, 1)
+    si.t = dr.inf
+
+    for h in heights:
+        origin = [0.0, 0.0, h]
+        rays.append(mi.Ray3f(origin, direction))
+
+    trs = []
+    pdfs = []
+    for idx, ray in enumerate(rays):
+        tr, pdf, _ = medium.eval_transmittance_pdf_real(ray, si, 0, True)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    assert dr.allclose(trs, gt_trs)
+
+
+def test07_eval_transmittance_down(variant_scalar_mono):
+    dr.set_thread_count(0)
+    from mitsuba import LogLevel, Thread
+
+    Thread.thread().logger().set_log_level(LogLevel.Debug)
+
+    medium = create_medium_dict()
+
+    gt_trs = [
+        1.0,
+        0.03865759,
+        0.01566748,
+        0.00663011,
+        0.00588964,
+        0.00573872,
+        0.00573247,
+    ]
+
+    heights = [0.0, 9000.0, 15000.0, 29800.0, 45000.0, 70020, 100000.0]
+    direction = [0.0, 0.0, -1.0]
+    rays = []
+    si = dr.zeros(mi.SurfaceInteraction3f, 1)
+    si.t = dr.inf
+
+    for h in heights:
+        origin = [0.0, 0.0, h]
+        rays.append(mi.Ray3f(origin, direction))
+
+    trs = []
+    pdfs = []
+    for idx, ray in enumerate(rays):
+        tr, pdf, _ = medium.eval_transmittance_pdf_real(ray, si, 0, True)
+        trs.append(tr)
+        pdfs.append(pdf)
+
+    assert dr.allclose(trs, gt_trs)

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -95,6 +95,29 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
     return { tr, pdf };
 }
 
+// #RAY_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+MI_VARIANT
+std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float, Float>
+Medium<Float, Spectrum>::sample_interaction_real(const Ray3f &/*ray*/, 
+                                            const SurfaceInteraction3f &/*si*/, Float /*sample*/,
+                                            UInt32 /*channel*/, Mask /*active*/) const {
+    // PiecewiseVolPathIntegrator should only be used with piecewise medium                                                
+    NotImplementedError("sample_interaction_real");
+    MediumInteraction3f mi = dr::zeros<MediumInteraction3f>(); 
+    return {mi,0.f,0.f};
+}
+
+MI_VARIANT
+std::tuple<Float, Float, typename Medium<Float, Spectrum>::Mask>
+Medium<Float, Spectrum>::eval_transmittance_pdf_real(const Ray3f &/*ray*/, 
+                                    const SurfaceInteraction3f &/*si*/,
+                                    UInt32 /*channel*/, Mask /*active*/) const {
+    // PiecewiseVolPathIntegrator should only be used with piecewise medium
+    NotImplementedError("eval_transmittance_pdf_real");
+    return {0.f, 0.f, false};
+}
+// #RAY_CHANGE_END
+
 MI_IMPLEMENT_CLASS_VARIANT(Medium, Object, "medium")
 MI_INSTANTIATE_CLASS(Medium)
 NAMESPACE_END(mitsuba)

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -79,6 +79,17 @@ template <typename Ptr, typename Cls> void bind_medium_generic(Cls &cls) {
                 return ptr->transmittance_eval_pdf(mi, si, active); },
             "mi"_a, "si"_a, "active"_a,
             D(Medium, transmittance_eval_pdf))
+        .def("sample_interaction_real",
+            [](Ptr ptr, const Ray3f &ray, const SurfaceInteraction3f &si, Float sample, UInt32 channel, Mask active) {
+                return ptr->sample_interaction_real(ray, si, sample, channel, active); },
+            "ray"_a, "si"_a, "sample"_a, "channel"_a, "active"_a,
+            D(Medium, sample_interaction_real))
+        .def("eval_transmittance_pdf_real",
+            [](Ptr ptr, const Ray3f &ray,  
+                const SurfaceInteraction3f &si, UInt32 channel, Mask active) {
+                return ptr->eval_transmittance_pdf_real(ray, si, channel, active); },
+            "ray"_a, "si"_a, "channel"_a, "active"_a,
+            D(Medium, eval_transmittance_pdf_real))
        .def("get_scattering_coefficients",
             [](Ptr ptr, const MediumInteraction3f &mi, Mask active = true) {
                 return ptr->get_scattering_coefficients(mi, active); },

--- a/src/render/volume.cpp
+++ b/src/render/volume.cpp
@@ -56,6 +56,20 @@ Volume<Float, Spectrum>::max_per_channel(ScalarFloat * /*out*/) const {
     NotImplementedError("max_per_channel");
 }
 
+// #RAY_CHANGE_BEGIN, NM 24/05/2024 : Add util functions to the volume class
+MI_VARIANT typename Volume<Float, Spectrum>::ScalarVector3f
+Volume<Float, Spectrum>::voxel_size() const {
+    // Extract the scale from the to_world matrix, assuming an affine transformation.
+    ScalarTransform4f to_world = m_to_local.inverse();
+    ScalarVector3f scale(
+        dr::norm(to_world.matrix.x()),
+        dr::norm(to_world.matrix.y()),
+        dr::norm(to_world.matrix.z())
+    );
+    return dr::rcp(ScalarVector3f(resolution())) * scale;
+}
+// #RAY_CHANGE_END
+
 MI_VARIANT typename Volume<Float, Spectrum>::ScalarVector3i
 Volume<Float, Spectrum>::resolution() const {
     return ScalarVector3i(1, 1, 1);


### PR DESCRIPTION
## Description

This PR introduces two plugins, the piecewise medium and the piecewise volumetric integrator. The piecewise medium is a 1D heterogeneous grid that implements analytical distance sampling and transmittance evaluation. The medium takes advantage of the known geometry to optimizes the calculations and precompute the optical thickness. The piecewise volumetric integrator performs regular tracking for distance sampling and takes advantage of the analytical transmittance evaluation when sampling emitters. 

The 1D Grid is a common configuration in earth observation  simulations that assume a Plane Parallel Geometry. These plugins can therefore offer performance improvements and variance reductions compared to the delta tracking approach of mitsuba's volumetric path integrator.

**This integrator has not been tested on llvm or cuda. It is also not functional in rgb mode. The vertical axis is assumed to be the z axis.**

## Testing

The medium and integrator have been tested in various mitsuba plane parallel geometry scenarios at different scales. Renders of the piecewise and majorant approach were compared, and their relative difference evaluated to ensure no there was no bias. Note that the piecewise integrator only works with piecewise medium and other mediums are not supported. Scenes with objects and ray interactions, as well as different lights, placed inside and outside the medium were also tested.

A suite of tests was added in `test_piecewise.py` to assess the integrity of the distance sampling and transmittance evaluation methods.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)