### PR TITLE
[Feature] Enable volumetric polarization

### DIFF
--- a/include/mitsuba/render/interaction.h
+++ b/include/mitsuba/render/interaction.h
@@ -562,6 +562,95 @@ struct MediumInteraction : Interaction<Float_, Spectrum_> {
         return sh_frame.to_local(v);
     }
 
+    /**
+     * \brief Converts a Mueller matrix defined in a local frame to world space
+     *
+     * A Mueller matrix operates from the (implicitly) defined frame
+     * stokes_basis(in_forward) to the frame stokes_basis(out_forward).
+     * This method converts a Mueller matrix defined on directions in the local
+     * frame to a Mueller matrix defined on world-space directions.
+     *
+     * This expands to a no-op in non-polarized modes.
+     *
+     * \param M_local
+     *      The Mueller matrix in local space, e.g. returned by a BSDF.
+     *
+     * \param in_forward_local
+     *      Incident direction (along propagation direction of light),
+     *      given in local frame coordinates.
+     *
+     * \param wo_local
+     *      Outgoing direction (along propagation direction of light),
+     *      given in local frame coordinates.
+     *
+     * \return
+     *      Equivalent Mueller matrix that operates in world-space coordinates.
+     */
+    Spectrum to_world_mueller(const Spectrum &M_local,
+                              const Vector3f &in_forward_local,
+                              const Vector3f &out_forward_local) const {
+        if constexpr (is_polarized_v<Spectrum>) {
+            Vector3f in_forward_world  = to_world(in_forward_local),
+                     out_forward_world = to_world(out_forward_local);
+
+            Vector3f in_basis_current = to_world(mueller::stokes_basis(in_forward_local)),
+                     in_basis_target  = mueller::stokes_basis(in_forward_world);
+
+            Vector3f out_basis_current = to_world(mueller::stokes_basis(out_forward_local)),
+                     out_basis_target  = mueller::stokes_basis(out_forward_world);
+
+            return mueller::rotate_mueller_basis(M_local,
+                                                 in_forward_world, in_basis_current, in_basis_target,
+                                                 out_forward_world, out_basis_current, out_basis_target);
+        } else {
+            DRJIT_MARK_USED(in_forward_local);
+            DRJIT_MARK_USED(out_forward_local);
+            return M_local;
+        }
+    }
+
+    /**
+     * \brief Converts a Mueller matrix defined in world space to a local frame
+     *
+     * A Mueller matrix operates from the (implicitly) defined frame
+     * stokes_basis(in_forward) to the frame stokes_basis(out_forward).
+     * This method converts a Mueller matrix defined on directions in
+     * world-space to a Mueller matrix defined in the local frame.
+     *
+     * This expands to a no-op in non-polarized modes.
+     *
+     * \param in_forward_local
+     *      Incident direction (along propagation direction of light),
+     *      given in world-space coordinates.
+     *
+     * \param wo_local
+     *      Outgoing direction (along propagation direction of light),
+     *      given in world-space coordinates.
+     *
+     * \return
+     *      Equivalent Mueller matrix that operates in local frame coordinates.
+     */
+    Spectrum to_local_mueller(const Spectrum &M_world,
+                              const Vector3f &in_forward_world,
+                              const Vector3f &out_forward_world) const {
+        if constexpr (is_polarized_v<Spectrum>) {
+            Vector3f in_forward_local = to_local(in_forward_world),
+                     out_forward_local = to_local(out_forward_world);
+
+            Vector3f in_basis_current = to_local(mueller::stokes_basis(in_forward_world)),
+                     in_basis_target  = mueller::stokes_basis(in_forward_local);
+
+            Vector3f out_basis_current = to_local(mueller::stokes_basis(out_forward_world)),
+                     out_basis_target  = mueller::stokes_basis(out_forward_local);
+
+            return mueller::rotate_mueller_basis(M_world,
+                                                 in_forward_local, in_basis_current, in_basis_target,
+                                                 out_forward_local, out_basis_current, out_basis_target);
+        } else {
+            return M_world;
+        }
+    }
+
     //! @}
     // =============================================================
 

--- a/include/mitsuba/render/mueller.h
+++ b/include/mitsuba/render/mueller.h
@@ -4,6 +4,7 @@
 #include <mitsuba/render/fwd.h>
 #include <mitsuba/render/fresnel.h>
 #include <drjit/matrix.h>
+#include <drjit/sphere.h>
 
 NAMESPACE_BEGIN(mitsuba)
 

--- a/src/eradiate_plugins/CMakeLists.txt
+++ b/src/eradiate_plugins/CMakeLists.txt
@@ -2,11 +2,11 @@ message(STATUS "Building Eradiate plugins")
 
 # Plugins
 add_subdirectory(bsdfs)
+add_subdirectory(emitters)
+add_subdirectory(integrators)
+add_subdirectory(media)
 add_subdirectory(phase)
 add_subdirectory(sensors)
 add_subdirectory(volumes)
-add_subdirectory(emitters)
-add_subdirectory(media)
-add_subdirectory(integrators)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/phase/CMakeLists.txt
+++ b/src/eradiate_plugins/phase/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(MI_PLUGIN_PREFIX "phasefunctions")
 
+add_plugin(rayleigh_polarized rayleigh_polarized.cpp)
 add_plugin(tabphase_irregular tabphase_irregular.cpp)
+add_plugin(tabphase_polarized tabphase_polarized.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/phase/rayleigh_polarized.cpp
+++ b/src/eradiate_plugins/phase/rayleigh_polarized.cpp
@@ -1,0 +1,184 @@
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/mueller.h>
+#include <mitsuba/render/phase.h>
+
+/**!
+
+.. _phase-rayleigh_polarized:
+
+Rayleigh phase function (:monosp:`rayleigh_polarized`)
+------------------------------------------------------
+
+.. pluginparameters::
+
+ * - depolarization
+   - |float|
+   - Depolarization factor, the ratio of intensities parallel and perpendicular
+     to the plane of scattering for light scattered at 90 deg.
+
+
+Scattering by particles that are much smaller than the wavelength
+of light (e.g. individual molecules in the atmosphere) is well-approximated
+by the Rayleigh phase function.
+
+*/
+
+// This implementation is based on the one developed by Kate Salesin.
+// Sampling method reference: Frisvad (2011)
+
+NAMESPACE_BEGIN(mitsuba)
+
+template <typename Float, typename Spectrum>
+class RayleighPolarizedPhaseFunction final
+    : public PhaseFunction<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(PhaseFunction, m_flags)
+    MI_IMPORT_TYPES(PhaseFunctionContext)
+
+    RayleighPolarizedPhaseFunction(const Properties &props) : Base(props) {
+        m_depolarization = props.get<ScalarFloat>("depolarization", 0.f);
+
+        if (m_depolarization < 0.f || m_depolarization >= 1.f)
+            Log(Error, "Depolarization factor must be in [0, 1[");
+
+        m_flags = +PhaseFunctionFlags::Anisotropic;
+    }
+
+    MI_INLINE
+    MuellerMatrix<Float> rayleigh_scatter(const Float cos_theta,
+                                          const Float rho) const {
+        /* Calculates the Mueller matrix of a Rayleigh scatter event given
+           the scattering angle (Hansen & Travis (1974), eq. (2.15)).
+           The angle θ is defined in the physics convention. */
+
+        Float r1 = (1.f - rho) / (1.f + rho / 2.f),
+              r2 = (1.f + rho) / (1.f - rho),
+              r3 = (1.f - 2.f * rho) / (1.f - rho);
+
+        Float a = r2 + dr::sqr(cos_theta),
+              b = dr::sqr(cos_theta) + 1.f,
+              c = dr::sqr(cos_theta) - 1.f,
+              d = 2.f * cos_theta;
+
+        return Float(3.f / 16.f) * dr::InvPi<Float> * r1 * MuellerMatrix<Float>(
+            a, c, 0, 0,
+            c, b, 0, 0,
+            0, 0, d, 0,
+            0, 0, 0, d * r3
+        );
+    }
+
+    MI_INLINE Float eval_rayleigh_pdf(Float cos_theta) const {
+        // TODO: Check vs Frisvad (2011)
+        return (3.f / 16.f) * dr::InvPi<Float> * (1.f + dr::sqr(cos_theta));
+    }
+
+    MI_INLINE Spectrum eval_rayleigh(const PhaseFunctionContext &ctx,
+                                     const MediumInteraction3f &mei,
+                                     const Vector3f &wo,
+                                     Float cos_theta) const {
+        Spectrum phase_val;
+
+        if constexpr (is_polarized_v<Spectrum>) {
+            // We first evaluate the Rayleigh phase matrix
+            phase_val = rayleigh_scatter(cos_theta, (Float) m_depolarization);
+
+            /* Due to the coordinate system rotations for polarization-aware
+               phase functions, we need to know the propagation direction of
+               light. In the following, light arrives along `-wo_hat` and leaves
+               along
+               `+wi_hat`. */
+            Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : mei.wi,
+                     wi_hat = ctx.mode == TransportMode::Radiance ? mei.wi : wo;
+
+            /* The Stokes reference frame vector of this matrix lies in the
+               scattering plane spanned by wi and wo. */
+            Vector3f x_hat      = dr::normalize(dr::cross(-wo_hat, wi_hat)),
+                     p_axis_in  = dr::normalize(dr::cross(x_hat, -wo_hat)),
+                     p_axis_out = dr::normalize(dr::cross(x_hat, wi_hat));
+
+            /* Rotate in/out reference vector of weight s.t. it aligns with the
+             * implicit Stokes bases of -wo_hat & wi_hat.
+             */
+            phase_val = mueller::rotate_mueller_basis(
+                phase_val, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+                wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
+
+            // If the cross product x_hat is too small, phase_val may be NaN
+            dr::masked(phase_val, dr::isnan(phase_val)) = 0.f;
+
+        } else {
+            Float rho = (Float) m_depolarization,
+                  r1  = (1.f - rho) / (1.f + rho / 2.f),
+                  r2  = (1.f + rho) / (1.f - rho);
+
+            phase_val = (3.f / 16.f) * dr::InvPi<Float> * r1 *
+                        (r2 + dr::sqr(cos_theta));
+        }
+
+        return phase_val;
+    }
+
+    std::tuple<Vector3f, Spectrum, Float>
+    sample(const PhaseFunctionContext &ctx, const MediumInteraction3f &mei,
+           Float /* sample1 */, const Point2f &sample,
+           Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
+
+        Float z                 = 2.f * (2.f * sample.x() - 1.f);
+        Float tmp               = dr::sqrt(dr::sqr(z) + 1.f);
+        Float A                 = dr::cbrt(z + tmp);
+        Float B                 = dr::cbrt(z - tmp);
+        Float cos_theta         = A + B; /* cos_theta in physics convention */
+        Float sin_theta         = dr::safe_sqrt(1.0f - dr::sqr(cos_theta));
+        auto [sin_phi, cos_phi] = dr::sincos(dr::TwoPi<Float> * sample.y());
+
+        /* If θ is the scattering angle in physics convention, and θ'
+           the scattering angle in graphics convention, then θ' = π - θ
+           and cos(θ') = -cos(θ) and sin(θ') = sin(θ). */
+        Vector3f wo = { sin_theta * cos_phi, sin_theta * sin_phi, cos_theta };
+        wo          = -mei.to_world(wo);
+
+        /* eval_rayleigh_pdf expects cos(θ) in physics convention, but expects
+         * wo in graphics convention */
+        Float pdf = eval_rayleigh_pdf(cos_theta);
+        Spectrum phase_weight =
+            eval_rayleigh(ctx, mei, wo, cos_theta) * dr::rcp(pdf);
+
+        return { wo, phase_weight, pdf };
+    }
+
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext &ctx,
+                                        const MediumInteraction3f &mei,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
+        /* If the incident direction is ω in graphics convention, it
+         * is -ω in physics convention. The evaluation implementation routines
+         * expect cos(θ) in physics convention.
+         */
+
+        Float cos_theta    = dot(wo, -mei.wi);
+        Spectrum phase_val = eval_rayleigh(ctx, mei, wo, cos_theta);
+        Float pdf          = eval_rayleigh_pdf(cos_theta);
+        return { phase_val, pdf };
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "RayleighPolarizedPhaseFunction["
+            << "depolarization = " << m_depolarization << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS()
+private:
+    ScalarFloat m_depolarization;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(RayleighPolarizedPhaseFunction, PhaseFunction)
+MI_EXPORT_PLUGIN(RayleighPolarizedPhaseFunction,
+                 "Polarized Rayleigh phase function")
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -1,0 +1,441 @@
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/phase.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**
+ * \brief 1D array defined in terms of an *irregularly* sampled linear
+ * interpolant
+ *
+ * This data structure represents an an array that is defined as a linear
+ * interpolant of an irregularly discretized signal. The nodes represent
+ * the irregular abscissa only which the array is represented.
+ *
+ * Notes: The data array can be different types as long as they are laid out in
+ * a contiguous array of Float. The templated Value will specify the output
+ * type of eval_data(). Also note that the size of data should be a multiple of
+ * the size of nodes.
+ *
+ * TODO : Ideally, I would like it not to have m11, m12, etc.. but to use
+ * a templated size for the number of coefficients. The crux of this is
+ * that each individual property needs to be updatable individually.
+ */
+template <typename Float> struct IrregularInterpolant {
+
+    using FloatStorage   = DynamicBuffer<Float>;
+    using UInt32         = dr::uint32_array_t<Float>;
+    using Index          = dr::uint32_array_t<Float>;
+    using Mask           = dr::mask_t<Float>;
+    using Vector2u       = dr::Array<UInt32, 2>;
+    using ScalarFloat    = dr::scalar_t<Float>;
+    using ScalarVector2f = dr::Array<ScalarFloat, 2>;
+
+    using Vector3f = dr::Array<Float, 3>;
+
+public:
+    /// Create an uninitialized IrregularInterpolant instance
+    IrregularInterpolant() {}
+
+    /// Initialize from a given floating point array
+    IrregularInterpolant(const ScalarFloat *nodes, const ScalarFloat *m12,
+                         const ScalarFloat *m33, const ScalarFloat *m34,
+                         size_t nodes_size)
+        : m_nodes(dr::load<FloatStorage>(nodes, nodes_size)),
+          m_m12(dr::load<FloatStorage>(m12, nodes_size)),
+          m_m33(dr::load<FloatStorage>(m33, nodes_size)),
+          m_m34(dr::load<FloatStorage>(m34, nodes_size)) {
+        update();
+    }
+
+    /// Update the internal state. Must be invoked when changing the data or
+    /// range.
+    void update() {
+
+        if (m_m12.size() != m_nodes.size() || m_m33.size() != m_nodes.size() ||
+            m_m34.size() != m_nodes.size())
+            Throw("IrregularInterpolant: 'data' and 'nodes' size "
+                  "mismatch!");
+
+        if constexpr (dr::is_jit_v<Float>) {
+            if (m_nodes.size() < 2)
+                Throw("IrregularInterpolant: needs at least two "
+                      "entries!");
+
+            uint32_t size = m_nodes.size() - 1;
+            m_range =
+                ScalarVector2f(dr::slice(m_nodes, 0), dr::slice(m_nodes, size));
+        } else {
+            if (m_nodes.size() < 2)
+                Throw("IrregularInterpolant: needs at least two "
+                      "entries!");
+
+            uint32_t size            = m_nodes.size();
+            const ScalarFloat *nodes = m_nodes.data();
+            m_range                  = ScalarVector2f(dr::Infinity<ScalarFloat>,
+                                                      -dr::Infinity<ScalarFloat>);
+
+            for (size_t i = 0; i < size - 1; ++i) {
+                double x0 = (double) nodes[0], x1 = (double) nodes[1];
+
+                m_range.x() = dr::minimum(m_range.x(), (ScalarFloat) x0);
+                m_range.y() = dr::maximum(m_range.y(), (ScalarFloat) x1);
+
+                nodes++;
+                if (!(x1 > x0)) {
+                    Throw("IrregularInterpolant: node positions "
+                          "must be strictly increasing!");
+                }
+            }
+        }
+    }
+
+    /// Return the nodes of the underlying discretization
+    FloatStorage &nodes() { return m_nodes; }
+
+    /// Return the nodes of the underlying discretization (const version)
+    const FloatStorage &nodes() const { return m_nodes; }
+
+    /// Return the unnormalized discretized probability density function
+    FloatStorage &m12() { return m_m12; }
+    const FloatStorage &m12() const { return m_m12; }
+
+    FloatStorage &m33() { return m_m33; }
+    const FloatStorage &m33() const { return m_m33; }
+
+    FloatStorage &m34() { return m_m34; }
+    const FloatStorage &m34() const { return m_m34; }
+
+    /// Evaluate the data value at position x
+    Vector3f eval_data(Float x, Mask active = true) const {
+        MI_MASK_ARGUMENT(active);
+
+        active &= x >= m_range.x() && x <= m_range.y();
+
+        Index index = dr::binary_search<Index>(
+            0, (uint32_t) m_nodes.size(), [&](Index index) DRJIT_INLINE_LAMBDA {
+                return dr::gather<Float>(m_nodes, index, active) < x;
+            });
+
+        index = dr::maximum(dr::minimum(index, (uint32_t) m_nodes.size() - 1u),
+                            1u) -
+                1u;
+
+        Vector3f y0, y1 = dr::zeros<Vector3f>();
+
+        Float x0 = dr::gather<Float>(m_nodes, index, active),
+              x1 = dr::gather<Float>(m_nodes, index + 1u, active);
+
+        y0.x() = dr::gather<Float>(m_m12, index, active);
+        y0.y() = dr::gather<Float>(m_m33, index, active);
+        y0.z() = dr::gather<Float>(m_m34, index, active);
+
+        y1.x() = dr::gather<Float>(m_m12, index + 1u, active);
+        y1.y() = dr::gather<Float>(m_m33, index + 1u, active);
+        y1.z() = dr::gather<Float>(m_m34, index + 1u, active);
+
+        x = (x - x0) / (x1 - x0);
+
+        return dr::select(active, dr::fmadd(x, y1 - y0, y0), 0.f);
+    }
+
+private:
+    FloatStorage m_nodes;
+    FloatStorage m_m12;
+    FloatStorage m_m33;
+    FloatStorage m_m34;
+    ScalarVector2f m_range{ 0.f, 0.f };
+};
+
+/**!
+
+.. _phase-tabphase_polarized:
+
+Lookup table (polarized) phase function (:monosp:`tabphase_polarized`)
+------------------------------------------------
+
+.. pluginparameters::
+
+ * - m11
+   - |string|
+   - A comma-separated list of phase matrix coefficient 1,1 of the
+     phase funciton, parametrized by the cosine of the scattering angle.
+   - |exposed|
+
+* - m12
+   - |string|
+   - A comma-separated list of phase matrix coefficient 1,2 of the
+     phase funciton, parametrized by the cosine of the scattering angle.
+   - |exposed|
+
+* - m33
+   - |string|
+   - A comma-separated list of phase matrix coefficient 3,3 of the
+     phase funciton, parametrized by the cosine of the scattering angle.
+   - |exposed|
+
+* - m34
+   - |string|
+   - A comma-separated list of phase matrix coefficient 3,4 of the
+     phase funciton, parametrized by the cosine of the scattering angle.
+   - |exposed|
+
+* - nodes
+   - |string|
+   - A comma-separated list of :math:`\cos \theta` specifying the grid on which
+     `values` are defined. Bounds must be [-1, 1] and values must be strictly
+     increasing. Must have the same length as `values`.
+   - |exposed|
+
+This plugin implements a generic phase function model for isotropic media
+parametrized by a lookup table giving values of the phase function as a
+function of the cosine of the scattering angle.
+
+.. admonition:: Notes
+
+   * The scattering angle cosine is here defined as the dot product of the
+     incoming and outgoing directions, where the incoming, resp. outgoing
+     direction points *toward*, resp. *outward* the interaction point.
+   * From this follows that :math:`\cos \theta = 1` corresponds to forward
+     scattering.
+   * Lookup table points are regularly spaced between -1 and 1.
+   * Phase function values are automatically normalized.
+   * For polarized phase functions, this assumes (for the time being) the
+     structure of a phase function with spherically symmetric particles, 
+     i.e. there are only four unique elements of the Mueller matrix: 
+     `M_{11}`, `M_{12}`, `M_{33}`, and `M_{34}`
+*/
+
+template <typename Float, typename Spectrum>
+class TabulatedPolarizedPhaseFunction final
+    : public PhaseFunction<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
+    MI_IMPORT_TYPES(PhaseFunctionContext)
+
+    using SomeArray = std::array<std::vector<ScalarFloat>, 3>;
+    TabulatedPolarizedPhaseFunction(const Properties &props) : Base(props) {
+        if (props.type("m11") == Properties::Type::String) {
+
+            // Extract required properties, nodes (cos_theta) and m11.
+            std::vector<std::string> cos_theta_str =
+                string::tokenize(props.string("nodes"), " ,");
+            std::vector<std::string> entry_str1,
+                m11_str = string::tokenize(props.string("m11"), " ,");
+
+            if (cos_theta_str.size() != m11_str.size()) {
+                Throw("TabulatedPolarizedPhaseFunction: 'cos_theta_str' and "
+                      "'m11_str' parameters must have the same size!");
+            }
+
+            std::vector<ScalarFloat> cos_theta, m11;
+            cos_theta.reserve(cos_theta_str.size());
+            m11.reserve(m11_str.size());
+
+            // convert from string to float arrays
+            for (size_t i = 0; i < cos_theta_str.size(); ++i) {
+                ScalarVector3f ms{ 0.f, 0.f, 0.f };
+                try {
+                    cos_theta.push_back(
+                        string::stof<ScalarFloat>(cos_theta_str[i]));
+                } catch (...) {
+                    Throw("Could not parse floating point value '%s'",
+                          cos_theta_str[i]);
+                }
+                try {
+                    m11.push_back(string::stof<ScalarFloat>(m11_str[i]));
+                } catch (...) {
+                    Throw("Could not parse floating point value '%s'",
+                          m11_str[i]);
+                }
+            }
+
+            m_m11 = IrregularContinuousDistribution<Float>(
+                cos_theta.data(), m11.data(), m11.size());
+
+            // Initial the other phase matrix coefs with zeros
+            SomeArray ms_vec;
+            ms_vec[0].reserve(m11_str.size() * 3);
+            ms_vec[1].reserve(m11_str.size() * 3);
+            ms_vec[2].reserve(m11_str.size() * 3);
+            for (size_t i = 0; i < cos_theta_str.size() * 3; ++i) {
+                ms_vec[0].push_back(ScalarFloat(0.f));
+                ms_vec[1].push_back(ScalarFloat(0.f));
+                ms_vec[2].push_back(ScalarFloat(0.f));
+            }
+
+            // Extract the optional phase matrix coefs
+            const std::string &raw_m12 = props.string("m12", "");
+            const std::string &raw_m33 = props.string("m33", "");
+            const std::string &raw_m34 = props.string("m34", "");
+
+            extract_phase_coef(ms_vec, raw_m12, 0, cos_theta_str.size());
+            extract_phase_coef(ms_vec, raw_m33, 1, cos_theta_str.size());
+            extract_phase_coef(ms_vec, raw_m34, 2, cos_theta_str.size());
+
+            m_mvec = IrregularInterpolant<Float>(
+                cos_theta.data(), ms_vec[0].data(), ms_vec[1].data(),
+                ms_vec[2].data(), cos_theta.size());
+        }
+
+        m_flags = +PhaseFunctionFlags::Anisotropic;
+        dr::set_attr(this, "flags", m_flags);
+        m_components.push_back(m_flags);
+    }
+
+    std::tuple<Vector3f, Spectrum, Float>
+    sample(const PhaseFunctionContext &ctx, const MediumInteraction3f &mei,
+           Float /* sample1 */, const Point2f &sample2,
+           Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
+
+        // Sample a direction in physics convention.
+        // We sample cos θ' = cos(π - θ) = -cos θ.
+        Float cos_theta_prime = m_m11.sample(sample2.x());
+        Float sin_theta_prime =
+            dr::safe_sqrt(1.f - cos_theta_prime * cos_theta_prime);
+        auto [sin_phi, cos_phi] =
+            dr::sincos(2.f * dr::Pi<ScalarFloat> * sample2.y());
+        Vector3f wo{ sin_theta_prime * cos_phi, sin_theta_prime * sin_phi,
+                     cos_theta_prime };
+
+        // Switch the sampled direction to graphics convention and transform the
+        // computed direction to world coordinates
+        wo = -mei.to_world(wo);
+
+        auto [phase_val, phase_pdf] = eval_pdf(ctx, mei, wo, active);
+        Spectrum phase_weight       = phase_val * dr::rcp(phase_pdf);
+
+        return { wo, phase_weight, phase_pdf };
+    }
+
+    std::pair<Spectrum, Float> eval_pdf(const PhaseFunctionContext &ctx,
+                                        const MediumInteraction3f &mei,
+                                        const Vector3f &wo,
+                                        Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
+
+        // The data is laid out in physics convention
+        // (with cos θ = 1 corresponding to forward scattering).
+        // This parameterization differs from the convention used internally by
+        // Mitsuba and is the reason for the minus sign below.
+        Float cos_theta = -dot(wo, mei.wi);
+
+        Spectrum phase_val(0.f);
+
+        // Use m11 for the for the phase and pdf since it is used for sampling
+        // cos theta.
+        Float m11      = m_m11.eval_pdf(cos_theta, active);
+        Float m11_norm = m_m11.normalization();
+        Float pdf      = m11 * m11_norm * dr::InvTwoPi<ScalarFloat>;
+
+        if constexpr (is_polarized_v<Spectrum>) {
+
+            Vector3f ms = m_mvec.eval_data(cos_theta, active);
+            phase_val =
+                MuellerMatrix<Float>(m11, ms.x(), 0, 0, ms.x(), m11, 0, 0, 0, 0,
+                                     ms.y(), ms.z(), 0, 0, -ms.z(), ms.y());
+            phase_val *= m11_norm * dr::InvTwoPi<ScalarFloat>;
+
+            /* Due to the coordinate system rotations for polarization-aware
+                pBSDFs below we need to know the propagation direction of light.
+                In the following, light arrives along `-wo_hat` and leaves along
+                `+wi_hat`. */
+            Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : mei.wi,
+                     wi_hat = ctx.mode == TransportMode::Radiance ? mei.wi : wo;
+
+            /* The Stokes reference frame vector of this matrix lies in the
+                scattering plane spanned by wi and wo. */
+            Vector3f x_hat      = dr::cross(-wo_hat, wi_hat),
+                     p_axis_in  = dr::normalize(dr::cross(x_hat, -wo_hat)),
+                     p_axis_out = dr::normalize(dr::cross(x_hat, wi_hat));
+
+            /* Rotate in/out reference vector of weight s.t. it aligns with the
+            implicit Stokes bases of -wo_hat & wi_hat. */
+            phase_val = mueller::rotate_mueller_basis(
+                phase_val, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+                wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
+
+            // If the cross product x_hat is too small, phase_val may be NaN
+            dr::masked(phase_val, dr::isnan(phase_val)) =
+                depolarizer<Spectrum>(0.f);
+        } else {
+            phase_val = Spectrum(m11) * m11_norm * dr::InvTwoPi<ScalarFloat>;
+            ;
+        }
+
+        return { phase_val, pdf };
+    }
+
+    void traverse(TraversalCallback *callback) override {
+
+        callback->put_parameter("m11", m_m11.pdf(),
+                                +ParamFlags::NonDifferentiable);
+        callback->put_parameter("m12", m_mvec.m12(),
+                                +ParamFlags::NonDifferentiable);
+        callback->put_parameter("m33", m_mvec.m33(),
+                                +ParamFlags::NonDifferentiable);
+        callback->put_parameter("m34", m_mvec.m34(),
+                                +ParamFlags::NonDifferentiable);
+
+        callback->put_parameter("nodes", m_m11.nodes(),
+                                +ParamFlags::NonDifferentiable);
+        callback->put_parameter("nodes", m_mvec.nodes(),
+                                +ParamFlags::NonDifferentiable);
+    }
+
+    void
+    parameters_changed(const std::vector<std::string> & /*keys*/) override {
+        m_m11.update();
+        m_mvec.update();
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "TabulatedPhaseFunction[" << std::endl
+            << "  distr = " << string::indent(m_m11) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+private:
+    void extract_phase_coef(SomeArray &output, const std::string &raw,
+                            size_t offset, size_t node_size) {
+        bool is_init = raw != "";
+
+        // only need to extract non-default properties.
+        if (is_init) {
+            std::vector<std::string> coef_str = string::tokenize(raw, " ,");
+
+            if (node_size != coef_str.size()) {
+                Throw("TabulatedPolarizedPhaseFunction: the provided "
+                      "parameters must have the same size as 'cos_theta_str'!");
+            }
+
+            for (size_t i = 0; i < node_size; ++i) {
+                try {
+                    // output[i*3+offset] =
+                    // string::stof<ScalarFloat>(coef_str[i]);
+                    output[offset][i] = string::stof<ScalarFloat>(coef_str[i]);
+                } catch (...) {
+                    Throw("Could not parse floating point value '%s'",
+                          coef_str[i]);
+                }
+            }
+        }
+    }
+
+    MI_DECLARE_CLASS()
+private:
+    // m11 of the mueller matrix, used to sample the phase function
+    IrregularContinuousDistribution<Float> m_m11;
+    // rest of the relevant mueller matrix' terms.
+    // IrregularInterpolant<Vector3f> m_mvec;
+    IrregularInterpolant<Float> m_mvec;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(TabulatedPolarizedPhaseFunction, PhaseFunction)
+MI_EXPORT_PLUGIN(TabulatedPolarizedPhaseFunction,
+                 "Tabulated (polarized) phase function")
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/tests/phase/test_rayleigh_polarized.py
+++ b/src/eradiate_plugins/tests/phase/test_rayleigh_polarized.py
@@ -1,0 +1,109 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def test_create(variant_scalar_mono_polarized):
+    p = mi.load_dict({"type": "rayleigh_polarized", "depolarization": 0.05})
+    assert p is not None
+
+
+def test_eval(variant_scalar_mono_polarized):
+    import numpy as np
+
+    def sph_to_dir(theta, phi):
+        """Map spherical to Euclidean coordinates."""
+        st = np.sin(theta)
+        ct = np.cos(theta)
+        sp = np.sin(phi)
+        cp = np.cos(phi)
+        return np.array([cp * st, sp * st, ct])
+
+    # Reference implementation
+    def rayleigh_scatter(cos_theta, rho=0.0):
+        # Based on Hansen & Travis (1974) eq. (2.15)
+        delta = (1.0 - rho) / (1.0 + 0.5 * rho)
+        delta_prime = (1.0 - 2.0 * rho) / (1.0 - rho)
+
+        cos_theta2 = cos_theta**2
+        a = cos_theta2 + 1.0
+        b = cos_theta2 - 1.0
+        c = 2.0 * cos_theta
+
+        norm_factor = 3.0 / (16.0 * np.pi)
+        return norm_factor * np.array(
+            [
+                [a * delta + (1.0 - delta), b * delta, 0, 0],
+                [b * delta, a * delta, 0, 0],
+                [0, 0, c * delta, 0],
+                [0, 0, 0, c * delta * delta_prime],
+            ]
+        )
+
+    rayleigh_polarized = mi.load_dict(
+        {
+            "type": "rayleigh_polarized",
+        }
+    )
+
+    # Create a (dummy) surface interaction to use for the evaluation of the BSDF
+    mei = dr.zeros(mi.MediumInteraction3f)
+
+    # Specify an incident direction with 45 degrees elevation
+    theta_i = 0.0
+    phi_i = 0.0
+    mei.wi = sph_to_dir(dr.deg2rad(theta_i), dr.deg2rad(phi_i))
+    mei.sh_frame = mi.Frame3f(mei.wi)
+
+    # Create grid in spherical coordinates and map it onto the sphere
+    test_res = 15
+    theta_os = np.linspace(0.00001, dr.pi, test_res)
+    phi_os = np.linspace(0.0, 2.0 * dr.pi, 2 * test_res)
+
+    data_reference = np.zeros((test_res, 2 * test_res, 4, 4))
+    data_rayleigh = np.zeros((test_res, 2 * test_res, 4, 4))
+
+    print(f"mei.wi : {mei.wi}")
+
+    for i, theta_o in enumerate(theta_os):
+        for j, phi_o in enumerate(phi_os):
+            wo = sph_to_dir(theta_o, phi_o)
+
+            data_rayleigh[i, j, :, :] = rayleigh_polarized.eval_pdf(
+                mi.PhaseFunctionContext(None), mei, wo
+            )[0]
+
+            phase_ref = rayleigh_scatter(np.dot(wo, -mei.wi))
+
+            wo = mi.Vector3f(wo)
+
+            # rotate reference frame to stokes basis
+            x_hat = dr.normalize(dr.cross(-wo, mei.wi))
+            p_axis_in = dr.normalize(dr.cross(x_hat, -wo))
+            p_axis_out = dr.normalize(dr.cross(x_hat, mei.wi))
+            phase_ref = mi.mueller.rotate_mueller_basis(
+                phase_ref,
+                -wo,
+                p_axis_in,
+                mi.mueller.stokes_basis(-wo),
+                mei.wi,
+                p_axis_out,
+                mi.mueller.stokes_basis(mei.wi),
+            )
+            data_reference[i, j, :, :] = phase_ref
+
+    assert np.allclose(data_rayleigh, data_reference, rtol=1e-4, atol=1e-4)
+
+
+def test_chi2(variant_llvm_mono_polarized):
+    sample_func, pdf_func = mi.chi2.PhaseFunctionAdapter("rayleigh_polarized", "")
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+    )
+
+    assert chi2.run()
+

--- a/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
+++ b/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
@@ -1,0 +1,261 @@
+import pytest
+import drjit as dr
+import mitsuba as mi
+
+
+def test_create_m11_only(variant_scalar_mono_polarized):
+    p = mi.load_dict(
+        {
+            "type": "tabphase_polarized",
+            "nodes": "-1.0, 0.0, 1.0",
+            "m11": "0.5, 1.0, 1.5",
+        }
+    )
+    assert p is not None
+
+
+def test_create_all_coefs(variant_scalar_mono_polarized):
+    p = mi.load_dict(
+        {
+            "type": "tabphase_polarized",
+            "nodes": "-1.0, 0.0, 1.0",
+            "m11": "0.5, 1.0, 1.5",
+            "m12": "0.5, 1.0, 1.5",
+            "m33": "0.5, 1.0, 1.5",
+            "m34": "0.5, 1.0, 1.5",
+        }
+    )
+    assert p is not None
+
+
+def test_eval(variant_scalar_mono_polarized):
+    import numpy as np
+
+    def sph_to_dir(theta, phi):
+        """Map spherical to Euclidean coordinates."""
+        st = np.sin(theta)
+        ct = np.cos(theta)
+        sp = np.sin(phi)
+        cp = np.cos(phi)
+        return np.array([cp * st, sp * st, ct])
+
+    # Reference implementation
+    def rayleigh_scatter(cos_theta, rho=0.0):
+        # Based on Hansen & Travis (1974) eq. (2.15)
+        delta = (1.0 - rho) / (1.0 + 0.5 * rho)
+        delta_prime = (1.0 - 2.0 * rho) / (1.0 - rho)
+
+        cos_theta2 = cos_theta**2
+        a = cos_theta2 + 1.0
+        b = cos_theta2 - 1.0
+        c = 2.0 * cos_theta
+
+        norm_factor = 3.0 / (16.0 * np.pi)
+        return norm_factor * np.array(
+            [
+                [a * delta + (1.0 - delta), b * delta, 0, 0],
+                [b * delta, a * delta, 0, 0],
+                [0, 0, c * delta, 0],
+                [0, 0, 0, c * delta * delta_prime],
+            ]
+        )
+
+    res = 100
+    # regular grid
+    # cos_thetas = np.linspace(-1., 1., res)
+    # irregular grid
+    cos_thetas = np.concatenate(
+        (
+            np.linspace(-1, 0, int(res * 0.3), False),
+            np.linspace(0.0, 1.0, int(res * 0.7)),
+        )
+    )
+
+    reference_val = np.zeros((res, 4, 4))
+    rho = 0.0
+
+    for i, cos_theta in enumerate(cos_thetas):
+        reference_val[i, :, :] = rayleigh_scatter(cos_theta, rho)
+
+    m_ref = np.zeros((4, res))
+    m_ref[0, :] = reference_val[:, 0, 0]
+    m_ref[1, :] = reference_val[:, 0, 1]
+    m_ref[2, :] = reference_val[:, 2, 2]
+    m_ref[3, :] = reference_val[:, 2, 3]
+
+    cos_theta_str = ", ".join([str(x) for x in cos_thetas])
+
+    m_ref_str = []
+    for i in range(4):
+        m_ref_str.append(", ".join([str(x) for x in m_ref[i, :]]))
+
+    tabphase_polarized = mi.load_dict(
+        {
+            "type": "tabphase_polarized",
+            "nodes": cos_theta_str,
+            "m11": m_ref_str[0],
+            "m12": m_ref_str[1],
+            "m33": m_ref_str[2],
+            "m34": m_ref_str[3],
+        }
+    )
+
+    # Create a (dummy) surface interaction to use for the evaluation of the BSDF
+    mei = dr.zeros(mi.MediumInteraction3f)
+
+    # Specify an incident direction with 45 degrees elevation
+    theta_i = 0.0
+    phi_i = 0.0
+    mei.wi = sph_to_dir(dr.deg2rad(theta_i), dr.deg2rad(phi_i))
+    mei.sh_frame = mi.Frame3f(mei.wi)
+
+    # Create grid in spherical coordinates and map it onto the sphere
+    test_res = 15
+    theta_os = np.linspace(0.00001, dr.pi, test_res)
+    phi_os = np.linspace(0.0, 2.0 * dr.pi, 2 * test_res)
+
+    data_reference = np.zeros((test_res, 2 * test_res, 4, 4))
+    data_tabphase = np.zeros((test_res, 2 * test_res, 4, 4))
+
+    print(f"mei.wi : {mei.wi}")
+
+    for i, theta_o in enumerate(theta_os):
+        for j, phi_o in enumerate(phi_os):
+            wo = sph_to_dir(theta_o, phi_o)
+
+            data_tabphase[i, j, :, :] = tabphase_polarized.eval_pdf(
+                mi.PhaseFunctionContext(None), mei, wo
+            )[0]
+
+            phase_ref = rayleigh_scatter(np.dot(wo, -mei.wi))
+
+            wo = mi.Vector3f(wo)
+
+            # rotate reference frame to stokes basis
+            x_hat = dr.normalize(dr.cross(-wo, mei.wi))
+            p_axis_in = dr.normalize(dr.cross(x_hat, -wo))
+            p_axis_out = dr.normalize(dr.cross(x_hat, mei.wi))
+            phase_ref = mi.mueller.rotate_mueller_basis(
+                phase_ref,
+                -wo,
+                p_axis_in,
+                mi.mueller.stokes_basis(-wo),
+                mei.wi,
+                p_axis_out,
+                mi.mueller.stokes_basis(mei.wi),
+            )
+            data_reference[i, j, :, :] = phase_ref
+
+    assert np.allclose(data_tabphase, data_reference, rtol=1e-4, atol=1e-4)
+
+
+def test_sample(variant_scalar_mono_polarized):
+    """
+    Check if the sampling routine uses consistent incoming-outgoing orientation
+    conventions.
+    """
+
+    tab = mi.load_dict(
+        {
+            "type": "tabphase_polarized",
+            "nodes": "-1.0, 0.0, 1.0",
+            "m11": "0.0, 0.5, 1.0",
+        }
+    )
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.t = 0.1
+    mei.p = [0, 0, 0]
+    mei.sh_frame = mi.Frame3f([0, 0, 1])
+    mei.wi = [0, 0, 1]
+
+    # The passed sample corresponds to forward scattering
+    wo, w, pdf = tab.sample(ctx, mei, 0, (1, 0))
+
+    # The sampled direction indicates forward scattering in the "graphics"
+    # convention
+    assert dr.allclose(wo, [0, 0, -1])
+
+    # The expected value was derived manually from the PDF expression.
+    # An incorrect convention (i.e. using -cos θ to fetch the PDF value) will
+    # yield 0 thanks to the values used to initialize the distribution and will
+    # make the test fail.
+    assert dr.allclose(pdf, 0.5 / dr.pi)
+
+
+def test_chi2(variant_llvm_mono_polarized):
+    sample_func, pdf_func = mi.chi2.PhaseFunctionAdapter(
+        "tabphase_polarized",
+        "<string name='nodes' value='-1.0, 0.0, 1.0'/>"
+        "<string name='m11' value='0.5, 1.0, 1.5'/>",
+    )
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+    )
+
+    result = chi2.run()
+    # chi2._dump_tables()
+    assert result
+
+
+def test_traverse(variant_scalar_mono_polarized):
+    # Phase function table definition
+    import numpy as np
+
+    ref_y = np.array([0.5, 1.0, 1.5])
+    ref_x = np.linspace(-1, 1, len(ref_y))
+    ref_integral = np.trapz(ref_y, ref_x)
+
+    # Initialise as isotropic and update with parameters
+    phase = mi.load_dict(
+        {
+            "type": "tabphase_polarized",
+            "m11": "1, 1, 1",
+            "m12": "1, 1, 1",
+            "m33": "1, 1, 1",
+            "m34": "1, 1, 1",
+            "nodes": "-1, 0, 1",
+        }
+    )
+    params = mi.traverse(phase)
+    params["m11"] = [0.5, 1.0, 1.5]
+    params["m12"] = [0.5, 1.0, 1.5]
+    params["m33"] = [0.5, 1.0, 1.5]
+    params["m34"] = [0.5, 1.0, 1.5]
+    params["nodes"] = [-1.0, 0.5, 1.0]
+    params.update()
+
+    # Distribution parameters are updated
+    params = mi.traverse(phase)
+    assert dr.allclose(params["m11"], [0.5, 1.0, 1.5])
+    assert dr.allclose(params["m12"], [0.5, 1.0, 1.5])
+    assert dr.allclose(params["m33"], [0.5, 1.0, 1.5])
+    assert dr.allclose(params["m34"], [0.5, 1.0, 1.5])
+    assert dr.allclose(params["nodes"], [-1.0, 0.5, 1.0])
+
+    # The plugin itself evaluates consistently
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.wi = np.array([0, 0.0000000001, -0.999999999])
+    wo = [0, 0, 1]
+    print(phase.eval_pdf(ctx, mei, wo)[0])
+    a = dr.inv_two_pi * 1.5 / ref_integral
+    ref = (
+        mi.Spectrum(
+            [
+                [1.0, -1.0, 0.0, 0.0],
+                [-1.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, -1.0],
+                [0.0, 0.0, 1.0, 1.0],
+            ]
+        )
+        * a
+    )
+    print(ref)
+
+    assert dr.allclose(phase.eval_pdf(ctx, mei, wo)[0], ref, rtol=1e-5, atol=1e-6)
+


### PR DESCRIPTION


<!-- Please add the labels (e.g. bug fix, feature, ..) corresponding to this PR -->

## Description

This PR enable volumetric polarization through two new plugins : `rayleigh_polarized` and `tabphase_polarized`.
* Rayleigh polarized :  implements the polarized version of the rayleigh function. This has been adapted from the [mitsuba-nasa fork](https://github.com/ksalesin/mitsuba3-nasa), the main difference being that medium interactions are done in world space (instead of local space). 
* Tabphase polarized: like `tabphase` and `tabphase_irregular`, allows to provide a phase function in a tabulated form. Specifically, this version allows to pass coefficients $m_{11}$, $m_{12}$, $m_{33}$, and $m_{34}$ of the phase function, which are used to construct the scattering matrix for spherical particles:  
\
$``
P = \begin{bmatrix}
m_{11} & m_{12} & 0 & 0 \\
m_{12} & m_{11} & 0 & 0 \\
0 & 0 & m_{33} & m_{34} \\
0 & 0 & -m_{34} & m_{33} \\
\end{bmatrix}
``$
\
This is also taken from [mitsuba-nasa fork](https://github.com/ksalesin/mitsuba3-nasa), and again modifications were made to optimize the table lookup. An interpolated irregular array is used to look up all remaining coefficients form one index.  
* Added a parameter to the stokes integrator to allow alignment of the stokes vector to the meridian plane (plane spanned by vertical vector and ray) instead of the sensor's x axis. Note that this alignment fails in vertical direction at the moment because it should then use the alignment of the sensor up direction. This, however, is not compatible with the batch sensor, and we are awaiting an answer from RGL on how to proceed with it. 
* Added unit test and Chi2 tests to the phase functions.

Note that the volumetric path tracers didn't need any modifications. This also means that it is compatible with the piecewise volumetric path tracer out of the box. Polarization has been tested in scalar and llvm mode. Color representations are as recommended in [mitsuba's guide to polarization](https://mitsuba.readthedocs.io/en/stable/src/key_topics/polarization.html#representation). 

## Testing

Testing was done by comparing our results to the ones of Natraj et al. (2009) and to the [benchmarks of IPRT](https://www.meteo.physik.uni-muenchen.de/~iprt/doku.php?id=intercomparisons:intercomparisons). Our results are in agreement with both models, giving us confidence in our implementation.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)