### PR TITLE
[Feature] Heterogeneous depolarization factor for Rayleigh Phase Function.

### DIFF
--- a/src/eradiate_plugins/phase/rayleigh_polarized.cpp
+++ b/src/eradiate_plugins/phase/rayleigh_polarized.cpp
@@ -41,10 +41,15 @@ public:
     RayleighPolarizedPhaseFunction(const Properties &props) : Base(props) {
         m_depolarization = props.volume<Volume>("depolarization",0.f);
 
-        if( m_depolarization->max() >= 1.f )
+        if(m_depolarization->max() >= 1.f)
             Log(Error, "Depolarization factor must be in [0, 1[");
 
         m_flags = +PhaseFunctionFlags::Anisotropic;
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_object("depolarization", m_depolarization.get(),
+                             +ParamFlags::Differentiable);
     }
 
     MI_INLINE

--- a/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
+++ b/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
@@ -95,8 +95,10 @@ def test_eval(variant_scalar_mono_polarized):
             "nodes": cos_theta_str,
             "m11": m_ref_str[0],
             "m12": m_ref_str[1],
+            "m22": m_ref_str[0],
             "m33": m_ref_str[2],
             "m34": m_ref_str[3],
+            "m44": m_ref_str[2],
         }
     )
 
@@ -216,16 +218,20 @@ def test_traverse(variant_scalar_mono_polarized):
             "type": "tabphase_polarized",
             "m11": "1, 1, 1",
             "m12": "1, 1, 1",
+            "m22": "1, 1, 1",
             "m33": "1, 1, 1",
             "m34": "1, 1, 1",
+            "m44": "1, 1, 1",
             "nodes": "-1, 0, 1",
         }
     )
     params = mi.traverse(phase)
     params["m11"] = [0.5, 1.0, 1.5]
     params["m12"] = [0.5, 1.0, 1.5]
+    params["m22"] = [0.5, 1.0, 1.5]
     params["m33"] = [0.5, 1.0, 1.5]
     params["m34"] = [0.5, 1.0, 1.5]
+    params["m44"] = [0.5, 1.0, 1.5]
     params["nodes"] = [-1.0, 0.5, 1.0]
     params.update()
 


### PR DESCRIPTION
## Description

Hello, this PR aims to modify the depolarization factor of the Rayleigh phase function into a volume in order to make it an heterogeneous parameter over the medium. 
This change also means that the depolarization factor is resolved into an `UnpolarizedSpectrum`, which propagates to the rest of the functions.

This PR also includes a fix to the tabphase_polarized tests which were failing.

## Testing

The changes have been tested by running renders with various numbers of volume cells and configurations (+ 1 llvm test).

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)