### PR TITLE
[Feature] New polarized Ocean BRDF as implemented by Mishchenko (1997).  

### DIFF
--- a/include/mitsuba/eradiate/oceanprops.h
+++ b/include/mitsuba/eradiate/oceanprops.h
@@ -1,0 +1,531 @@
+#pragma once
+
+#include <mitsuba/mitsuba.h>
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/math.h>
+#include <mitsuba/render/fwd.h>
+#include <drjit/complex.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+// Header content - THIS CAN BE MOVED IF NECESSARY
+#ifndef OCEAN_PROPS
+#define OCEAN_PROPS
+
+template <typename Float, typename Spectrum> class OceanProperties {
+public:
+    MI_IMPORT_TYPES()
+
+    /**
+     * @brief Construct a new Ocean Properties object and initializes the data.
+     *
+     * Initializes the data for the effective reflectance of whitecaps, the
+     * complex index of refraction of water, the water scattering and
+     * attenuation coefficients, and the molecular scattering coefficients. The
+     * data is taken from various sources in the literature.
+     */
+    OceanProperties() {
+        /*
+        * Effective reflectance of whitecaps (Whitlock et al. 1982)
+        * Wavelength specified in um.
+        * Wavelengths are stored in a regular grid, using range instead.
+        constexpr ScalarFloat wc_wavelengths[] = {  
+            0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1,
+            1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 
+            2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1,
+            3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0 };
+        */
+        constexpr ScalarFloat wc_data[] = {
+            0.220, 0.220, 0.220, 0.220, 0.220, 0.220, 0.215, 0.210,
+            0.200, 0.190, 0.175, 0.155, 0.130, 0.080, 0.100, 0.105,
+            0.100, 0.080, 0.045, 0.055, 0.065, 0.060, 0.055, 0.040,
+            0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000,
+            0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000
+        };
+
+        // Complex index of refraction of water (Hale & Querry 1973)
+        // !! Note that the wavelength is in nm to align with the rest of
+        // Mitsuba !!
+        constexpr ScalarFloat ior_wavelengths[] = {
+            200,  225,  250,  275,  300,  325,  345,  375,  400,  425,  445,
+            475,  500,  525,  550,  575,  600,  625,  650,  675,  700,  725,
+            750,  775,  800,  825,  850,  875,  900,  925,  950,  975,  1000,
+            1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2650, 2700, 2750,
+            2800, 2850, 2900, 2950, 3000, 3050, 3100, 3150, 3200, 3250, 3300,
+            3350, 3400, 3450, 3500, 3600, 3700, 3800, 3900, 4000
+        };
+        constexpr ScalarFloat ior_real_data[] = {
+            1.369, 1.373, 1.362, 1.354, 1.349, 1.346, 1.343, 1.341,
+            1.339, 1.338, 1.337, 1.336, 1.335, 1.334, 1.333, 1.333,
+            1.332, 1.332, 1.331, 1.331, 1.331, 1.330, 1.330, 1.330,
+            1.329, 1.329, 1.329, 1.328, 1.328, 1.328, 1.327, 1.327,
+            1.327, 1.324, 1.321, 1.317, 1.312, 1.306, 1.296, 1.279,
+            1.242, 1.219, 1.188, 1.157, 1.142, 1.149, 1.201, 1.292,
+            1.371, 1.426, 1.467, 1.483, 1.478, 1.467, 1.450, 1.432,
+            1.420, 1.410, 1.400, 1.385, 1.374, 1.364, 1.357, 1.351
+        };
+        constexpr ScalarFloat ior_cplx_data[] = {
+            1.10e-07, 4.90e-08, 3.35e-08, 2.35e-08, 1.60e-08, 1.08e-08,
+            6.50e-09, 3.50e-09, 1.86e-09, 1.30e-09, 1.02e-09, 9.35e-10,
+            1.00e-09, 1.32e-09, 1.96e-09, 3.60e-09, 1.09e-08, 1.39e-08,
+            1.64e-08, 2.23e-08, 3.35e-08, 9.15e-08, 1.56e-07, 1.48e-07,
+            1.25e-07, 1.82e-07, 2.93e-07, 3.91e-07, 4.86e-07, 1.06e-06,
+            2.93e-06, 3.48e-06, 2.89e-06, 9.89e-06, 1.38e-04, 8.55e-05,
+            1.15e-04, 1.10e-03, 2.89e-04, 9.56e-04, 3.17e-03, 6.70e-03,
+            1.90e-02, 5.90e-02, 1.15e-01, 1.85e-01, 2.68e-01, 2.98e-01,
+            2.72e-01, 2.40e-01, 1.92e-01, 1.35e-01, 9.24e-02, 6.10e-02,
+            3.68e-02, 2.61e-02, 1.95e-02, 1.32e-02, 9.40e-03, 5.15e-03,
+            3.60e-03, 3.40e-03, 3.80e-03, 4.60e-03
+        };
+
+        /*
+        * Water scattering and attenuation coefficient data (Morel 1988)
+        * Wavelength specified in nm.
+        * Wavelengths are stored in a regular grid, using range instead.
+        constexpr ScalarFloat attn_wavelengths[] = { 
+            400, 405, 410, 415, 420, 425, 430, 435, 440, 445, 
+            450, 455, 460, 465, 470, 475, 480, 485, 490, 495, 
+            500, 505, 510, 515, 520, 525, 530, 535, 540, 545, 
+            550, 555, 560, 565, 570, 575, 580, 585, 590, 595, 
+            600, 605, 610, 615, 620, 625, 630, 635, 640, 645, 
+            650, 655, 660, 665, 670, 675, 680, 685, 690, 695, 
+            700 
+        };
+        */
+        constexpr ScalarFloat attn_k[] = {
+            0.0209, 0.0200, 0.0196, 0.0189, 0.0183, 0.0182, 0.0171, 0.0170,
+            0.0168, 0.0166, 0.0168, 0.0170, 0.0173, 0.0174, 0.0175, 0.0184,
+            0.0194, 0.0203, 0.0217, 0.0240, 0.0271, 0.0320, 0.0384, 0.0445,
+            0.0490, 0.0505, 0.0518, 0.0543, 0.0568, 0.0615, 0.0640, 0.0640,
+            0.0717, 0.0762, 0.0807, 0.0940, 0.1070, 0.1280, 0.1570, 0.2000,
+            0.2530, 0.2790, 0.2960, 0.3030, 0.3100, 0.3150, 0.3200, 0.3250,
+            0.3300, 0.3400, 0.3500, 0.3700, 0.4050, 0.4180, 0.4300, 0.4400,
+            0.4500, 0.4700, 0.5000, 0.5500, 0.6500
+        };
+        constexpr ScalarFloat attn_chi[] = {
+            0.1100, 0.1110, 0.1125, 0.1135, 0.1126, 0.1104, 0.1078, 0.1065,
+            0.1041, 0.0996, 0.0971, 0.0939, 0.0896, 0.0859, 0.0823, 0.0788,
+            0.0746, 0.0726, 0.0690, 0.0660, 0.0636, 0.0600, 0.0578, 0.0540,
+            0.0498, 0.0475, 0.0467, 0.0450, 0.0440, 0.0426, 0.0410, 0.0400,
+            0.0390, 0.0375, 0.0360, 0.0340, 0.0330, 0.0328, 0.0325, 0.0330,
+            0.0340, 0.0350, 0.0360, 0.0375, 0.0385, 0.0400, 0.0420, 0.0430,
+            0.0440, 0.0445, 0.0450, 0.0460, 0.0475, 0.0490, 0.0515, 0.0520,
+            0.0505, 0.0440, 0.0390, 0.0340, 0.0300
+        };
+        constexpr ScalarFloat attn_e[] = {
+            0.668, 0.672, 0.680, 0.687, 0.693, 0.701, 0.707, 0.708, 0.707,
+            0.704, 0.701, 0.699, 0.700, 0.703, 0.703, 0.703, 0.703, 0.704,
+            0.702, 0.700, 0.700, 0.695, 0.690, 0.685, 0.680, 0.675, 0.670,
+            0.665, 0.660, 0.655, 0.650, 0.645, 0.640, 0.630, 0.623, 0.615,
+            0.610, 0.614, 0.618, 0.622, 0.626, 0.630, 0.634, 0.638, 0.642,
+            0.647, 0.653, 0.658, 0.663, 0.667, 0.672, 0.677, 0.682, 0.687,
+            0.695, 0.697, 0.693, 0.665, 0.640, 0.620, 0.600
+        };
+        // IMPORTANT: This table uses the values provided by Morel, which are
+        // different than the ones from 6SV
+        constexpr ScalarFloat molecular_scatter_coeffs[] = {
+            0.00618095, 0.00578095, 0.00547619, 0.00517619, 0.00492222,
+            0.0046746,  0.00447143, 0.00426825, 0.00406508, 0.0038619,
+            0.00365873, 0.00346667, 0.00331429, 0.0031619,  0.00300952,
+            0.00287143, 0.00276984, 0.00265238, 0.0025,     0.00236508,
+            0.00226349, 0.0021619,  0.00206032, 0.00195873, 0.00185714,
+            0.00177778, 0.00172698, 0.00167619, 0.0016254,  0.0015746,
+            0.00152381, 0.00144603, 0.00134444, 0.0013,     0.0013,
+            0.00126984, 0.00121905, 0.00116825, 0.00111746, 0.00107,
+            0.00102429, 0.00098556, 0.00095,    0.0009181,  0.00088762,
+            0.00085714, 0.00082667, 0.00079619, 0.00076571, 0.00073937,
+            0.00071397, 0.00069286, 0.00067254, 0.00065222, 0.0006319,
+            0.00061159, 0.00059127, 0.00057095, 0.00055063, 0.00053524,
+            0.00052
+        };
+
+        constexpr ScalarFloat molecular_scatter_coeffs_6s[] = {
+            0.0076, 0.0072, 0.0068, 0.0064, 0.0061, 0.0058, 0.0055, 0.0052,
+            0.0049, 0.0047, 0.0045, 0.0043, 0.0041, 0.0039, 0.0037, 0.0036,
+            0.0034, 0.0033, 0.0031, 0.0030, 0.0029, 0.0027, 0.0026, 0.0025,
+            0.0024, 0.0023, 0.0022, 0.0022, 0.0021, 0.0020, 0.0019, 0.0018,
+            0.0018, 0.0017, 0.0017, 0.0016, 0.0016, 0.0015, 0.0015, 0.0014,
+            0.0014, 0.0013, 0.0013, 0.0012, 0.0012, 0.0011, 0.0011, 0.0010,
+            0.0010, 0.0010, 0.0010, 0.0009, 0.0008, 0.0008, 0.0008, 0.0007,
+            0.0007, 0.0007, 0.0007, 0.0007, 0.0007
+        };
+
+        // Construct distributions from the provided data sets
+        // !! Note that unlike the wavelength is in nm to align with the rest of
+        // Mitsuba !!
+        m_effective_reflectance = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(200.f, 4000.f), wc_data, std::size(wc_data));
+
+        m_ior_real = IrregularContinuousDistribution<ScalarFloat>(
+            ior_wavelengths, ior_real_data, std::size(ior_real_data));
+
+        m_ior_imag = IrregularContinuousDistribution<ScalarFloat>(
+            ior_wavelengths, ior_cplx_data, std::size(ior_cplx_data));
+
+        m_attn_k = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(400.f, 700.f), attn_k, std::size(attn_k));
+
+        m_attn_chi = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(400.f, 700.f), attn_chi, std::size(attn_chi));
+
+        m_attn_e = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(400.f, 700.f), attn_e, std::size(attn_e));
+
+        m_molecular_scatter_coeffs = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(400.f, 700.f), molecular_scatter_coeffs,
+            std::size(molecular_scatter_coeffs));
+
+        m_molecular_scatter_coeffs_6s = ContinuousDistribution<ScalarFloat>(
+            ScalarVector2f(400.f, 700.f), molecular_scatter_coeffs_6s,
+            std::size(molecular_scatter_coeffs_6s));
+    }
+
+    /**
+     * @brief Evaluate the effective reflectance of whitecaps.
+     *
+     * Evaluates the effective reflectance of whitecaps at the given
+     * wavelength. The value returned already takes into account
+     * the base offset of 0.4 as described by (Koepke 1984).
+     *
+     * @param wavelength The wavelength at which to evaluate the reflectance.
+     * @return ScalarFloat The effective reflectance of whitecaps.
+     */
+    ScalarFloat effective_reflectance(const ScalarFloat &wavelength) const {
+        return m_effective_reflectance.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the real index of refraction of water.
+     *
+     * Evaluates the real index of refraction of water at the given
+     * wavelength. The value returned is the real part of the complex
+     * index of refraction as described by (Hale & Querry 1973).
+     *
+     * @param wavelength The wavelength at which to evaluate the index of
+     * refraction.
+     * @return ScalarFloat The real part of the index of refraction.
+     */
+    ScalarFloat ior_real(const ScalarFloat &wavelength) const {
+        return m_ior_real.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the complex index of refraction of water.
+     *
+     * Evaluates the complex index of refraction of water at the given
+     * wavelength. The value returned is the imaginary part of the complex
+     * index of refraction as described by (Hale & Querry 1973).
+     *
+     * @param wavelength The wavelength at which to evaluate the index of
+     * refraction.
+     * @return ScalarFloat The imaginary part of the index of refraction.
+     */
+    ScalarFloat ior_cplx(const ScalarFloat &wavelength) const {
+        return m_ior_imag.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the K-term of the attenuation coefficient of water.
+     *
+     * Evaluates the K-term of the attenuation coefficient of water at the given
+     * wavelength. The value returned is the K-term as described by (Morel
+     * 1988).
+     *
+     * @param wavelength The wavelength at which to evaluate the K-term of the
+     * attenuation coefficient.
+     * @return ScalarFloat The K-term of the attenuation coefficient.
+     */
+    ScalarFloat attn_k(const ScalarFloat &wavelength) const {
+        return m_attn_k.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the Chi-term of the attenuation coefficient of water.
+     *
+     * Evaluates the Chi-term of the attenuation coefficient of water at the
+     * given wavelength. The value returned is the Chi-term as described by
+     * (Morel 1988).
+     *
+     * @param wavelength The wavelength at which to evaluate the Chi-term of the
+     * attenuation coefficient.
+     * @return ScalarFloat The Chi-term of the attenuation coefficient.
+     */
+    ScalarFloat attn_chi(const ScalarFloat &wavelength) const {
+        return m_attn_chi.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the E-term of the attenuation coefficient of water.
+     *
+     * Evaluates the E-term of the attenuation coefficient of water at the given
+     * wavelength. The value returned is the E-term as described by (Morel
+     * 1988).
+     *
+     * @param wavelength The wavelength at which to evaluate the E-term of the
+     * attenuation coefficient.
+     * @return ScalarFloat The E-term of the attenuation coefficient.
+     */
+    ScalarFloat attn_e(const ScalarFloat &wavelength) const {
+        return m_attn_e.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the molecular scattering coefficient of water.
+     *
+     * Evaluates the molecular scattering coefficient of water at the given
+     * wavelength. The value returned is the molecular scattering coefficient
+     * as described by (Morel 1988).
+     *
+     * @param wavelength The wavelength at which to evaluate the molecular
+     * scattering coefficient.
+     * @return ScalarFloat The molecular scattering coefficient.
+     */
+    ScalarFloat molecular_scatter_coeff(const ScalarFloat &wavelength) const {
+        return m_molecular_scatter_coeffs.eval_pdf(wavelength);
+    }
+
+    /**
+     * @brief Evaluate the molecular scattering coefficient of water.
+     *
+     * Evaluates the molecular scattering coefficient of water at the given
+     * wavelength. The value returned is the molecular scattering coefficient
+     * as described by the 6S radiative transfer model.
+     *
+     * @param wavelength The wavelength at which to evaluate the molecular
+     * scattering coefficient.
+     * @return ScalarFloat The molecular scattering coefficient.
+     */
+    ScalarFloat molecular_scatter_coeff_6s(const ScalarFloat &wavelength) const {
+        return m_molecular_scatter_coeffs_6s.eval_pdf(wavelength);
+    }
+
+private:
+    // Effective reflectance of whitecaps
+    ContinuousDistribution<ScalarFloat> m_effective_reflectance;
+
+    // Real/Complex IOR of water (Hale & Querry 1973)
+    IrregularContinuousDistribution<ScalarFloat> m_ior_real;
+    IrregularContinuousDistribution<ScalarFloat> m_ior_imag;
+
+    // Water scattering and attenuation coefficients (Morel 1988)
+    ContinuousDistribution<ScalarFloat> m_attn_k;
+    ContinuousDistribution<ScalarFloat> m_attn_chi;
+    ContinuousDistribution<ScalarFloat> m_attn_e;
+    ContinuousDistribution<ScalarFloat> m_molecular_scatter_coeffs;
+    ContinuousDistribution<ScalarFloat> m_molecular_scatter_coeffs_6s;
+};
+
+
+/**
+ * @brief Compute the correction to the IOR of water.
+ *
+ * Computes the correction to the index of refraction of water according to
+ * the formulas provided by Friedman (1969) and Sverdrup (1942). The
+ * correction is computed as a function of the chlorinity of the water.
+ *
+ * @param chlorinity The chlorinity of the water.
+ * @return ScalarFloat The correction to the index of refraction.
+ */
+template<typename Float>
+Float friedman_sverdrup(const Float &chlorinity) {
+    return 0.00017492711f * (0.03f + 1.805f * chlorinity);
+}
+
+/**
+ * @brief Evaluate the complex index of refraction of the ocean.
+ *
+ * @param wavelength The wavelength at which to evaluate the reflectance.
+ * @param chlorinity The chlorinity of the water.
+ * @return The complex index of refraction of water.
+ */
+template<typename Float, typename Spectrum, typename ScalarFloat>
+std::pair<ScalarFloat, ScalarFloat> 
+water_ior( const OceanProperties<Float, Spectrum> &ocean_props,
+           const ScalarFloat &wavelength,
+           const ScalarFloat &chlorinity) {
+    ScalarFloat n_real =
+        ocean_props.ior_real(wavelength) + friedman_sverdrup<ScalarFloat>(chlorinity);
+    ScalarFloat n_imag = ocean_props.ior_cplx(wavelength);
+
+    return { n_real, n_imag };
+}
+
+/**
+ * @brief Evaluate the Fresnel coefficient as implemented by 6SV
+ * (based on Born and Wolf (1975), which we couldn't verify).
+ *
+ * Evaluates the Fresnel coefficient at the given real and imaginary parts
+ * of the index of refraction, and relevant geometry terms derived from the
+ * incoming and outgoing directions. The coefficient is computed using the
+ * Fresnel equations.
+ *
+ * @param n_real The real part of the index of refraction.
+ * @param n_imag The imaginary part of the index of refraction.
+ * @param coschi The cosine of the geometry term.
+ * @param sinchi The sine of the geometry term.
+ * @return Float The Fresnel coefficient.
+ */
+template<typename Float>
+Float fresnel_sunglint_legacy( 
+    const Float &n_real, 
+    const Float &n_imag, 
+    const Float &coschi, 
+    const Float &sinchi) {
+    
+    const Float n_real2 = n_real * n_real;
+    const Float n_imag2 = n_imag * n_imag;
+
+    const Float s = (n_real2) - (n_imag2) - (sinchi * sinchi);
+
+    const Float a_1 = dr::abs(s);
+    const Float a_2 = dr::sqrt(dr::sqr(s) + 4.0f * n_real2 * n_imag2);
+
+    const Float u = dr::sqrt(0.5f * dr::abs(a_1 + a_2));
+    const Float v = dr::sqrt(0.5f * dr::abs(a_2 - a_1));
+
+    const Float b_1 = (n_real2 - n_imag2) * coschi;
+    const Float b_2 = 2 * n_real * n_imag * coschi;
+
+    const Float right_squared =
+        (dr::sqr(coschi - u) + v * v) / (dr::sqr(coschi + u) + v * v);
+    const Float left_squared = (dr::sqr(b_1 - u) + dr::sqr(b_2 + v)) /
+                                (dr::sqr(b_1 + u) + dr::sqr(b_2 - v));
+    
+    return (right_squared + left_squared) * 0.5f;
+};
+
+/**
+ * @brief Evaluate the polarized Fresnel coefficient as implemented by Mischenko (1997).
+ *
+ * Evaluates the polarized Fresnel coefficient at given complex indices of 
+ * refraction and geometry defined by the incoming and outgoing directions.
+ * The mueller matrix is computed using the formulation from Mishchenko (1997).
+ *
+ * @param n_ext The external complex index of refraction.
+ * @param n_water The water complex index of refraction.
+ * @param wi The incident direction, in the direction of progagation (physics convention).
+ * @param wo The outgoing direciton, in the direction of propagation (physics convention).
+ * @return MuellerMatrix<UnpolarizedSpectrum> The Fresnel mueller matrix.
+ */
+template<typename Float, typename UnpolarizedSpectrum>
+MuellerMatrix<UnpolarizedSpectrum> fresnel_sunglint_polarized(
+    const dr::Complex<UnpolarizedSpectrum> &n_ext, 
+    const dr::Complex<UnpolarizedSpectrum> &n_water,
+    Vector<Float, 3> wi, 
+    Vector<Float, 3> wo){
+
+    using Mask = dr::mask_t<Float>;
+    using Complex2u = dr::Complex<UnpolarizedSpectrum>;
+    using Vector3f = Vector<Float, 3>;
+
+    const Complex2u n1 = n_ext;
+    const Complex2u n2 = n_water;
+
+    Float mu_i = dr::abs(wi.z());
+    Float mu_o = dr::abs(wo.z());
+
+    Float phi_i = dr::atan2(wi.y(), wi.x());
+    Float phi_o = dr::atan2(wo.y(), wo.x());
+
+    dr::masked(mu_i, mu_i > 0.9999999f) = 0.9999999f;
+    dr::masked(mu_o, mu_o > 0.9999999f) = 0.9999999f;
+
+    /* unit vectors of incident and reflected rays */
+    Float sitheta_i = dr::sqrt(1.f - mu_i * mu_i);
+    Float sitheta_o = dr::sqrt(1.f - mu_o * mu_o);
+
+    wi = Vector3f(sitheta_i * cos (phi_i), sitheta_i * sin (phi_i), -mu_i);
+    wo = Vector3f(sitheta_o * cos (phi_o), sitheta_o * sin (phi_o), mu_o);
+
+    // local surface normal k_d
+    const Vector3f k_d = wi - wo;
+    const Float k_d_norm2 = dr::dot(k_d, k_d);
+    
+    // Fresnel reflection coefficition (should that be taken out?)
+    // the incident angel wrt local surface normal
+    const Float mu_i_l = dr::dot(k_d, wi) / dr::sqrt(k_d_norm2);
+    // mu_refr_l, R_r and R_l are all complex. R_r for Fresnel perpendicular and R_l for fresnel parallel
+    const Complex2u mu_refr_l = dr::sqrt(1.f - (1.f - mu_i_l * mu_i_l) * n1 * n1 / (n2 * n2));
+    const Complex2u R_r = (n1 * mu_i_l - n2 * mu_refr_l) / (n1 * mu_i_l + n2 * mu_refr_l);
+    const Complex2u R_l = (n2 * mu_i_l - n1 * mu_refr_l) / (n2 * mu_i_l + n1 * mu_refr_l);
+
+    // theta_v, phi_v, and w represent the polarization frame
+    const Vector3f z(0.f, 0.f, 1.f);
+
+    Mask collinear = dr::all(dr::eq(wi, -z));
+    const Vector3f phi_v_i = dr::select(collinear, Vector3f(0.f, 1.f, 0.f), dr::normalize(dr::cross(z, wi)));
+    const Vector3f theta_v_i = dr::cross(wi, phi_v_i);
+
+    collinear = dr::all(dr::eq(wo, z));
+    const Vector3f phi_v_o = dr::select(collinear, Vector3f(0.f,1.f,0.f), dr::normalize(dr::cross(z, wo)));
+    const Vector3f theta_v_o = dr::cross(wo, phi_v_o);
+
+    // amplitude scattering matrix
+    const Float pi_dot_wo = dr::dot(phi_v_i, wo);
+    const Float po_dot_wi = dr::dot(phi_v_o, wi);
+    const Float ti_dot_wo = dr::dot(theta_v_i, wo);
+    const Float to_dot_wi = dr::dot(theta_v_o, wi);
+
+    const Complex2u f_tt =  pi_dot_wo * po_dot_wi * R_r + ti_dot_wo * to_dot_wi * R_l;
+    const Complex2u f_tp = -ti_dot_wo * po_dot_wi * R_r + pi_dot_wo * to_dot_wi * R_l;
+    const Complex2u f_pt = -pi_dot_wo * to_dot_wi * R_r + ti_dot_wo * po_dot_wi * R_l;
+    const Complex2u f_pp =  ti_dot_wo * to_dot_wi * R_r + pi_dot_wo * po_dot_wi * R_l;
+
+    // stokes transmission matrix
+    const Vector3f wi_cross_wo = dr::cross(wi, wo);
+    collinear = dr::all(dr::eq(wo, -wi));
+    const Float norm2 = dr::select(collinear, 
+                                    0.000001f, 
+                                    dr::pow(dr::dot(wi_cross_wo, wi_cross_wo),2));
+    Float coeff = 1.f / norm2;
+
+    const UnpolarizedSpectrum n_f_tt = dr::abs(f_tt);
+    const UnpolarizedSpectrum n_f_tp = dr::abs(f_tp);
+    const UnpolarizedSpectrum n_f_pt = dr::abs(f_pt);
+    const UnpolarizedSpectrum n_f_pp = dr::abs(f_pp);
+
+    const UnpolarizedSpectrum M00 = 0.5 * coeff * (n_f_tt * n_f_tt + n_f_tp * n_f_tp + n_f_pt * n_f_pt + n_f_pp * n_f_pp);
+    const UnpolarizedSpectrum M01 = 0.5 * coeff * (n_f_tt * n_f_tt - n_f_tp * n_f_tp + n_f_pt * n_f_pt - n_f_pp * n_f_pp);
+    const UnpolarizedSpectrum M10 = 0.5 * coeff * (n_f_tt * n_f_tt + n_f_tp * n_f_tp - n_f_pt * n_f_pt - n_f_pp * n_f_pp);
+    const UnpolarizedSpectrum M11 = 0.5 * coeff * (n_f_tt * n_f_tt - n_f_tp * n_f_tp - n_f_pt * n_f_pt + n_f_pp * n_f_pp);
+    const UnpolarizedSpectrum M02 = -coeff * dr::real(f_tt*dr::conj(f_tp) + f_pt*dr::conj(f_pp));
+    const UnpolarizedSpectrum M03 = -coeff * dr::imag(f_tt*dr::conj(f_tp) + f_pt*dr::conj(f_pp));
+    const UnpolarizedSpectrum M12 = -coeff * dr::real(f_tt*dr::conj(f_tp) - f_pt*dr::conj(f_pp));
+    const UnpolarizedSpectrum M13 = -coeff * dr::imag(f_tt*dr::conj(f_tp) - f_pt*dr::conj(f_pp));
+    const UnpolarizedSpectrum M20 = -coeff * dr::real(f_tt*dr::conj(f_pt) + f_tp*dr::conj(f_pp));
+    const UnpolarizedSpectrum M21 = -coeff * dr::real(f_tt*dr::conj(f_pt) - f_tp*dr::conj(f_pp));
+    const UnpolarizedSpectrum M22 =  coeff * dr::real(f_tt*dr::conj(f_pp) + f_tp*dr::conj(f_pt));
+    const UnpolarizedSpectrum M23 =  coeff * dr::imag(f_tt*dr::conj(f_pp) - f_tp*dr::conj(f_pt));
+    const UnpolarizedSpectrum M30 =  coeff * dr::imag(f_tt*dr::conj(f_pt) + f_tp*dr::conj(f_pp));
+    const UnpolarizedSpectrum M31 =  coeff * dr::imag(f_tt*dr::conj(f_pt) - f_tp*dr::conj(f_pp));
+    const UnpolarizedSpectrum M32 = -coeff * dr::imag(f_tt*dr::conj(f_pp) + f_tp*dr::conj(f_pt));
+    const UnpolarizedSpectrum M33 =  coeff * dr::real(f_tt*dr::conj(f_pp) - f_tp*dr::conj(f_pt));
+    
+    return MuellerMatrix<UnpolarizedSpectrum>(
+        M00, M01, M02, M03,
+        M10, M11, M12, M13,
+        M20, M21, M22, M23,
+        M30, M31, M32, M33
+    );
+};
+
+/**
+ * @brief Mean square slope *squared* as described by Cox and Munk (1954).
+ * 
+ * @param wind_speed speed of wind at sea surface (mast height).
+ * @return tuple (Float, Float, Float) 
+ * Respectively the cross wind, along wind, and isotropic wind 
+ * mean square slope squared.
+ */
+template<typename Float>
+std::tuple<Float, Float, Float> mean_square_slope_cox_munk(const Float& wind_speed) {
+    Float sigma_cross_2 = 0.003f + 0.00192f * wind_speed;
+    Float sigma_along_2 = 0.00316f * wind_speed;
+    Float sigma_iso_2 = 0.003f + 0.00512f * wind_speed;
+
+    return { sigma_cross_2, sigma_along_2, sigma_iso_2 };
+}
+
+#endif // OCEAN_PROPS
+
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/bsdfs/CMakeLists.txt
+++ b/src/eradiate_plugins/bsdfs/CMakeLists.txt
@@ -7,5 +7,6 @@ add_plugin(rtls rtls.cpp)
 add_plugin(hapke hapke.cpp)
 add_plugin(selectbsdf selectbsdf.cpp)
 add_plugin(ocean_legacy ocean_legacy.cpp)
+add_plugin(ocean_mishchenko ocean_mishchenko.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/bsdfs/ocean_legacy.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_legacy.cpp
@@ -9,6 +9,7 @@
 #include <mitsuba/core/warp.h>
 #include <mitsuba/render/bsdf.h>
 #include <mitsuba/render/texture.h>
+#include <mitsuba/eradiate/oceanprops.h>
 #include <tuple>
 
 // Transmittance angular resolution
@@ -22,7 +23,7 @@ NAMESPACE_BEGIN(mitsuba)
 .. _plugin-bsdf-ocean_legacy:
 
 (Legacy 6S) Oceanic reflection model (:monosp:`ocean-legacy`)
----------------------------------------------------------------
+-------------------------------------------------------------
 
 .. pluginparameters::
 
@@ -110,320 +111,11 @@ parameters:
         </bsdf>
 */
 
-// Header content - THIS CAN BE MOVED IF NECESSARY
-#ifndef OCEAN_PROPS
-#define OCEAN_PROPS
-
-template <typename Float, typename Spectrum> class OceanProperties {
-public:
-    MI_IMPORT_TYPES()
-
-    using FloatX = DynamicBuffer<Float>;
-    using Value  = dr::Array<ScalarFloat, 1>;
-
-    /**
-     * @brief Construct a new Ocean Properties object and initializes the data.
-     *
-     * Initializes the data for the effective reflectance of whitecaps, the
-     * complex index of refraction of water, the water scattering and
-     * attenuation coefficients, and the molecular scattering coefficients. The
-     * data is taken from various sources in the literature.
-     */
-    OceanProperties() {
-        /*
-        * Effective reflectance of whitecaps (Whitlock et al. 1982)
-        * Wavelength specified in um.
-        * Wavelengths are stored in a regular grid, using range instead.
-        constexpr ScalarFloat wc_wavelengths[] = {  
-            0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1,
-            1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 
-            2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1,
-            3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0 };
-        */
-        constexpr ScalarFloat wc_data[] = {
-            0.220, 0.220, 0.220, 0.220, 0.220, 0.220, 0.215, 0.210,
-            0.200, 0.190, 0.175, 0.155, 0.130, 0.080, 0.100, 0.105,
-            0.100, 0.080, 0.045, 0.055, 0.065, 0.060, 0.055, 0.040,
-            0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000,
-            0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000
-        };
-
-        // Complex index of refraction of water (Hale & Querry 1973)
-        // !! Note that the wavelength is in nm to align with the rest of
-        // Mitsuba !!
-        constexpr ScalarFloat ior_wavelengths[] = {
-            200,  225,  250,  275,  300,  325,  345,  375,  400,  425,  445,
-            475,  500,  525,  550,  575,  600,  625,  650,  675,  700,  725,
-            750,  775,  800,  825,  850,  875,  900,  925,  950,  975,  1000,
-            1200, 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2650, 2700, 2750,
-            2800, 2850, 2900, 2950, 3000, 3050, 3100, 3150, 3200, 3250, 3300,
-            3350, 3400, 3450, 3500, 3600, 3700, 3800, 3900, 4000
-        };
-        constexpr ScalarFloat ior_real_data[] = {
-            1.369, 1.373, 1.362, 1.354, 1.349, 1.346, 1.343, 1.341,
-            1.339, 1.338, 1.337, 1.336, 1.335, 1.334, 1.333, 1.333,
-            1.332, 1.332, 1.331, 1.331, 1.331, 1.330, 1.330, 1.330,
-            1.329, 1.329, 1.329, 1.328, 1.328, 1.328, 1.327, 1.327,
-            1.327, 1.324, 1.321, 1.317, 1.312, 1.306, 1.296, 1.279,
-            1.242, 1.219, 1.188, 1.157, 1.142, 1.149, 1.201, 1.292,
-            1.371, 1.426, 1.467, 1.483, 1.478, 1.467, 1.450, 1.432,
-            1.420, 1.410, 1.400, 1.385, 1.374, 1.364, 1.357, 1.351
-        };
-        constexpr ScalarFloat ior_cplx_data[] = {
-            1.10e-07, 4.90e-08, 3.35e-08, 2.35e-08, 1.60e-08, 1.08e-08,
-            6.50e-09, 3.50e-09, 1.86e-09, 1.30e-09, 1.02e-09, 9.35e-10,
-            1.00e-09, 1.32e-09, 1.96e-09, 3.60e-09, 1.09e-08, 1.39e-08,
-            1.64e-08, 2.23e-08, 3.35e-08, 9.15e-08, 1.56e-07, 1.48e-07,
-            1.25e-07, 1.82e-07, 2.93e-07, 3.91e-07, 4.86e-07, 1.06e-06,
-            2.93e-06, 3.48e-06, 2.89e-06, 9.89e-06, 1.38e-04, 8.55e-05,
-            1.15e-04, 1.10e-03, 2.89e-04, 9.56e-04, 3.17e-03, 6.70e-03,
-            1.90e-02, 5.90e-02, 1.15e-01, 1.85e-01, 2.68e-01, 2.98e-01,
-            2.72e-01, 2.40e-01, 1.92e-01, 1.35e-01, 9.24e-02, 6.10e-02,
-            3.68e-02, 2.61e-02, 1.95e-02, 1.32e-02, 9.40e-03, 5.15e-03,
-            3.60e-03, 3.40e-03, 3.80e-03, 4.60e-03
-        };
-
-        /*
-        * Water scattering and attenuation coefficient data (Morel 1988)
-        * Wavelength specified in nm.
-        * Wavelengths are stored in a regular grid, using range instead.
-        constexpr ScalarFloat attn_wavelengths[] = { 
-            400, 405, 410, 415, 420, 425, 430, 435, 440, 445, 
-            450, 455, 460, 465, 470, 475, 480, 485, 490, 495, 
-            500, 505, 510, 515, 520, 525, 530, 535, 540, 545, 
-            550, 555, 560, 565, 570, 575, 580, 585, 590, 595, 
-            600, 605, 610, 615, 620, 625, 630, 635, 640, 645, 
-            650, 655, 660, 665, 670, 675, 680, 685, 690, 695, 
-            700 
-        };
-        */
-        constexpr ScalarFloat attn_k[] = {
-            0.0209, 0.0200, 0.0196, 0.0189, 0.0183, 0.0182, 0.0171, 0.0170,
-            0.0168, 0.0166, 0.0168, 0.0170, 0.0173, 0.0174, 0.0175, 0.0184,
-            0.0194, 0.0203, 0.0217, 0.0240, 0.0271, 0.0320, 0.0384, 0.0445,
-            0.0490, 0.0505, 0.0518, 0.0543, 0.0568, 0.0615, 0.0640, 0.0640,
-            0.0717, 0.0762, 0.0807, 0.0940, 0.1070, 0.1280, 0.1570, 0.2000,
-            0.2530, 0.2790, 0.2960, 0.3030, 0.3100, 0.3150, 0.3200, 0.3250,
-            0.3300, 0.3400, 0.3500, 0.3700, 0.4050, 0.4180, 0.4300, 0.4400,
-            0.4500, 0.4700, 0.5000, 0.5500, 0.6500
-        };
-        constexpr ScalarFloat attn_chi[] = {
-            0.1100, 0.1110, 0.1125, 0.1135, 0.1126, 0.1104, 0.1078, 0.1065,
-            0.1041, 0.0996, 0.0971, 0.0939, 0.0896, 0.0859, 0.0823, 0.0788,
-            0.0746, 0.0726, 0.0690, 0.0660, 0.0636, 0.0600, 0.0578, 0.0540,
-            0.0498, 0.0475, 0.0467, 0.0450, 0.0440, 0.0426, 0.0410, 0.0400,
-            0.0390, 0.0375, 0.0360, 0.0340, 0.0330, 0.0328, 0.0325, 0.0330,
-            0.0340, 0.0350, 0.0360, 0.0375, 0.0385, 0.0400, 0.0420, 0.0430,
-            0.0440, 0.0445, 0.0450, 0.0460, 0.0475, 0.0490, 0.0515, 0.0520,
-            0.0505, 0.0440, 0.0390, 0.0340, 0.0300
-        };
-        constexpr ScalarFloat attn_e[] = {
-            0.668, 0.672, 0.680, 0.687, 0.693, 0.701, 0.707, 0.708, 0.707,
-            0.704, 0.701, 0.699, 0.700, 0.703, 0.703, 0.703, 0.703, 0.704,
-            0.702, 0.700, 0.700, 0.695, 0.690, 0.685, 0.680, 0.675, 0.670,
-            0.665, 0.660, 0.655, 0.650, 0.645, 0.640, 0.630, 0.623, 0.615,
-            0.610, 0.614, 0.618, 0.622, 0.626, 0.630, 0.634, 0.638, 0.642,
-            0.647, 0.653, 0.658, 0.663, 0.667, 0.672, 0.677, 0.682, 0.687,
-            0.695, 0.697, 0.693, 0.665, 0.640, 0.620, 0.600
-        };
-        // IMPORTANT: This table uses the values provided by Morel, which are
-        // different than the ones from 6SV
-        constexpr ScalarFloat molecular_scatter_coeffs[] = {
-            0.00618095, 0.00578095, 0.00547619, 0.00517619, 0.00492222,
-            0.0046746,  0.00447143, 0.00426825, 0.00406508, 0.0038619,
-            0.00365873, 0.00346667, 0.00331429, 0.0031619,  0.00300952,
-            0.00287143, 0.00276984, 0.00265238, 0.0025,     0.00236508,
-            0.00226349, 0.0021619,  0.00206032, 0.00195873, 0.00185714,
-            0.00177778, 0.00172698, 0.00167619, 0.0016254,  0.0015746,
-            0.00152381, 0.00144603, 0.00134444, 0.0013,     0.0013,
-            0.00126984, 0.00121905, 0.00116825, 0.00111746, 0.00107,
-            0.00102429, 0.00098556, 0.00095,    0.0009181,  0.00088762,
-            0.00085714, 0.00082667, 0.00079619, 0.00076571, 0.00073937,
-            0.00071397, 0.00069286, 0.00067254, 0.00065222, 0.0006319,
-            0.00061159, 0.00059127, 0.00057095, 0.00055063, 0.00053524,
-            0.00052
-        };
-
-        constexpr ScalarFloat molecular_scatter_coeffs_6s[] = {
-            0.0076, 0.0072, 0.0068, 0.0064, 0.0061, 0.0058, 0.0055, 0.0052,
-            0.0049, 0.0047, 0.0045, 0.0043, 0.0041, 0.0039, 0.0037, 0.0036,
-            0.0034, 0.0033, 0.0031, 0.0030, 0.0029, 0.0027, 0.0026, 0.0025,
-            0.0024, 0.0023, 0.0022, 0.0022, 0.0021, 0.0020, 0.0019, 0.0018,
-            0.0018, 0.0017, 0.0017, 0.0016, 0.0016, 0.0015, 0.0015, 0.0014,
-            0.0014, 0.0013, 0.0013, 0.0012, 0.0012, 0.0011, 0.0011, 0.0010,
-            0.0010, 0.0010, 0.0010, 0.0009, 0.0008, 0.0008, 0.0008, 0.0007,
-            0.0007, 0.0007, 0.0007, 0.0007, 0.0007
-        };
-
-        // Construct distributions from the provided data sets
-        // !! Note that unlike the wavelength is in nm to align with the rest of
-        // Mitsuba !!
-        m_effective_reflectance = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(200.f, 4000.f), wc_data, std::size(wc_data));
-
-        m_ior_real = IrregularContinuousDistribution<ScalarFloat>(
-            ior_wavelengths, ior_real_data, std::size(ior_real_data));
-
-        m_ior_imag = IrregularContinuousDistribution<ScalarFloat>(
-            ior_wavelengths, ior_cplx_data, std::size(ior_cplx_data));
-
-        m_attn_k = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(400.f, 700.f), attn_k, std::size(attn_k));
-
-        m_attn_chi = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(400.f, 700.f), attn_chi, std::size(attn_chi));
-
-        m_attn_e = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(400.f, 700.f), attn_e, std::size(attn_e));
-
-        m_molecular_scatter_coeffs = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(400.f, 700.f), molecular_scatter_coeffs,
-            std::size(molecular_scatter_coeffs));
-
-        m_molecular_scatter_coeffs_6s = ContinuousDistribution<ScalarFloat>(
-            ScalarVector2f(400.f, 700.f), molecular_scatter_coeffs_6s,
-            std::size(molecular_scatter_coeffs_6s));
-    }
-
-    /**
-     * @brief Evaluate the effective reflectance of whitecaps.
-     *
-     * Evaluates the effective reflectance of whitecaps at the given
-     * wavelength. The value returned already takes into account
-     * the base offset of 0.4 as described by (Koepke 1984).
-     *
-     * @param wavelength The wavelength at which to evaluate the reflectance.
-     * @return ScalarFloat The effective reflectance of whitecaps.
-     */
-    ScalarFloat effective_reflectance(const ScalarFloat &wavelength) const {
-        return m_effective_reflectance.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the real index of refraction of water.
-     *
-     * Evaluates the real index of refraction of water at the given
-     * wavelength. The value returned is the real part of the complex
-     * index of refraction as described by (Hale & Querry 1973).
-     *
-     * @param wavelength The wavelength at which to evaluate the index of
-     * refraction.
-     * @return ScalarFloat The real part of the index of refraction.
-     */
-    ScalarFloat ior_real(const ScalarFloat &wavelength) const {
-        return m_ior_real.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the complex index of refraction of water.
-     *
-     * Evaluates the complex index of refraction of water at the given
-     * wavelength. The value returned is the imaginary part of the complex
-     * index of refraction as described by (Hale & Querry 1973).
-     *
-     * @param wavelength The wavelength at which to evaluate the index of
-     * refraction.
-     * @return ScalarFloat The imaginary part of the index of refraction.
-     */
-    ScalarFloat ior_cplx(const ScalarFloat &wavelength) const {
-        return m_ior_imag.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the K-term of the attenuation coefficient of water.
-     *
-     * Evaluates the K-term of the attenuation coefficient of water at the given
-     * wavelength. The value returned is the K-term as described by (Morel
-     * 1988).
-     *
-     * @param wavelength The wavelength at which to evaluate the K-term of the
-     * attenuation coefficient.
-     * @return ScalarFloat The K-term of the attenuation coefficient.
-     */
-    ScalarFloat attn_k(const ScalarFloat &wavelength) const {
-        return m_attn_k.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the Chi-term of the attenuation coefficient of water.
-     *
-     * Evaluates the Chi-term of the attenuation coefficient of water at the
-     * given wavelength. The value returned is the Chi-term as described by
-     * (Morel 1988).
-     *
-     * @param wavelength The wavelength at which to evaluate the Chi-term of the
-     * attenuation coefficient.
-     * @return ScalarFloat The Chi-term of the attenuation coefficient.
-     */
-    ScalarFloat attn_chi(const ScalarFloat &wavelength) const {
-        return m_attn_chi.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the E-term of the attenuation coefficient of water.
-     *
-     * Evaluates the E-term of the attenuation coefficient of water at the given
-     * wavelength. The value returned is the E-term as described by (Morel
-     * 1988).
-     *
-     * @param wavelength The wavelength at which to evaluate the E-term of the
-     * attenuation coefficient.
-     * @return ScalarFloat The E-term of the attenuation coefficient.
-     */
-    ScalarFloat attn_e(const ScalarFloat &wavelength) const {
-        return m_attn_e.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the molecular scattering coefficient of water.
-     *
-     * Evaluates the molecular scattering coefficient of water at the given
-     * wavelength. The value returned is the molecular scattering coefficient
-     * as described by (Morel 1988).
-     *
-     * @param wavelength The wavelength at which to evaluate the molecular
-     * scattering coefficient.
-     * @return ScalarFloat The molecular scattering coefficient.
-     */
-    ScalarFloat molecular_scatter_coeff(const ScalarFloat &wavelength) const {
-        return m_molecular_scatter_coeffs.eval_pdf(wavelength);
-    }
-
-    /**
-     * @brief Evaluate the molecular scattering coefficient of water.
-     *
-     * Evaluates the molecular scattering coefficient of water at the given
-     * wavelength. The value returned is the molecular scattering coefficient
-     * as described by the 6S radiative transfer model.
-     *
-     * @param wavelength The wavelength at which to evaluate the molecular
-     * scattering coefficient.
-     * @return ScalarFloat The molecular scattering coefficient.
-     */
-    ScalarFloat
-    molecular_scatter_coeff_6s(const ScalarFloat &wavelength) const {
-        return m_molecular_scatter_coeffs_6s.eval_pdf(wavelength);
-    }
-
-private:
-    // Effective reflectance of whitecaps
-    ContinuousDistribution<ScalarFloat> m_effective_reflectance;
-
-    // Real/Complex IOR of water (Hale & Querry 1973)
-    IrregularContinuousDistribution<ScalarFloat> m_ior_real;
-    IrregularContinuousDistribution<ScalarFloat> m_ior_imag;
-
-    // Water scattering and attenuation coefficients (Morel 1988)
-    ContinuousDistribution<ScalarFloat> m_attn_k;
-    ContinuousDistribution<ScalarFloat> m_attn_chi;
-    ContinuousDistribution<ScalarFloat> m_attn_e;
-    ContinuousDistribution<ScalarFloat> m_molecular_scatter_coeffs;
-    ContinuousDistribution<ScalarFloat> m_molecular_scatter_coeffs_6s;
-};
-
 template <typename Float, typename Spectrum> class OceanUtilities {
 public:
     MI_IMPORT_TYPES()
+
+    using Complex2u = dr::Complex<UnpolarizedSpectrum>;
 
     /**
      * @brief Construct a new Ocean Utilities object.
@@ -441,8 +133,10 @@ public:
     void update(const ScalarFloat &wavelength, const ScalarFloat &wind_speed,
                 const ScalarFloat &pigmentation) {
         // Update Cox-Munk variables
-        m_sigma_c = dr::sqrt(0.003f + 0.00192f * wind_speed);
-        m_sigma_u = dr::sqrt(0.00316f * wind_speed);
+        std::tie(m_sigma_c, m_sigma_u, std::ignore) = mean_square_slope_cox_munk(wind_speed);
+        m_sigma_c = dr::sqrt(m_sigma_c);
+        m_sigma_u = dr::sqrt(m_sigma_u);
+
         m_c_21    = 0.01f - 0.0086f * wind_speed;
         m_c_03    = 0.04f - 0.033f * wind_speed;
 
@@ -459,10 +153,8 @@ public:
     std::pair<ScalarFloat, ScalarFloat>
     eval_index_refraction(const ScalarFloat &wavelength,
                           const ScalarFloat &chlorinity) const {
-        ScalarFloat n_real =
-            m_ocean_props.ior_real(wavelength) + friedman_sverdrup(chlorinity);
-        ScalarFloat n_imag = m_ocean_props.ior_cplx(wavelength);
-
+        auto [n_real, n_imag] = 
+            water_ior<Float, Spectrum, ScalarFloat>(m_ocean_props,wavelength,chlorinity);
         return { n_real, n_imag };
     }
 
@@ -525,7 +217,7 @@ public:
      * light.
      * @return Float The sun glint reflectance.
      */
-    Float eval_glint(const ScalarFloat &n_real, const ScalarFloat &n_imag,
+    Spectrum eval_glint(const ScalarFloat &n_real, const ScalarFloat &n_imag,
                      const Vector3f &wi, const Vector3f &wo,
                      const ScalarFloat &wind_direction) const {
         // Transform directions into azimuthal and zenithal angles
@@ -543,12 +235,29 @@ public:
         Float phi_w             = phi_i - wind_direction;
         auto [s_phi_w, c_phi_w] = dr::sincos(phi_w);
 
-        return eval_sun_glint(n_real, n_imag, s_theta_i, c_theta_i, s_theta_o,
-                              c_theta_o, s_phi, c_phi, s_phi_w, c_phi_w);
+        Spectrum value = dr::zeros<Spectrum>();
+
+        if constexpr (is_polarized_v<Spectrum>){
+            value = eval_sun_glint_polarized( n_real, n_imag, 
+                                              wi, wo,
+                                              s_theta_i, c_theta_i, 
+                                              s_theta_o, c_theta_o, 
+                                              s_phi, c_phi, 
+                                              s_phi_w, c_phi_w);
+
+        } else {
+            value = eval_sun_glint( n_real, n_imag, 
+                                    s_theta_i, c_theta_i, 
+                                    s_theta_o, c_theta_o, 
+                                    s_phi, c_phi, 
+                                    s_phi_w, c_phi_w );
+        }
+
+        return value;
     }
 
     /**
-     * @brief Evaluate the sun glint reflectance.
+     * @brief Evaluate the sun glint reflectance as implemented in 6SV.
      *
      * Evaluates the sun glint reflectance at the given index of refraction, 
      * incident and outgoing angles, relative azimuthal angle for 
@@ -570,11 +279,11 @@ public:
      * @param invert_real Whether to invert the real part of the IOR.
      * @return Float The sun glint reflectance.
      */
-    Float eval_sun_glint(ScalarFloat n_real, ScalarFloat n_imag,
-                         const Float &s_i, Float c_i, const Float &s_o,
-                         Float c_o, const Float &s_phi, const Float &c_phi,
-                         const Float &s_phi_w, const Float &c_phi_w,
-                         const bool invert_real = false) const {
+    Float eval_sun_glint( ScalarFloat n_real, ScalarFloat n_imag,
+                          const Float &s_i, Float c_i, const Float &s_o,
+                          Float c_o, const Float &s_phi, const Float &c_phi,
+                          const Float &s_phi_w, const Float &c_phi_w,
+                          const bool invert_real = false)  const {
 
         dr::masked(c_i, c_i < 1e-6f) = 1e-6f;
         dr::masked(c_o, c_o < 1e-6f) = 1e-6f;
@@ -589,33 +298,98 @@ public:
 
         // Cox-Munk specular probability
         Float specular_prob = eval_cox_munk(s_phi_w, c_phi_w, z_x, z_y);
-        auto mask           = Mask(specular_prob < 0.0f);
-        specular_prob       = dr::select(mask, 0.0f, specular_prob);
+        auto mask           = Mask(specular_prob < 0.f);
+        specular_prob       = dr::select(mask, 0.f, specular_prob);
 
         Float cos_2_chi = c_o * c_i + s_o * s_i * c_phi;
 
-        cos_2_chi = dr::select(cos_2_chi > 1.0f, 0.999999999f, cos_2_chi);
-        cos_2_chi = dr::select(cos_2_chi < -1.0f, -0.999999999f, cos_2_chi);
+        cos_2_chi = dr::select(cos_2_chi > 1.f, 0.999999999f, cos_2_chi);
+        cos_2_chi = dr::select(cos_2_chi < -1.f, -0.999999999f, cos_2_chi);
 
-        Float coschi = dr::sqrt(0.5f * (1.0f + cos_2_chi));
-        Float sinchi = dr::sqrt(0.5f * (1.0f - cos_2_chi));
+        Float coschi = dr::sqrt(0.5f * (1.f + cos_2_chi));
+        Float sinchi = dr::sqrt(0.5f * (1.f - cos_2_chi));
 
-        coschi = dr::select(coschi > 1.0f, 0.999999999f, coschi);
-        coschi = dr::select(coschi < -1.0f, -0.999999999f, coschi);
-        sinchi = dr::select(sinchi > 1.0f, 0.999999999f, sinchi);
-        sinchi = dr::select(sinchi < -1.0f, -0.999999999f, sinchi);
+        coschi = dr::select(coschi > 1.f, 0.999999999f, coschi);
+        coschi = dr::select(coschi < -1.f, -0.999999999f, coschi);
+        sinchi = dr::select(sinchi > 1.f, 0.999999999f, sinchi);
+        sinchi = dr::select(sinchi < -1.f, -0.999999999f, sinchi);
 
         // Invert the real part of the IOR
         if (invert_real) {
             n_real = 1 / n_real;
-            n_imag = 0.0f;
+            n_imag = 0.f;
         }
 
-        Float fresnel_coeff = eval_fresnel(n_real, n_imag, coschi, sinchi);
-        // Sun glint reflectance
+        Float fresnel_coeff = fresnel_sunglint_legacy<Float>(n_real, n_imag, coschi, sinchi);
         Float num   = dr::Pi<Float> * fresnel_coeff * specular_prob;
-        Float denom = 4.0f * c_i * c_o * dr::pow(dr::cos(tilt), 4.0f);
-        return num / denom;
+        Float denom = 4.f * c_i * c_o * dr::pow(dr::cos(tilt), 4.f);
+
+        // Float fresnel_coeff = eval_fresnel(n_real, n_imag, coschi, sinchi);
+        // Sun glint reflectance
+        return num/denom;
+    }
+
+    /**
+     * @brief Evaluate the polarized sun glint reflectance.
+     *
+     * Evaluates the polarized sun glint reflectance at the given index of 
+     * refraction, incident and outgoing angles, relative azimuthal angle for 
+     * ingoing and outgoing directions, and relative azimuthal angle for 
+     * wind direction. The reflectance is computed using the Cox-Munk
+     * distribution, the polarized Fresnel equations as implemented by Mishchenko,
+     * and relative tilt of the oceanic surface.
+     *
+     * @param n_real The real part of the index of refraction of water.
+     * @param n_imag The imaginary part of the index of refraction of water.
+     * @param wi The incident light direction.
+     * @param wo The outgoing light direction.
+     * @param s_i The sine of the incident zenith angle.
+     * @param c_i The cosine of the incident zenith angle.
+     * @param s_o The sine of the outgoing zenith angle.
+     * @param c_o The cosine of the outgoing zenith angle.
+     * @param s_phi The sine of the incident azimuthal angle.
+     * @param c_phi The cosine of the incident azimuthal angle.
+     * @param s_phi_w The sine of the relative azimuthal angle of the wind.
+     * @param c_phi_w The cosine of the relative azimuthal angle of the wind.
+     * @return Float The sun glint reflectance.
+     */
+    Spectrum eval_sun_glint_polarized( ScalarFloat n_real, ScalarFloat n_imag, 
+                                       Vector3f wi, Vector3f wo,
+                                       const Float &s_i, Float c_i, 
+                                       const Float &s_o, Float c_o, 
+                                       const Float &s_phi, const Float &c_phi,
+                                       const Float &s_phi_w, const Float &c_phi_w) const {
+        
+        Spectrum value = dr::zeros<Spectrum>();
+
+        if constexpr (is_polarized_v<Spectrum>){
+            
+            dr::masked(c_i, c_i < 1e-6f) = 1e-6f;
+            dr::masked(c_o, c_o < 1e-6f) = 1e-6f;
+
+            // Implementation analog to 6SV
+            Float z_x = (-s_o * s_phi) / (c_i + c_o);
+            Float z_y = (s_i + s_o * c_phi) / (c_i + c_o);
+
+            // Tilt angle (rad)
+            const Float tan_tilt = dr::sqrt(z_x * z_x + z_y * z_y);
+            const Float tilt     = dr::atan(tan_tilt);
+
+            // Cox-Munk specular probability
+            Float specular_prob = eval_cox_munk(s_phi_w, c_phi_w, z_x, z_y);
+            auto mask           = Mask(specular_prob < 0.f);
+            specular_prob       = dr::select(mask, 0.f, specular_prob);
+
+            Complex2u n_ext(1.f,0.f);
+            Complex2u n_water(n_real,n_imag);
+            Spectrum fresnel_coeff = fresnel_sunglint_polarized(n_ext, n_water, wi, wo);
+
+            Spectrum num   = dr::Pi<Float> * fresnel_coeff * specular_prob;
+            Float denom = 4.f * c_i * c_o * dr::pow(dr::cos(tilt), 4.f);
+            value = num/denom;
+        }
+
+        return value;
     }
 
     /**
@@ -646,11 +420,11 @@ public:
         auto outside_range = Mask(wavelength < 400.f || wavelength > 700.f);
 
         // Compute the underlight term
-        Float underlight = (1.0f / (dr::sqr(n_real) + dr::sqr(n_imag))) *
+        Float underlight = (1.f / (dr::sqr(n_real) + dr::sqr(n_imag))) *
                            (m_r_omega * t_u * t_d) /
-                           (1.0f - m_underlight_alpha * m_r_omega);
+                           (1.f - m_underlight_alpha * m_r_omega);
 
-        return dr::select(outside_range, 0.0f, underlight);
+        return dr::select(outside_range, 0.f, underlight);
     }
 
 private:
@@ -677,70 +451,17 @@ private:
         const Float xe2 = xe * xe;
         const Float xn2 = xn * xn;
 
-        Float coef = 1.0f - (m_c_21 / 2.0f) * (xe2 - 1.0f) * xn -
-                     (m_c_03 / 6.0f) * (xn2 - 3.0f) * xn;
-        coef = coef + (m_c_40 / 24.0f) * (xe2 * xe2 - 6.0f * xe2 + 3.0f);
-        coef = coef + (m_c_04 / 24.0f) * (xn2 * xn2 - 6.0f * xn2 + 3.0f);
-        coef = coef + (m_c_22 / 4.0f) * (xe2 - 1.0f) * (xn2 - 1.0f);
+        Float coef = 1.f - (m_c_21 / 2.f) * (xe2 - 1.f) * xn -
+                     (m_c_03 / 6.f) * (xn2 - 3.f) * xn;
+        coef = coef + (m_c_40 / 24.f) * (xe2 * xe2 - 6.f * xe2 + 3.f);
+        coef = coef + (m_c_04 / 24.f) * (xn2 * xn2 - 6.f * xn2 + 3.f);
+        coef = coef + (m_c_22 / 4.f) * (xe2 - 1.f) * (xn2 - 1.f);
 
         Float prob = coef * dr::InvTwoPi<Float> / (m_sigma_u * m_sigma_c) *
                      dr::exp(-(xe2 + xn2) * 0.5f);
         return prob;
     }
 
-    /**
-     * @brief Evaluate the Fresnel coefficient.
-     *
-     * Evaluates the Fresnel coefficient at the given real and imaginary parts
-     * of the index of refraction, and relevant geometry terms derived from the
-     * incoming and outgoing directions. The coefficient is computed using the
-     * Fresnel equations.
-     *
-     * @param n_real The real part of the index of refraction.
-     * @param n_imag The imaginary part of the index of refraction.
-     * @param coschi The cosine of the geometry term.
-     * @param sinchi The sine of the geometry term.
-     * @return Float The Fresnel coefficient.
-     */
-    Float eval_fresnel(const ScalarFloat &n_real, const ScalarFloat &n_imag,
-                       const Float &coschi, const Float &sinchi) const {
-
-        const ScalarFloat n_real2 = n_real * n_real;
-        const ScalarFloat n_imag2 = n_imag * n_imag;
-
-        const Float s = (n_real2) - (n_imag2) - (sinchi * sinchi);
-
-        const Float a_1 = dr::abs(s);
-        const Float a_2 = dr::sqrt(dr::sqr(s) + 4.0f * n_real2 * n_imag2);
-
-        const Float u = dr::sqrt(0.5f * dr::abs(a_1 + a_2));
-        const Float v = dr::sqrt(0.5f * dr::abs(a_2 - a_1));
-
-        const Float b_1 = (n_real2 - n_imag2) * coschi;
-        const Float b_2 = 2 * n_real * n_imag * coschi;
-
-        const Float right_squared =
-            (dr::sqr(coschi - u) + v * v) / (dr::sqr(coschi + u) + v * v);
-        const Float left_squared = (dr::sqr(b_1 - u) + dr::sqr(b_2 + v)) /
-                                   (dr::sqr(b_1 + u) + dr::sqr(b_2 - v));
-        const Float R = (right_squared + left_squared) * 0.5f;
-
-        return R;
-    }
-
-    /**
-     * @brief Compute the correction to the IOR of water.
-     *
-     * Computes the correction to the index of refraction of water according to
-     * the formulas provided by Friedman (1969) and Sverdrup (1942). The
-     * correction is computed as a function of the chlorinity of the water.
-     *
-     * @param chlorinity The chlorinity of the water.
-     * @return ScalarFloat The correction to the index of refraction.
-     */
-    ScalarFloat friedman_sverdrup(const ScalarFloat &chlorinity) const {
-        return 0.00017492711f * (0.03f + 1.805f * chlorinity);
-    }
 
     /**
      * @brief Compute the ratio of upwelling to downwelling irradiance.
@@ -757,7 +478,7 @@ private:
      */
     ScalarFloat r_omega(const ScalarFloat &wavelength,
                         const ScalarFloat &pigmentation) const {
-        ScalarFloat pigment_log = dr::log(pigmentation) / dr::log(10.0f);
+        ScalarFloat pigment_log = dr::log(pigmentation) / dr::log(10.f);
 
         // Backscattering coefficient
         ScalarFloat molecular_scatter_coeff =
@@ -765,7 +486,7 @@ private:
         ScalarFloat scattering_coeff = 0.30f * dr::pow(pigmentation, 0.62);
         ScalarFloat backscatter_ratio =
             0.002f +
-            0.02f * (0.5f - 0.25f * pigment_log) * (550.0 / wavelength);
+            0.02f * (0.5f - 0.25f * pigment_log) * (550.f / wavelength);
         ScalarFloat backscatter_coeff = 0.5f * molecular_scatter_coeff +
                                         scattering_coeff * backscatter_ratio;
 
@@ -776,8 +497,8 @@ private:
         ScalarFloat attn_coeff = k + chi * dr::pow(pigmentation, e);
 
         // If any of the coefficients is zero, we return zero
-        if (backscatter_coeff == 0.0f || attn_coeff == 0.0f)
-            return 0.0f;
+        if (backscatter_coeff == 0.f || attn_coeff == 0.f)
+            return 0.f;
 
         // Iterative computation of the reflectance
         ScalarFloat u       = 0.75f;
@@ -786,7 +507,7 @@ private:
         bool converged = false;
         while (!converged) {
             // Update u
-            u = (0.9f * (1.0f - r_omega)) / (1.0f + 2.25f * r_omega);
+            u = (0.9f * (1.f - r_omega)) / (1.f + 2.25f * r_omega);
 
             // Update reflectance
             ScalarFloat r_omega_new =
@@ -829,8 +550,6 @@ private:
     const ScalarFloat m_underlight_alpha = 0.485f;
 };
 
-#endif // OCEAN_PROPS
-
 /**
  * @brief Evaluate the transmittance of the radiance over all
  * provided angles. For each angle, computes the quadrature of 
@@ -869,7 +588,7 @@ Float eval_ocean_transmittance(const OceanUtilitiesP &utils, Float theta,
 
     // nodes_x   -> [0,π/2], nodes_y   -> [0,2π],
     // weights_x -> [0,π/4], weights_y -> [0, π].
-    nodes_x = dr::fmadd(nodes_x, 0.25 * dr::Pi<FloatX>, 0.25 * dr::Pi<FloatX>);
+    nodes_x = dr::fmadd(nodes_x, 0.25f * dr::Pi<FloatX>, 0.25f * dr::Pi<FloatX>);
     nodes_y = dr::fmadd(nodes_y, dr::Pi<FloatX>, dr::Pi<FloatX>);
     weights_x                     = 0.25f * dr::Pi<FloatX> * weights_x;
     weights_y                     = dr::Pi<FloatX> * weights_y;
@@ -916,7 +635,7 @@ Float eval_ocean_transmittance(const OceanUtilitiesP &utils, Float theta,
         }
 
         dr::masked(td, td >= summ) = summ;
-        result_p = 1.0f - (td / summ);
+        result_p = 1.f - (td / summ);
 
         dr::store(result.data() + i * FloatP::Size, result_p);
     }
@@ -950,7 +669,7 @@ public:
         // convert from North Left to East Right.
         m_wind_direction = -m_wind_direction + 90.f;
         // m_wind_direction % 360.
-        m_wind_direction = m_wind_direction - ( 360.f*floor(m_wind_direction/360.f) );
+        m_wind_direction = m_wind_direction - (360.f * floor(m_wind_direction / 360.f));
         // Degree to radians.
         m_wind_direction = m_wind_direction * dr::Pi<ScalarFloat> / 360.f;
 
@@ -1000,7 +719,7 @@ public:
     void update() {
 
         // compute the index of refraction
-        std::tie(m_n_real, m_n_imag) =
+        std::tie(m_n_real, m_n_imag) = 
             m_ocean_utils.eval_index_refraction(m_wavelength, m_chlorinity);
 
         {
@@ -1069,7 +788,7 @@ public:
      * @param wo The outgoing direction of the light.
      * @return Float The sun glint reflectance.
      */
-    Float eval_glint(const Vector3f &wi, const Vector3f &wo) const {
+    Spectrum eval_glint(const Vector3f &wi, const Vector3f &wo) const {
         return m_ocean_utils.eval_glint(m_n_real, m_n_imag, wi, wo,
                                         m_wind_direction);
     }
@@ -1107,84 +826,21 @@ public:
                                              t_d, t_u);
     }
 
-    /**
-     * @brief Evaluate the oceanic reflectance.
-     *
-     * Evaluates the oceanic reflectance at the provided wavelength, incident
-     * and outgoing directions, wind direction, wind speed, chlorinity, and
-     * pigmentation. The reflectance is computed by combining the whitecap, sun
-     * glint, and underwater light reflectance, according to the coverage of
-     * whitecaps (based on 6S).
-     *
-     * @param ctx The context of evaluation.
-     * @param wi The incident direction of the light.
-     * @param wo The outgoing direction of the light.
-     * @return Float The oceanic reflectance
-     */
-    Float eval_ocean(const BSDFContext &ctx, const Vector3f &wi,
-                     const Vector3f &wo) const {
-        // 6S considers the incident direction to come from the light source
-        // `TransportMode` has two states:
-        //     - `Radiance`, meaning we trace from the sensor to the light
-        //     sources
-        //     - `Importance`, meaning we trace from the light sources to the
-        //     sensor
-        //
-        Vector3f wi_hat = ctx.mode == TransportMode::Radiance ? wo : wi,
-                 wo_hat = ctx.mode == TransportMode::Radiance ? wi : wo;
-
-        Float coverage = m_ocean_utils.eval_whitecap_coverage(m_wind_speed);
-        Float whitecap_reflectance   = eval_whitecaps();
-        Float glint_reflectance      = eval_glint(wi_hat, wo_hat);
-        Float underlight_reflectance = eval_underlight(wi_hat, wo_hat);
-
-        return (coverage * whitecap_reflectance) +
-               (1.f - coverage) * glint_reflectance +
-               (1.f - (coverage * whitecap_reflectance)) * underlight_reflectance;
-    }
-
-    /**
-     * @brief Evaluate the Blinn-Phong BRDF.
-     *
-     * Evaluates the Blinn-Phong BRDF at the provided incident and outgoing
-     * directions, and surface normal. The BRDF is computed using the
-     * Blinn-Phong distribution.
-     *
-     * @param wi The incident direction of the light.
-     * @param wo The outgoing direction of the light.
-     * @param normal The surface normal.
-     * @return Float The Blinn-Phong BRDF.
-     * @note This function is not used, but serves as a reference for future
-     * implementations.
-     */
-    Float eval_blinn_phong(const Vector3f &wi, const Vector3f &wo,
-                           const Normal3f &normal) const {
-        Float coverage = m_ocean_utils.eval_whitecap_coverage(m_wind_speed);
-        Float factor   = (m_shininess + 2.f) / (2.f * dr::Pi<Float>);
-        Vector3f half  = dr::normalize(wi + wo);
-        Float dot      = dr::dot(half, normal);
-
-        // Blinn-phong => clamp dot to above zero
-        dot = dr::clamp(dot, 0.f, 1.f);
-
-        Float phong = dr::pow(dot, m_shininess);
-
-        return coverage + (1 - coverage) * factor * phong;
-    }
-
     std::pair<BSDFSample3f, Spectrum>
     sample(const BSDFContext &ctx, const SurfaceInteraction3f &si,
            Float sample1, const Point2f &sample2, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFSample, active);
 
-        bool has_diffuse  = ctx.is_enabled(BSDFFlags::DiffuseReflection, 0);
-        bool has_specular = ctx.is_enabled(BSDFFlags::GlossyReflection, 1);
+        bool has_diffuse  = ctx.is_enabled(BSDFFlags::DiffuseReflection, 0),
+             has_specular = ctx.is_enabled(BSDFFlags::GlossyReflection, 1);
 
         Float cos_theta_i = Frame3f::cos_theta(si.wi);
-        BSDFSample3f bs   = dr::zeros<BSDFSample3f>();
         active &= cos_theta_i > 0.f;
-        if (unlikely(dr::none_or<false>(active)) ||
-            (!has_diffuse && !has_specular))
+
+        BSDFSample3f bs   = dr::zeros<BSDFSample3f>();
+        Spectrum result(0.f);
+
+        if (unlikely(dr::none_or<false>(active)) || (!has_diffuse && !has_specular))
             return { bs, 0.f };
 
         Float coverage  = m_ocean_utils.eval_whitecap_coverage(m_wind_speed);
@@ -1227,21 +883,18 @@ public:
         bs.pdf = pdf(ctx, si, bs.wo, active);
         bs.eta = 1.f;
 
-        UnpolarizedSpectrum value =
-            eval_ocean(ctx, si.wi, bs.wo) * Frame3f::cos_theta(bs.wo) / bs.pdf;
-        return { bs,
-                 (depolarizer<Spectrum>(value)) & (active && bs.pdf > 0.f) };
+        active &= bs.pdf > 0.f;
+        result = eval(ctx, si, bs.wo, active);
+
+        return { bs, result/bs.pdf & (active && bs.pdf > 0.f) };
     }
 
     Spectrum eval(const BSDFContext &ctx, const SurfaceInteraction3f &si,
                   const Vector3f &wo, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
 
-        bool has_diffuse = ctx.is_enabled(BSDFFlags::DiffuseReflection, 0);
-        bool has_glint   = ctx.is_enabled(BSDFFlags::GlossyReflection, 1);
-
-        if (unlikely(dr::none_or<false>(active) || !has_glint && !has_diffuse))
-            return 0.f;
+        bool has_diffuse = ctx.is_enabled(BSDFFlags::DiffuseReflection, 0),
+             has_glint   = ctx.is_enabled(BSDFFlags::GlossyReflection, 1);
 
         Float cos_theta_i = Frame3f::cos_theta(si.wi),
               cos_theta_o = Frame3f::cos_theta(wo);
@@ -1249,70 +902,92 @@ public:
         // Ensure incoming and outgoing directions are in the upper hemisphere
         active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
 
-        // Compute the whitecap reflectance
-        UnpolarizedSpectrum result(0.f);
-        UnpolarizedSpectrum blinn(0.f);
-        UnpolarizedSpectrum whitecap_reflectance(0.f);
-        UnpolarizedSpectrum glint_reflectance(0.f);
-        UnpolarizedSpectrum underlight_reflectance(0.f);
+        if (unlikely(dr::none_or<false>(active) || !has_glint && !has_diffuse))
+            return 0.f;
 
-        // Get the reflected directions
-        auto is_reflect =
-            Mask(dr::eq(dr::sign(cos_theta_i), dr::sign(cos_theta_o))) &&
-            active;
+
+        // Compute the whitecap reflectance
+        Spectrum result(0.f);
 
         // 6SV considers the incident direction to come from the light source
-        // `TransportMode` has two states:
-        //     - `Radiance`, meaning we trace from the sensor to the light
-        //     sources
-        //     - `Importance`, meaning we trace from the light sources to the
-        //     sensor
-        Vector3f wi_hat = ctx.mode == TransportMode::Radiance ? wo : si.wi,
-                 wo_hat = ctx.mode == TransportMode::Radiance ? si.wi : wo;
-
-        if (has_diffuse) {
-            // If whitecaps are enabled, compute the whitecap reflectance
-            whitecap_reflectance   = eval_whitecaps();
-            underlight_reflectance = eval_underlight(wi_hat, wo_hat);
-        }
-
-        if (has_glint)
-            // If sun glint is enabled, compute the glint reflectance
-            glint_reflectance = eval_glint(wi_hat, wo_hat);
-
+        //     - `Radiance`, trace from the sensor to the light sources
+        //     - `Importance`, trace from the light sources to the sensor
+        Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : si.wi,
+                 wi_hat = ctx.mode == TransportMode::Radiance ? si.wi : wo;
+        
         // Combine the results
         Float coverage = m_ocean_utils.eval_whitecap_coverage(m_wind_speed);
 
-        // For debugging purposes, the channel indicates what term of the BRDF
-        // to evaluate
-        switch (m_component) {
-            case 1:
-                result[is_reflect] = (whitecap_reflectance) &active;
-                break;
-            case 2:
-                result[is_reflect] =
-                    (1.f - coverage) * glint_reflectance & active;
-                break;
-            case 3:
-                result[is_reflect] =
-                    (1.f - (whitecap_reflectance)) * underlight_reflectance &
-                    active;
-                break;
-            case 4:
-                result[is_reflect] = coverage;
-                break;
-            default: {
-                result[is_reflect] =
-                    whitecap_reflectance + (1.f - coverage) * glint_reflectance +
-                    (1.f - (whitecap_reflectance)) * underlight_reflectance;
+        // Make reflectances available for debug purposes
+        UnpolarizedSpectrum whitecap_reflectance(0.f);
+        UnpolarizedSpectrum underlight_reflectance(0.f);
+        Spectrum glint_reflectance(0.f);
 
-                // Cosine foreshortening factor - not sure if this is actually
-                // needed?
-                result[is_reflect] *= cos_theta_o;
-            } break;
+        if (has_diffuse) {
+            whitecap_reflectance   = eval_whitecaps();
+            underlight_reflectance = eval_underlight(wo_hat, wi_hat);
+            // Diffuse scattering implies no polarization.
+            result += depolarizer<Spectrum>(
+                whitecap_reflectance + (1.f - whitecap_reflectance) * underlight_reflectance
+            );
         }
 
-        return depolarizer<Spectrum>(result) & active;
+        if (has_glint) {
+
+            if constexpr( is_polarized_v<Spectrum> ) {
+                // If sun glint is enabled, compute the glint reflectance
+                glint_reflectance = eval_glint(wo_hat, wi_hat);
+
+                /* The Stokes reference frame vector of this matrix lies in the meridian plane 
+                spanned by wi and n. */
+                Vector3f n(0.f, 0.f, 1.f);
+                Vector3f p_axis_in  = 
+                    dr::normalize(dr::cross(-wo_hat,dr::normalize(dr::cross(n, -wo_hat))));
+                Vector3f p_axis_out = 
+                    dr::normalize(dr::cross(wi_hat, dr::normalize(dr::cross(n, wi_hat))));
+                    
+                dr::masked( p_axis_in, dr::any(dr::isnan(p_axis_in)) ) = 
+                    Vector3f(0.f, 1.f, 0.f);
+                dr::masked( p_axis_out, dr::any(dr::isnan(p_axis_out)) ) = 
+                    Vector3f(0.f, 1.f, 0.f);
+
+                // Rotate in/out reference vector of `value` s.t. it aligns with the implicit
+                // Stokes bases of -wo_hat & wi_hat. */
+                glint_reflectance = mueller::rotate_mueller_basis(glint_reflectance,
+                                        -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+                                        wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
+
+            } else {
+                // If sun glint is enabled, compute the glint reflectance
+                glint_reflectance = eval_glint(wo_hat, wi_hat);
+            }
+
+            result += (1-coverage)*glint_reflectance;
+        }
+
+        dr::masked(result, active) *= cos_theta_o;
+
+        // For debugging purposes, channel indicates which BRDF term to evaluate
+        switch (m_component) {
+            case 1:
+                result[active] = depolarizer<Spectrum>(whitecap_reflectance);
+                break;
+            case 2:
+                result[active] =
+                    (1.f - coverage) * glint_reflectance;
+                break;
+            case 3:
+                result[active] =
+                    depolarizer<Spectrum>((1.f - whitecap_reflectance) * underlight_reflectance);
+                break;
+            case 4:
+                result[active] = coverage;
+                break;
+            default: 
+                break;
+        }
+
+        return result & active;
     }
 
     Float pdf(const BSDFContext &ctx, const SurfaceInteraction3f &si,
@@ -1326,7 +1001,7 @@ public:
             return 0.f;
 
         Float coverage = m_ocean_utils.eval_whitecap_coverage(m_wind_speed);
-        Float weight_diffuse = coverage, weight_specular = (1 - coverage);
+        Float weight_diffuse = coverage, weight_specular = (1.f - coverage);
 
         // Check if the normal has only zeros. If this is the case, use a
         // default normal
@@ -1336,14 +1011,14 @@ public:
 
         Vector3f half    = dr::normalize(si.wi + wo);
         Float projection = dr::dot(half, normal);
-        Float D          = ((m_shininess + 2.0f) /
+        Float D          = ((m_shininess + 2.f) /
                    dr::TwoPi<Float>) *dr::pow(projection, m_shininess);
 
         // We multiply the probability of the specular lobe with the pdf of
         // the Blinn-Phong distribution and the probability of the diffuse lobe
         // with the pdf of the cosine-weighted hemisphere.
         Float pdf_diffuse  = warp::square_to_cosine_hemisphere_pdf(wo),
-              pdf_specular = (D * projection) / (4.0f * dr::dot(si.wi, half));
+              pdf_specular = (D * projection) / (4.f * dr::dot(si.wi, half));
 
         Float pdf =
             weight_diffuse * pdf_diffuse + weight_specular * pdf_specular;
@@ -1351,7 +1026,6 @@ public:
         // If the outgoing direction is in the lower hemisphere, we return zero
         Float cos_theta_o = Frame3f::cos_theta(wo);
 
-        // return dr::select(cos_theta_o > 0.f, 1.f, 0.f);
         return dr::select(cos_theta_o > 0.f, pdf, 0.f);
     }
 

--- a/src/eradiate_plugins/bsdfs/ocean_mishchenko.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_mishchenko.cpp
@@ -1,0 +1,431 @@
+#include <array>
+#include <drjit/dynamic.h>
+#include <drjit/texture.h>
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/quad.h>
+#include <mitsuba/core/random.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/eradiate/oceanprops.h>
+#include <mitsuba/render/bsdf.h>
+#include <mitsuba/render/ior.h>
+#include <mitsuba/render/texture.h>
+#include <tuple>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _plugin-bsdf-ocean_mishchenko:
+
+Oceanic reflection model (:monosp:`ocean-mishchenko`)
+-----------------------------------------------------
+
+.. pluginparameters::
+
+ * - wind_speed
+   - |float|
+   - :math:`k \in [0, 37.54]` m/s.
+   - Specifies the wind speed at which to evaluate the oceanic reflectance
+     (Default: :monosp:`0.1 m/s`).
+
+ * - eta, k
+   - |spectrum| or |texture|
+   - Real and imaginary components of the water's index of refraction.
+     (Default: :monosp:`1.33, 0.`)
+   - |exposed|, |differentiable|, |discontinuous|
+
+ * - ext_ior
+   - |spectrum| or |texture|
+   - Exterior index of refraction specified numerically or using a known
+     material name. Note that the complex component is assumed to be 0 
+     (Default: 1.000277).
+
+ * - shininess
+   - |float|
+   - :math:`k \in [0, \infty]`.
+   - Specifies the shininess which is used as the exponent for Blinn-Phong MIS
+     (Default: :monosp:`50.`).
+
+ * - shadowing
+   - |bool|
+   - Flag that indicates whether shadowing is calculated or not
+     (Default: :monosp:`true`).
+
+This plugin implements the polarized oceanic reflection model originally
+implemented by :cite:`Mishchenko1997AerosolRetrievalPolarization`. This model
+focuses on the sunglint reflectance, which follows the Cox and Munk surface
+slope probability distribution. 
+
+Note that this material is one-sided---that is, observed from the
+back side, it will be completely black. If this is undesirable,
+consider using the ``twosided`` BSDF adapter plugin.
+The following snippet describes an oceanic surface material with monochromatic
+parameters:
+
+.. tab-set-code::
+
+    .. code-block:: python
+
+        "type": "ocean_mishchenko",
+        "wind_speed": 10,
+        "eta": 1.33,
+        "k": 0.,
+        "ext_ior": 1.0,
+        "shininess": 50
+
+    .. code-block:: xml
+
+        <bsdf type="ocean_mishchenko">
+            <float name="wind_speed" value="10"/>
+            <float name="eta" value="1.33"/>
+            <float name="k" value="0."/>
+            <float name="ext_ior" value=1.0/>
+            <float name="shininess" value="50"/>
+        </bsdf>
+
+.. note:: This model only implements the sunglint reflection. See :ref:`ocean
+    legacy <plugin-bsdf-ocean_legacy>` for a bsdf that includes whitecap, sunglint,
+    and underlight reflectance.
+
+*/
+
+template <typename Float, typename Spectrum>
+class MishchenkoOceanBSDF final : public BSDF<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(BSDF, m_flags, m_components)
+    MI_IMPORT_TYPES(Texture)
+
+    using Complex2u = dr::Complex<UnpolarizedSpectrum>;
+
+    /**
+     * @brief Construct a new OceanBSDF object.
+     *
+     * @param props A set of properties to initialize the oceanic BSDF.
+     */
+    MishchenkoOceanBSDF(const Properties &props) : Base(props) {
+        // Retrieve parameters
+        m_wind_speed = props.get<ScalarFloat>("wind_speed", 0.1f);
+        m_eta        = props.texture<Texture>("eta", 1.33f);
+        m_k          = props.texture<Texture>("k", 0.f);
+        m_ext_eta    = props.texture<Texture>("ext_ior", 1.000277f);
+        m_shininess  = props.get<ScalarFloat>("shininess", 50.f);
+        m_shadowing  = props.get<bool>("shadowing", true);
+
+        update();
+
+        // => Sun glint reflectance at the water surface is "specular"
+        m_components.push_back(BSDFFlags::GlossyReflection |
+                               BSDFFlags::FrontSide);
+
+        // Set all the flags
+        for (auto c : m_components)
+            m_flags |= c;
+        dr::set_attr(this, "flags", m_flags);
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_parameter("wind_speed", m_wind_speed, +ParamFlags::Differentiable);
+        callback->put_object("eta", m_eta, +ParamFlags::Differentiable);
+        callback->put_object("k", m_k, +ParamFlags::Differentiable);
+        callback->put_object("ext_ior", m_ext_eta, +ParamFlags::Differentiable);
+    }
+
+    void
+    parameters_changed(const std::vector<std::string> & /*keys*/) override {
+        update();
+    }
+
+    /**
+     * @brief Update the variables that can be preprocessed.
+     * This includes the complex index of refraction and mean square slope
+     */
+    void update() {
+
+        // compute the index of refraction
+        std::tie(std::ignore, std::ignore, m_sigma2) =
+            mean_square_slope_cox_munk(m_wind_speed);
+        m_sigma2 *= 0.5;
+    }
+
+    std::pair<BSDFSample3f, Spectrum> sample(const BSDFContext &ctx,
+                                             const SurfaceInteraction3f &si,
+                                             Float /*sample1*/,
+                                             const Point2f &sample2,
+                                             Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFSample, active);
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi);
+        active &= cos_theta_i > 0.f;
+
+        BSDFSample3f bs = dr::zeros<BSDFSample3f>();
+        Spectrum value(0.f);
+
+        if (unlikely(dr::none_or<false>(active)) ||
+            !ctx.is_enabled(BSDFFlags::GlossyReflection))
+            return { bs, value };
+
+        // For Blinn-Phong, we need to sample the half-vector
+        Float ksi_1 = sample2.x(), ksi_2 = sample2.y();
+        Float phi_h   = dr::TwoPi<Float> * ksi_1;
+        Float theta_h = dr::acos(dr::pow(ksi_2, 1.f / (m_shininess + 2.f)));
+        Vector3f half = dr::normalize(
+            Vector3f(dr::sin(theta_h) * dr::cos(phi_h),
+                     dr::sin(theta_h) * dr::sin(phi_h), dr::cos(theta_h)));
+
+        Vector3f wo = 2.f * dr::dot(si.wi, half) * half - si.wi;
+
+        // In the case of sampling the glint component, the outgoing
+        // direction is sampled using the Blinn-Phong distribution.
+        bs.wo                = wo;
+        bs.sampled_component = 0;
+        bs.sampled_type      = +BSDFFlags::GlossyReflection;
+
+        bs.pdf = pdf(ctx, si, bs.wo, active);
+        bs.eta = 1.f;
+
+        Mask shadowing  = m_shadowing & active;
+        Complex2u n_air(m_ext_eta->eval(si, active), 0.);
+        Complex2u n_water(m_eta->eval(si, active), 
+                          m_k->eval(si, active));
+
+        // `TransportMode` has two states:
+        //     - `Radiance`, trace from the sensor to the light sources
+        //     - `Importance`, trace from the light sources to the sensor
+        Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? bs.wo : si.wi,
+                 wi_hat = ctx.mode == TransportMode::Radiance ? si.wi : bs.wo;
+
+        if constexpr (is_polarized_v<Spectrum>) {
+
+            Spectrum val = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat,
+                                           m_sigma2, shadowing);
+            value = val * Frame3f::cos_theta(wo_hat) / (bs.pdf * dr::Pi<Float>);
+
+            /* The Stokes reference frame vector of this matrix lies in the
+            meridian plane spanned by wi and n. */
+            Vector3f n(0, 0, 1);
+            Vector3f p_axis_in  = 
+                dr::normalize(dr::cross(-wo_hat, dr::normalize(dr::cross(n, -wo_hat))));
+            Vector3f p_axis_out = 
+                dr::normalize(dr::cross(wi_hat, dr::normalize(dr::cross(n, wi_hat))));
+
+            dr::masked(p_axis_in, dr::any(dr::isnan(p_axis_in))) =
+                Vector3f(0.f, 1.f, 0.f);
+            dr::masked(p_axis_out, dr::any(dr::isnan(p_axis_out))) =
+                Vector3f(0.f, 1.f, 0.f);
+
+            // Rotate in/out reference vector of `value` s.t. it aligns with the
+            // implicit Stokes bases of -wo_hat & wi_hat. */
+            value = mueller::rotate_mueller_basis(
+                value, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+                wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
+
+        } else {
+            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
+                                    shadowing)[0][0];
+            value *= Frame3f::cos_theta(wo_hat) / (bs.pdf * dr::Pi<Float>);
+        }
+
+        return { bs, value & (active && bs.pdf > 0.f) };
+    }
+
+    Spectrum eval(const BSDFContext &ctx, const SurfaceInteraction3f &si,
+                  const Vector3f &wo, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
+
+        bool has_glint = ctx.is_enabled(BSDFFlags::GlossyReflection);
+
+        if (unlikely(dr::none_or<false>(active) || !has_glint))
+            return 0.f;
+
+        Float cos_theta_i = Frame3f::cos_theta(si.wi),
+              cos_theta_o = Frame3f::cos_theta(wo);
+
+        // Ensure incoming and outgoing directions are in the upper hemisphere
+        active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
+
+        // Compute the whitecap reflectance
+        Spectrum value(0.f);
+
+        Mask shadowing  = m_shadowing & active;
+        Complex2u n_air(m_ext_eta->eval(si, active), 0.);
+        Complex2u n_water(m_eta->eval(si, active), 
+                          m_k->eval(si, active));
+
+        // `TransportMode` has two states:
+        //     - `Radiance`, trace from the sensor to the light sources
+        //     - `Importance`, trace from the light sources to the sensor
+        Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : si.wi,
+                 wi_hat = ctx.mode == TransportMode::Radiance ? si.wi : wo;
+
+        if constexpr (is_polarized_v<Spectrum>) {
+            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
+                                    shadowing);
+            value *= Frame3f::cos_theta(wo_hat) * dr::InvPi<Float>;
+
+            // Compute the Stokes reference frame vectors of this matrix that
+            // are perpendicular to the plane of reflection.
+            Vector3f n(0.f, 0.f, 1.f);
+
+            /* The Stokes reference frame vector of this matrix lies in the
+               scattering plane spanned by wi and wo. */
+            Vector3f p_axis_in  = 
+                dr::normalize(dr::cross(-wo_hat, dr::normalize(dr::cross(n, -wo_hat))));
+            Vector3f p_axis_out = 
+                dr::normalize(dr::cross(wi_hat, dr::normalize(dr::cross(n, wi_hat))));
+
+            dr::masked(p_axis_in, dr::any(dr::isnan(p_axis_in)))   = 
+                Vector3f(0.f, 1.f, 0.f);
+            dr::masked(p_axis_out, dr::any(dr::isnan(p_axis_out))) = 
+                Vector3f(0.f, 1.f, 0.f);
+
+            // Rotate in/out reference vector of `value` s.t. it aligns with the
+            // implicit Stokes bases of -wo_hat & wi_hat. */
+            value = mueller::rotate_mueller_basis(
+                value, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+                wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
+        } else {
+            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
+                                    shadowing)[0][0];
+            value *= Frame3f::cos_theta(wo_hat) * dr::InvPi<Float>;
+        }
+
+        return value & active;
+    }
+
+    Float pdf(const BSDFContext &ctx, const SurfaceInteraction3f &si,
+              const Vector3f &wo, Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
+
+        if (unlikely(!ctx.is_enabled(BSDFFlags::GlossyReflection) ||
+                     dr::none_or<false>(active)))
+            return 0.f;
+
+        // Check if the normal has only zeros. If this is the case, use a
+        // default normal
+        Vector3f normal   = si.n;
+        Mask degen_normal = dr::all(dr::eq(normal, Vector3f(0.f)));
+        dr::masked(normal, degen_normal) = Vector3f(0.f, 0.f, 1.f);
+
+        Vector3f half    = dr::normalize(si.wi + wo);
+        Float projection = dr::dot(half, normal);
+        Float D          = ((m_shininess + 2.f) /
+                   dr::TwoPi<Float>) *dr::pow(projection, m_shininess);
+
+        // We multiply the probability of the specular lobe with the pdf of
+        // the Blinn-Phong distribution and the probability of the diffuse lobe
+        // with the pdf of the cosine-weighted hemisphere.
+        Float pdf_specular = (D * projection) / (4.0f * dr::dot(si.wi, half));
+
+        Float pdf = pdf_specular;
+
+        // If the outgoing direction is in the lower hemisphere, we return zero
+        Float cos_theta_o = Frame3f::cos_theta(wo);
+
+        return dr::select(cos_theta_o > 0.f, pdf, 0.f);
+    }
+
+    /**
+     * @brief Evaluate ocean BRDF as implemented by Mishchenko.
+     *
+     * Evaluate the polarized BRDF of the ocean implemented by Mishchenko.
+     * This model accounts for mean square slope probability, polarized
+     * fresnel reflectance, and shadowing.
+     *
+     * @param n_ext Complex index of refraction outside of the medium.
+     * @param n_water Complex index of refraction of the water.
+     * @param wi Incident direction of light (physics convention).
+     * @param wo Outgoing direction of light (physics convention).
+     * @param sigma2 Mean square slope squared.
+     * @param shadowing Flag that indicates the inclusion of shadowing.
+     *
+     * @return Ocean BPDF as a mueller matrix.
+     */
+    MuellerMatrix<UnpolarizedSpectrum> eval_mishchenko(
+        const Complex2u &n_ext, const Complex2u &n_water, 
+        Vector3f wi, Vector3f wo,
+        const Float sigma2, Mask shadowing
+    ) const {
+
+        MuellerMatrix<UnpolarizedSpectrum> F =
+            fresnel_sunglint_polarized(n_ext, n_water, wi, wo);
+
+        Float mu_i = dr::abs(wi.z());
+        Float mu_o = dr::abs(wo.z());
+
+        dr::masked(wi, mu_i > 0.9999999f) =
+            dr::normalize(wi + Vector3f(0.00001f, 0.f, 0.f));
+        dr::masked(wo, mu_o > 0.9999999f) =
+            dr::normalize(wo + Vector3f(0.00001f, 0.f, 0.f));
+        dr::masked(mu_i, mu_i > 0.9999999f) = 0.9999999f;
+        dr::masked(mu_o, mu_o > 0.9999999f) = 0.9999999f;
+
+        // local surface normal k_d
+        const Vector3f k_d    = wi - wo;
+        const Float k_d_norm2 = dr::dot(k_d, k_d);
+
+        // Slope probability distribution (Cox and Munk, 1955)
+        Float coeff =
+            1.f / (dr::pow(k_d.z(), 4.f) * 4.f * mu_i * mu_o * 2.f * sigma2);
+        const Float exp = dr::exp(-(k_d.x() * k_d.x() + k_d.y() * k_d.y()) 
+                                  / (k_d.z() * k_d.z() * 2.f * sigma2));
+        coeff *= exp * (k_d_norm2 * k_d_norm2);
+
+        F = F * coeff;
+
+        // shadowing
+        if (dr::any_or<true>(shadowing)) {
+
+            Float shadow = 1.f / (1.f + gamma_shadowing(mu_i, sigma2) + gamma_shadowing(mu_o, sigma2));
+            dr::masked(F, shadowing) = F * shadow;
+        }
+
+        return F;
+    }
+
+    /**
+     * @brief Shadowing function
+     *
+     * @param mu absolute value of the cosine of theta.
+     * @param sigma2 Mean square slope squared.
+     */
+    Float gamma_shadowing(const Float mu, const Float sigma2) const {
+        Float cot = mu / dr::sqrt(1.f - mu * mu);
+        Float result = 
+            0.5f *
+            (dr::sqrt(2.f * (1.f - mu * mu) / dr::Pi<Float>) 
+             * dr::sqrt(sigma2) / mu 
+             * dr::exp(-cot * cot / (2.f * sigma2)) 
+             - (1.f - dr::erf(cot / dr::sqrt(2.f * sigma2))));
+        return result;
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "OceanMishchenko[" << std::endl
+            << "  wind_speed = " << string::indent(m_wind_speed) << std::endl
+            << "  eta = " << string::indent(m_eta) << std::endl
+            << "  k = " << string::indent(m_k) << std::endl
+            << "  ext_ior = " << string::indent(m_ext_eta) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS()
+private:
+    //  User-provided fields
+    ScalarFloat m_wind_speed;
+    ref<Texture> m_eta;
+    ref<Texture> m_k;
+    ref<Texture> m_ext_eta;
+    ScalarFloat m_shininess;
+    bool m_shadowing;
+
+    ScalarFloat m_sigma2;
+    OceanProperties<Float, Spectrum> m_ocean_props;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(MishchenkoOceanBSDF, BSDF)
+MI_EXPORT_PLUGIN(MishchenkoOceanBSDF, "Mishchenko Ocean material")
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -11,7 +11,7 @@ NAMESPACE_BEGIN(mitsuba)
 .. _phase-tabphase_polarized:
 
 Lookup table (polarized) phase function (:monosp:`tabphase_polarized`)
-------------------------------------------------
+----------------------------------------------------------------------
 
 .. pluginparameters::
 
@@ -424,7 +424,7 @@ public:
 
     std::string to_string() const override {
         std::ostringstream oss;
-        oss << "TabulatedPhaseFunction[" << std::endl
+        oss << "TabulatedPolarizedPhaseFunction[" << std::endl
             << "  distr = " << string::indent(m_m11) << std::endl
             << "]";
         return oss.str();

--- a/src/eradiate_plugins/tests/bsdfs/test_ocean_mishchenko.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_ocean_mishchenko.py
@@ -1,0 +1,109 @@
+import drjit as dr
+import mitsuba as mi
+import pytest
+
+_bsdf_dict = {
+    "type": "ocean_mishchenko",
+    "wind_speed": 2.0,
+    "eta": 1.33,
+    "k": 0.0,
+    "ext_ior": 1.0,
+}
+
+
+@pytest.mark.slow
+def test_chi2_oceanic(variants_vec_backends_once_rgb):
+    """
+    Test the consistency of the oceanic BSDF using the chi2 test.
+    """
+    sample_func, pdf_func = mi.chi2.BSDFAdapter("ocean_mishchenko", _bsdf_dict)
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+        ires=16,
+        res=201,
+    )
+
+    assert chi2.run()
+
+
+def test_create_oceanic(variants_vec_backends_once_rgb):
+    # Test constructor of oceanic BSDF
+    brdf = mi.load_dict(_bsdf_dict)
+    gloss = brdf.flags()
+
+    # Obtain binary Mitsuba flags
+    gloss_flag = mi.BSDFFlags.GlossyReflection | mi.BSDFFlags.FrontSide
+
+    assert isinstance(brdf, mi.BSDF)
+    assert gloss == gloss_flag
+
+
+def test_traverse_oceanic(variant_scalar_mono_polarized):
+    # Mishchenko reference :
+    # wavelenth 550, windspeed 2, eta 1.33, vza 15, vaa 0, sza 15, saa 180
+    ref_550_2 = [
+        [0.125155, -0.0132689, 0.0, 0.0],
+        [-0.0132689, 0.125155, 0.0, -0.0],
+        [0.0, 0.0, -0.124450, 0.0],
+        [0.0, 0.0, -0.0, -0.124450],
+    ]
+
+    # wavelenth 900, windspeed 10, eta 1.39, vza 60, vaa 0, sza 40, saa 170
+    ref2_900_10 = [
+        [0.733924e-01, -0.713385e-01, 0.000000e00, -0.000000e00],
+        [-0.713385e-01, 0.733924e-01, 0.000000e00, -0.000000e00],
+        [0.000000e00, 0.000000e00, -0.172412e-01, 0.000000e00],
+        [0.000000e00, 0.000000e00, -0.000000e00, -0.172412e-01],
+    ]
+
+    def sph_to_eucl(theta, phi):
+        """angles in radians, return Vector3f"""
+        x = dr.sin(theta) * dr.cos(phi)
+        y = dr.sin(theta) * dr.sin(phi)
+        z = dr.cos(theta)
+        return mi.Vector3f(x, y, z)
+
+    vza = 15
+    vaa = 0.0
+    sza = 15
+    saa = 180.0
+
+    wi = sph_to_eucl(dr.deg2rad(vza), dr.deg2rad(vaa))
+    wo = sph_to_eucl(dr.deg2rad(sza), dr.deg2rad(saa))
+    n = dr.zeros(mi.Vector3f, dr.width(wi))
+    n.z = 1.0
+    si = dr.zeros(mi.SurfaceInteraction3f, dr.width(wi))
+    si.wi = wi
+    si.n = n
+
+    ctx = mi.BSDFContext(mi.TransportMode.Radiance)
+
+    brdf = mi.load_dict(_bsdf_dict)
+
+    brdf_dr = brdf.eval(ctx, si, wo)
+    brdf_np = brdf_dr.numpy()[0]
+
+    assert dr.allclose(brdf_np, ref_550_2, 0.0001, 0.00001)
+
+    params = mi.traverse(brdf)
+
+    params["wind_speed"] = 10.0
+    params["eta.value"] = 1.39
+    params.update()
+
+    vza = 60
+    vaa = 0.0
+    sza = 40
+    saa = 180.0
+
+    wo = sph_to_eucl(dr.deg2rad(sza), dr.deg2rad(saa))
+    si.wi = sph_to_eucl(dr.deg2rad(vza), dr.deg2rad(vaa))
+
+    brdf_dr = brdf.eval(ctx, si, wo)
+    brdf_np = brdf_dr.numpy()[0]
+
+    assert dr.allclose(brdf_np, ref2_900_10, 0.001, 0.0001)


### PR DESCRIPTION
## Description

This PR includes:
* A new polarized ocean BRDF which follows the implementation from Mishchenko (1997).
* A refactor of `ocean_legacy` to use the polarized fresnel function in polarized variants. 
* Fixes to the `ocean_legacy` plugin (especially sample function) and clean up making the plugin easier to follow. 
* A new `oceanprops` header that takes the properties from `ocean_legacy` and the ocean fresnel functions from both `ocean_mishchenko` and `ocean_legacy`.

The new ocean BRDF from Mishchenko introduces polarization for ocean surfaces. This model depends on wind speed and water's index of refraction. Unlike 6SV's model, the index of refraction is manually provided. If you prefer, we could instead have it automatically calculated from the same function as 6SV (now available in the header library) and provide a way to manually override it. 

The model from Mishchenko only models sunglint. Changes were made to the 6SV model to combine the polarized sunglint with its other components in the same way as in LibRadTran. To do so, the fresnel function from Mishchenko's implementation was extracted and made available in the `oceanprops` header. The `ocean_legacy` now uses this fresnel function to have polarized sunglint in conjunction to its other components. Care was taken to make sure that contribution from diffuse components still acted as depolarizers and that only the sunglint contributes to polarization. 

Along the way, the `sample` and `eval` functions from the 6SV models were cleaned up to be more in line with other models such as `roughplastic`. This also enabled to solve some bugs (e.g. missing $cos(\theta)$ factors).

## Testing

Testing of the `ocean_mishchenko` model was done by validating it against the IPRT A6 and B4 scenarios. New tests were written for the plugin. 
The `ocean_legacy` model was tested again against the 6SV model.

Both plugins were tested in `scalar` and `llvm` modes.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [X] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [X] My changes generate no new warnings
- [X] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)