### PR TITLE
[Feature] Ocean importance sampling

### DIFF
--- a/include/mitsuba/eradiate/oceanprops.h
+++ b/include/mitsuba/eradiate/oceanprops.h
@@ -328,9 +328,8 @@ private:
  */
 template<typename Float>
 Float whitecap_coverage_monahan(const Float &wind_speed) {
-    //@TODO Move to preprocessor constants?
-    const dr::scalar_t<Float> m_monahan_alpha  = 2.95e-06f;
-    const dr::scalar_t<Float> m_monahan_lambda = 3.52f;
+    static constexpr dr::scalar_t<Float> m_monahan_alpha  = 2.95e-06f;
+    static constexpr dr::scalar_t<Float> m_monahan_lambda = 3.52f;
     return dr::clamp(m_monahan_alpha *
                         dr::pow(wind_speed, m_monahan_lambda),
                         0.0f, 1.0f);
@@ -558,11 +557,10 @@ MuellerMatrix<UnpolarizedSpectrum> fresnel_sunglint_polarized(
 
 /**
  * @brief Mean square slope *squared* as described by Cox and Munk (1954).
- * 
- * @param wind_speed speed of wind at sea surface (mast height).
- * @return tuple (Float, Float, Float) 
- * Respectively the cross wind, along wind, and isotropic wind 
- * mean square slope squared.
+ *
+ * @param wind_speed speed of wind at sea surface (mast height, 10 m) [m/s].
+ * @return tuple (Float, Float)
+ * Respectively the cross wind and along wind mean square slope squared.
  */
 template<typename Float>
 std::tuple<Float, Float> cox_munk_crosswind_upwind(const Float& wind_speed) {
@@ -572,9 +570,173 @@ std::tuple<Float, Float> cox_munk_crosswind_upwind(const Float& wind_speed) {
     return { sigma_cross_2, sigma_along_2 };
 }
 
+/**
+ * @brief Isotropic Mean Squared Slope *squared* as described by Cox and Munk
+ * (1954)
+ *
+ * @param wind_speed speed of wind at sea surface (mast height, 10 m) [m/s].
+ * @return Float
+ * The isotropic wind mean square slope squared
+ */
 template<typename Float>
-Float cox_munk_MMS(const Float& wind_speed) {
+Float cox_munk_msslope_squared(const Float& wind_speed) {
     return dr::fmadd(wind_speed, 0.00512f, 0.003f);
+}
+
+/**
+ * @brief Evaluates the anisotropic distribution of Cox and Munk (1954), with
+ * the Gram Charlier series expansion.
+ *
+ * @param wind_direction direction in radians, east right convention.
+ * @param wind_speed wind_speed speed of wind at sea surface (mast height, 10 m)
+ * [m/s].
+ * @param sigma_u Upwind root mean slope distribution.
+ * @param sigma_c Crosswind root mean slope distribution.
+ * @param m Half vector.
+ *
+ */
+template <typename Float>
+Float cox_munk_anisotropic_distrib(const Float &wind_direction,
+                             const Float &wind_speed, const Float &sigma_u,
+                             const Float &sigma_c, const Vector<Float, 3> &m) {
+
+    using Vector3f    = Vector<Float, 3>;
+    using ScalarFloat = dr::scalar_t<Float>;
+
+    // Distribution constants
+    static constexpr ScalarFloat c_40 = 0.40f;
+    static constexpr ScalarFloat c_22 = 0.12f;
+    static constexpr ScalarFloat c_04 = 0.23f;
+
+    // Distribution variables
+    Float c_21 = 0.01f - 0.0086f * wind_speed;
+    Float c_03 = 0.04f - 0.033f * wind_speed;
+
+    auto [s_phi, c_phi] = dr::sincos(wind_direction);
+
+    Vector3f m_p = Vector3f(c_phi * m.x() + s_phi * m.y(),
+                            -s_phi * m.x() + c_phi * m.y(), m.z());
+    m_p          = dr::normalize(m_p);
+
+    const Float xn  = m_p.x() * dr::rcp(sigma_u * m_p.z());
+    const Float xe  = m_p.y() * dr::rcp(sigma_c * m_p.z());
+    const Float xe2 = xe * xe;
+    const Float xn2 = xn * xn;
+
+    Float coef =
+        1.f - (c_21 / 2.f) * (xe2 - 1.f) * xn - (c_03 / 6.f) * (xn2 - 3.f) * xn;
+    coef = coef + (c_40 / 24.f) * (xe2 * xe2 - 6.f * xe2 + 3.f);
+    coef = coef + (c_04 / 24.f) * (xn2 * xn2 - 6.f * xn2 + 3.f);
+    coef = coef + (c_22 / 4.f) * (xe2 - 1.f) * (xn2 - 1.f);
+
+    Float prob = coef * dr::InvTwoPi<Float> * dr::rcp(sigma_u * sigma_c) *
+                 dr::exp(-(xe2 + xn2) * 0.5f);
+    return prob;
+}
+
+/**
+ * Evaluates the gram charlier coefficient for the Cox and Munk (1954) only.
+ */
+template <typename Float>
+Float cox_munk_gram_charlier_coef(const Float &wind_direction,
+                            const Float &wind_speed, const Float &sigma_u,
+                            const Float &sigma_c, const Vector<Float, 3> &m) {
+
+    using Vector3f    = Vector<Float, 3>;
+    using ScalarFloat = dr::scalar_t<Float>;
+
+    // Distribution constants
+    static ScalarFloat c_40 = 0.40f;
+    static ScalarFloat c_22 = 0.12f;
+    static ScalarFloat c_04 = 0.23f;
+
+    // Distribution variables
+    Float c_21 = 0.01f - 0.0086f * wind_speed;
+    Float c_03 = 0.04f - 0.033f * wind_speed;
+
+    auto [s_phi, c_phi] = dr::sincos(wind_direction);
+
+    Vector3f m_p = Vector3f(c_phi * m.x() + s_phi * m.y(),
+                            -s_phi * m.x() + c_phi * m.y(), m.z());
+    m_p          = dr::normalize(m_p);
+
+    const Float xn = m_p.x() / (sigma_u * m_p.z());
+    const Float xe = m_p.y() / (sigma_c * m_p.z());
+
+    const Float xe2 = xe * xe;
+    const Float xn2 = xn * xn;
+
+    Float coef =
+        1.f - (c_21 / 2.f) * (xe2 - 1.f) * xn - (c_03 / 6.f) * (xn2 - 3.f) * xn;
+    coef = coef + (c_40 / 24.f) * (xe2 * xe2 - 6.f * xe2 + 3.f);
+    coef = coef + (c_04 / 24.f) * (xn2 * xn2 - 6.f * xn2 + 3.f);
+    coef = coef + (c_22 / 4.f) * (xe2 - 1.f) * (xn2 - 1.f);
+
+    return coef;
+}
+
+/**
+ * @brief Compute the ratio of upwelling to downwelling irradiance.
+ *
+ * Computes the ratio of upwelling to downwelling irradiance at the given
+ * wavelength and pigmentation. The ratio is computed by performing an
+ * iterative computation.
+ *
+ * @param wavelength The wavelength at which to evaluate the ratio.
+ * @param pigmentation The pigmentation of the water.
+ * @return ScalarFloat The ratio of upwelling to downwelling irradiance.
+ * @note This function is only defined for wavelengths in the range [400,
+ * 700] nm.
+ */
+template <typename Float, typename Spectrum, typename ScalarFloat>
+ScalarFloat r_omega(const OceanProperties<Float, Spectrum> ocean_props,
+                    const ScalarFloat &wavelength,
+                    const ScalarFloat &pigmentation) {
+
+    ScalarFloat pigment_log = dr::log(pigmentation) / dr::log(10.f);
+
+    // Backscattering coefficient
+    ScalarFloat molecular_scatter_coeff =
+        ocean_props.molecular_scatter_coeff_6s(wavelength);
+    ScalarFloat scattering_coeff = 0.30f * dr::pow(pigmentation, 0.62);
+    ScalarFloat backscatter_ratio =
+        0.002f + 0.02f * (0.5f - 0.25f * pigment_log) * (550.f / wavelength);
+    ScalarFloat backscatter_coeff =
+        0.5f * molecular_scatter_coeff + scattering_coeff * backscatter_ratio;
+
+    // (Diffuse) attenuation coefficient
+    ScalarFloat k          = ocean_props.attn_k(wavelength);
+    ScalarFloat chi        = ocean_props.attn_chi(wavelength);
+    ScalarFloat e          = ocean_props.attn_e(wavelength);
+    ScalarFloat attn_coeff = k + chi * dr::pow(pigmentation, e);
+
+    // If any of the coefficients is zero, we return zero
+    if (backscatter_coeff == 0.f || attn_coeff == 0.f)
+        return 0.f;
+
+    // Iterative computation of the reflectance
+    ScalarFloat u       = 0.75f;
+    ScalarFloat r_omega = 0.33f * backscatter_coeff / u / attn_coeff;
+
+    bool converged = false;
+    while (!converged) {
+        // Update u
+        u = (0.9f * (1.f - r_omega)) / (1.f + 2.25f * r_omega);
+
+        // Update reflectance
+        ScalarFloat r_omega_new = 0.33f * backscatter_coeff / (u * attn_coeff);
+
+        // Create a mask that marks the converged values
+        if (dr::abs((r_omega_new - r_omega) / r_omega_new) < 0.0001f) {
+            converged = true;
+            break;
+        }
+
+        // Update reflectance ONLY for non-converged values
+        r_omega = r_omega_new;
+    }
+
+    return r_omega;
 }
 
 #endif // OCEAN_PROPS

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4861,6 +4861,8 @@ Normals" by Eric Heitz)doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution_G = R"doc(Smith's separable shadowing-masking approximation)doc";
 
+static const char *__doc_mitsuba_MicrofacetDistribution_G_height_correlated = R"doc(Smith's height-correlated shadowing-masking approximation)doc";
+
 static const char *__doc_mitsuba_MicrofacetDistribution_MicrofacetDistribution =
 R"doc(Create an isotropic microfacet distribution of the specified type
 
@@ -4945,6 +4947,15 @@ static const char *__doc_mitsuba_MicrofacetDistribution_scale_alpha = R"doc(Scal
 
 static const char *__doc_mitsuba_MicrofacetDistribution_smith_g1 =
 R"doc(Smith's shadowing-masking function for a single direction
+
+Parameter ``v``:
+    An arbitrary direction
+
+Parameter ``m``:
+    The microfacet normal)doc";
+
+static const char *__doc_mitsuba_MicrofacetDistribution_smith_lambda =
+R"doc(Smith's shadowing-masking lambda function for a single direction
 
 Parameter ``v``:
     An arbitrary direction

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4882,7 +4882,10 @@ Parameter ``alpha_u``:
     The surface roughness in the tangent direction
 
 Parameter ``alpha_v``:
-    The surface roughness in the bitangent direction)doc";
+    The surface roughness in the bitangent direction
+
+Parameter ``alpha_v``:
+    The angle of rotation of the anisotropic distribution)doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution_MicrofacetDistribution_3 = R"doc(Create a microfacet distribution from a Property data structure)doc";
 
@@ -4891,6 +4894,8 @@ static const char *__doc_mitsuba_MicrofacetDistribution_alpha = R"doc(Return the
 static const char *__doc_mitsuba_MicrofacetDistribution_alpha_u = R"doc(Return the roughness along the tangent direction)doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution_alpha_v = R"doc(Return the roughness along the bitangent direction)doc";
+
+static const char *__doc_mitsuba_MicrofacetDistribution_angle = R"doc(Return the angle of anisotropy)doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution_configure = R"doc()doc";
 
@@ -4906,7 +4911,15 @@ static const char *__doc_mitsuba_MicrofacetDistribution_is_isotropic = R"doc(Is 
 
 static const char *__doc_mitsuba_MicrofacetDistribution_m_alpha_u = R"doc()doc";
 
+static const char *__doc_mitsuba_MicrofacetDistribution_m_alpha_up = R"doc()doc";
+
 static const char *__doc_mitsuba_MicrofacetDistribution_m_alpha_v = R"doc()doc";
+
+static const char *__doc_mitsuba_MicrofacetDistribution_m_alpha_vp = R"doc()doc";
+
+static const char *__doc_mitsuba_MicrofacetDistribution_m_angle = R"doc()doc";
+
+static const char *__doc_mitsuba_MicrofacetDistribution_m_correlation = R"doc()doc";
 
 static const char *__doc_mitsuba_MicrofacetDistribution_m_sample_visible = R"doc()doc";
 

--- a/include/mitsuba/render/microfacet.h
+++ b/include/mitsuba/render/microfacet.h
@@ -75,7 +75,7 @@ public:
      */
     MicrofacetDistribution(MicrofacetType type, Float alpha, bool sample_visible = true)
         : m_type(type), m_alpha_u(alpha), m_alpha_v(alpha),
-          m_sample_visible(sample_visible) {
+          m_angle(Float(0.f)), m_sample_visible(sample_visible) {
         configure();
     }
 
@@ -88,11 +88,16 @@ public:
      *     The surface roughness in the tangent direction
      * \param alpha_v
      *     The surface roughness in the bitangent direction
+     * \param alpha_v
+     *     The angle of rotation of the anisotropic distribution
      */
-    MicrofacetDistribution(MicrofacetType type, Float alpha_u, Float alpha_v,
-                           bool sample_visible = true)
+    MicrofacetDistribution(MicrofacetType type, 
+                           Float alpha_u, 
+                           Float alpha_v,
+                           bool sample_visible = true, 
+                           Float angle = Float(0.f))
         : m_type(type), m_alpha_u(alpha_u), m_alpha_v(alpha_v),
-          m_sample_visible(sample_visible) {
+          m_angle(angle), m_sample_visible(sample_visible) {
         configure();
     }
 
@@ -123,6 +128,8 @@ public:
             if (props.has_property("alpha_u") || props.has_property("alpha_v"))
                 Throw("Microfacet model: please specify"
                       "either 'alpha' or 'alpha_u'/'alpha_v'.");
+            if (props.has_property("angle"))
+                Throw("Microfacet model: cannot specify 'angle' with 'alpha'.");
         } else if (props.has_property("alpha_u") || props.has_property("alpha_v")) {
             if (!props.has_property("alpha_u") || !props.has_property("alpha_v"))
                 Throw("Microfacet model: both 'alpha_u' and 'alpha_v' must be specified.");
@@ -139,7 +146,7 @@ public:
                 "Please use the corresponding smooth reflectance model to get zero roughness.");
 
         m_sample_visible = props.get<bool>("sample_visible", sample_visible);
-
+        m_angle = props.get<ScalarFloat>("angle", 0.f);
         configure();
     }
 
@@ -155,6 +162,9 @@ public:
 
     /// Return the roughness along the bitangent direction
     Float alpha_v() const { return m_alpha_v; }
+
+    /// Return the angle of anisotropy
+    Float angle() const { return m_angle; }
 
     /// Return whether or not only visible normals are sampled?
     bool sample_visible() const { return m_sample_visible; }
@@ -187,19 +197,25 @@ public:
               cos_theta         = Frame3f::cos_theta(m),
               cos_theta_2       = dr::sqr(cos_theta),
               result;
+        
+        Vector3f m_p = m;
+
+        auto [s_phi, c_phi] = dr::sincos(-m_angle);
+        m_p = Vector3f(c_phi*m.x()-s_phi*m.y(), s_phi*m.x()+c_phi*m.y(), m.z());
+        m_p = dr::normalize(m_p);
 
         if (m_type == MicrofacetType::Beckmann) {
             // Beckmann distribution function for Gaussian random surfaces
-            result = dr::exp(-(dr::sqr(m.x() / m_alpha_u) +
-                               dr::sqr(m.y() / m_alpha_v)) /
+            result = dr::exp(-(dr::sqr(m_p.x() / m_alpha_u) +
+                               dr::sqr(m_p.y() / m_alpha_v)) /
                              cos_theta_2) /
                      (dr::Pi<Float> * alpha_uv * dr::sqr(cos_theta_2));
         } else {
             // GGX / Trowbridge-Reitz distribution function
             result =
                 dr::rcp(dr::Pi<Float> * alpha_uv *
-                        dr::sqr(dr::sqr(m.x() / m_alpha_u) +
-                                dr::sqr(m.y() / m_alpha_v) + dr::sqr(m.z())));
+                        dr::sqr(dr::sqr(m_p.x() / m_alpha_u) +
+                                dr::sqr(m_p.y() / m_alpha_v) + dr::sqr(m_p.z())));
         }
 
         // Prevent potential numerical issues in other stages of the model
@@ -296,11 +312,12 @@ public:
         } else {
             // Visible normal sampling.
             Float sin_phi, cos_phi, cos_theta;
+            auto [sin_dir, cos_dir] = dr::sincos(m_angle);
 
             // Step 1: stretch wi
             Vector3f wi_p = dr::normalize(Vector3f(
-                m_alpha_u * wi.x(),
-                m_alpha_v * wi.y(),
+                m_alpha_u * ( wi.x() * cos_dir + wi.y() * sin_dir),
+                m_alpha_v * (-wi.x() * sin_dir + wi.y() * cos_dir),
                 wi.z()
             ));
 
@@ -317,6 +334,11 @@ public:
 
             // Step 4: compute normal & PDF
             Normal3f m = dr::normalize(Vector3f(-slope.x(), -slope.y(), 1));
+            m = dr::normalize(Vector3f(
+                (m.x() * cos_dir - m.y() * sin_dir),
+                (m.x() * sin_dir + m.y() * cos_dir),
+                m.z()
+            ));
 
             Float pdf = eval(m) * smith_g1(wi, m) * dr::abs_dot(wi, m) /
                         Frame3f::cos_theta(wi);
@@ -332,7 +354,7 @@ public:
 
     /// Smith's height-correlated shadowing-masking approximation
     Float G_height_correlated(const Vector3f &wi, const Vector3f &wo, const Vector3f &m) const {
-        Float result =  dr::rcp(1.f+smith_lambda(wi,m)+smith_lambda(wo,m));
+        Float result =  dr::rcp(1.f+smith_lambda(wi)+smith_lambda(wo));
 
         /* Ensure consistent orientation (can't see the back
            of the microfacet from the front and vice versa) */
@@ -351,7 +373,9 @@ public:
      *     The microfacet normal
      */
     Float smith_g1(const Vector3f &v, const Vector3f &m) const {
-        Float xy_alpha_2 = dr::sqr(m_alpha_u * v.x()) + dr::sqr(m_alpha_v * v.y()),
+        Float xy_alpha_2 = dr::sqr(m_alpha_up * v.x()) 
+                         + dr::sqr(m_alpha_vp * v.y()) 
+                         + v.x()*v.y() * m_correlation,
               tan_theta_alpha_2 = xy_alpha_2 / dr::sqr(v.z()),
               result;
 
@@ -385,8 +409,10 @@ public:
      * \param m
      *     The microfacet normal
      */
-    Float smith_lambda(const Vector3f &v, const Vector3f &m) const {
-        Float xy_alpha_2 = dr::sqr(m_alpha_u * v.x()) + dr::sqr(m_alpha_v * v.y()),
+    Float smith_lambda(const Vector3f &v) const {
+        Float xy_alpha_2 = dr::sqr(m_alpha_up * v.x()) 
+                         + dr::sqr(m_alpha_vp * v.y()) 
+                         + v.x()*v.y() * m_correlation,
               tan_theta_alpha_2 = xy_alpha_2 / dr::sqr(v.z()),
               result;
 
@@ -468,6 +494,13 @@ protected:
     void configure() {
         m_alpha_u = dr::maximum(m_alpha_u, 1e-4f);
         m_alpha_v = dr::maximum(m_alpha_v, 1e-4f);
+
+        // Calculate the correlated coefficient that form the inverse Quadric
+        // equation that describe the ellispoid of this distribution.
+        auto [s_phi, c_phi] = dr::sincos(m_angle);
+        m_alpha_up = dr::sqrt(dr::sqr(m_alpha_u*c_phi) + dr::sqr(m_alpha_v*s_phi));
+        m_alpha_vp = dr::sqrt(dr::sqr(m_alpha_u*s_phi) + dr::sqr(m_alpha_v*c_phi));
+        m_correlation = 2.f * (dr::sqr(m_alpha_u) - dr::sqr(m_alpha_v))*c_phi*s_phi;
     }
 
     /// Compute the squared 1D roughness along direction \c v
@@ -484,6 +517,8 @@ protected:
 protected:
     MicrofacetType m_type;
     Float m_alpha_u, m_alpha_v;
+    Float m_alpha_up, m_alpha_vp, m_correlation;
+    Float m_angle;
     bool  m_sample_visible;
 };
 
@@ -499,6 +534,7 @@ std::ostream &operator<<(std::ostream &os, const MicrofacetDistribution<Float, S
        << "  alpha_u = " << md.alpha_u() << "," << std::endl
        << "  alpha_v = " << md.alpha_v() << "," << std::endl
        << "  sample_visible = " << md.sample_visible() << std::endl
+       << "  angle = " << md.angle() << std::endl
        << "]";
     return os;
 }

--- a/src/eradiate_plugins/bsdfs/ocean_grasp.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_grasp.cpp
@@ -169,7 +169,7 @@ public:
      * @return Float Root Mean Square Slope.
      */
     Float eval_sigma(Float wind_speed) const {
-        return dr::sqrt(0.5f * cox_munk_MMS(wind_speed));
+        return dr::sqrt(0.5f * cox_munk_msslope_squared(wind_speed));
     }
 
     /**

--- a/src/eradiate_plugins/bsdfs/ocean_mishchenko.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_mishchenko.cpp
@@ -3,13 +3,13 @@
 #include <drjit/texture.h>
 #include <mitsuba/core/distr_1d.h>
 #include <mitsuba/core/properties.h>
-#include <mitsuba/core/quad.h>
 #include <mitsuba/core/random.h>
 #include <mitsuba/core/spectrum.h>
 #include <mitsuba/core/warp.h>
 #include <mitsuba/eradiate/oceanprops.h>
 #include <mitsuba/render/bsdf.h>
 #include <mitsuba/render/ior.h>
+#include <mitsuba/render/microfacet.h>
 #include <mitsuba/render/texture.h>
 #include <tuple>
 
@@ -42,15 +42,9 @@ Oceanic reflection model (:monosp:`ocean-mishchenko`)
      material name. Note that the complex component is assumed to be 0 
      (Default: 1.000277).
 
- * - shininess
-   - |float|
-   - :math:`k \in [0, \infty]`.
-   - Specifies the shininess which is used as the exponent for Blinn-Phong MIS
-     (Default: :monosp:`50.`).
-
  * - shadowing
    - |bool|
-   - Flag that indicates whether shadowing is calculated or not
+   - Indicates whether evaluation accounts for the shadowing-masking term.
      (Default: :monosp:`true`).
 
 This plugin implements the polarized oceanic reflection model originally
@@ -73,7 +67,6 @@ parameters:
         "eta": 1.33,
         "k": 0.,
         "ext_ior": 1.0,
-        "shininess": 50
 
     .. code-block:: xml
 
@@ -82,7 +75,6 @@ parameters:
             <float name="eta" value="1.33"/>
             <float name="k" value="0."/>
             <float name="ext_ior" value=1.0/>
-            <float name="shininess" value="50"/>
         </bsdf>
 
 .. note:: This model only implements the sunglint reflection. See :ref:`ocean
@@ -95,7 +87,7 @@ template <typename Float, typename Spectrum>
 class MishchenkoOceanBSDF final : public BSDF<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(BSDF, m_flags, m_components)
-    MI_IMPORT_TYPES(Texture)
+    MI_IMPORT_TYPES(Texture, MicrofacetDistribution)
 
     using Complex2u = dr::Complex<UnpolarizedSpectrum>;
 
@@ -110,7 +102,6 @@ public:
         m_eta        = props.texture<Texture>("eta", 1.33f);
         m_k          = props.texture<Texture>("k", 0.f);
         m_ext_eta    = props.texture<Texture>("ext_ior", 1.000277f);
-        m_shininess  = props.get<ScalarFloat>("shininess", 50.f);
         m_shadowing  = props.get<bool>("shadowing", true);
 
         update();
@@ -144,7 +135,7 @@ public:
     void update() {
 
         // compute the index of refraction
-        m_sigma2 = 0.5f * cox_munk_MMS(m_wind_speed);
+        m_sigma = dr::SqrtTwo<Float> * dr::sqrt(0.5f * cox_munk_msslope_squared(m_wind_speed));
     }
 
     std::pair<BSDFSample3f, Spectrum> sample(const BSDFContext &ctx,
@@ -154,36 +145,39 @@ public:
                                              Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFSample, active);
 
+        BSDFSample3f bs = dr::zeros<BSDFSample3f>();
         Float cos_theta_i = Frame3f::cos_theta(si.wi);
         active &= cos_theta_i > 0.f;
 
-        BSDFSample3f bs = dr::zeros<BSDFSample3f>();
-        Spectrum value(0.f);
+        if (unlikely(dr::none_or<false>(active)) || !ctx.is_enabled(BSDFFlags::GlossyReflection))
+            return { bs, 0.f };
+        
 
-        if (unlikely(dr::none_or<false>(active)) ||
-            !ctx.is_enabled(BSDFFlags::GlossyReflection))
-            return { bs, value };
+        /* Construct a microfacet distribution matching the
+           roughness values at the current surface position. */
+        MicrofacetDistribution distr(MicrofacetType::Beckmann,
+                                     m_sigma,
+                                     true);
 
-        // For Blinn-Phong, we need to sample the half-vector
-        Float ksi_1 = sample2.x(), ksi_2 = sample2.y();
-        Float phi_h   = dr::TwoPi<Float> * ksi_1;
-        Float theta_h = dr::acos(dr::pow(ksi_2, 1.f / (m_shininess + 2.f)));
-        Vector3f half = dr::normalize(
-            Vector3f(dr::sin(theta_h) * dr::cos(phi_h),
-                     dr::sin(theta_h) * dr::sin(phi_h), dr::cos(theta_h)));
-
-        Vector3f wo = 2.f * dr::dot(si.wi, half) * half - si.wi;
-
-        // In the case of sampling the glint component, the outgoing
-        // direction is sampled using the Blinn-Phong distribution.
-        bs.wo                = wo;
-        bs.sampled_component = 0;
-        bs.sampled_type      = +BSDFFlags::GlossyReflection;
-
-        bs.pdf = pdf(ctx, si, bs.wo, active);
+        // Sample M, the microfacet normal
+        Normal3f m;
+        std::tie(m, bs.pdf) = distr.sample(si.wi, sample2);
+        
+        /// Perfect specular reflection based on the microfacet normal
+        bs.wo = reflect(si.wi, m);
         bs.eta = 1.f;
+        bs.sampled_component = 0;
+        bs.sampled_type = +BSDFFlags::GlossyReflection;
+        
+        // Ensure that this is a valid sample
+        active &= dr::neq(bs.pdf, 0.f) && Frame3f::cos_theta(bs.wo) > 0.f;
 
-        Mask shadowing  = m_shadowing & active;
+        // Jacobian of the half-direction mapping
+        bs.pdf /= 4.f * dr::dot(bs.wo, m);
+
+        UnpolarizedSpectrum weight;
+        weight = distr.G_height_correlated(si.wi, bs.wo, m) / distr.smith_g1(si.wi, m);
+
         Complex2u n_air(m_ext_eta->eval(si, active), 0.);
         Complex2u n_water(m_eta->eval(si, active), 
                           m_k->eval(si, active));
@@ -194,11 +188,9 @@ public:
         Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? bs.wo : si.wi,
                  wi_hat = ctx.mode == TransportMode::Radiance ? si.wi : bs.wo;
 
+        Spectrum F;
         if constexpr (is_polarized_v<Spectrum>) {
-
-            Spectrum val = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat,
-                                           m_sigma2, shadowing);
-            value = val * Frame3f::cos_theta(wo_hat) / (bs.pdf * dr::Pi<Float>);
+            F = fresnel_sunglint_polarized(n_air, n_water, -wo_hat, wi_hat);
 
             /* The Stokes reference frame vector of this matrix lies in the
             meridian plane spanned by wi and n. */
@@ -215,17 +207,16 @@ public:
 
             // Rotate in/out reference vector of `value` s.t. it aligns with the
             // implicit Stokes bases of -wo_hat & wi_hat. */
-            value = mueller::rotate_mueller_basis(
-                value, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+            F = mueller::rotate_mueller_basis(
+                F, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
                 wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
 
         } else {
-            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
-                                    shadowing)[0][0];
-            value *= Frame3f::cos_theta(wo_hat) / (bs.pdf * dr::Pi<Float>);
+            F = 
+                UnpolarizedSpectrum(fresnel_sunglint_polarized(n_air, n_water, -wo_hat, wi_hat)[0][0]);
         }
 
-        return { bs, value & (active && bs.pdf > 0.f) };
+        return { bs, (F*weight) & (active) };
     }
 
     Spectrum eval(const BSDFContext &ctx, const SurfaceInteraction3f &si,
@@ -234,19 +225,28 @@ public:
 
         bool has_glint = ctx.is_enabled(BSDFFlags::GlossyReflection);
 
-        if (unlikely(dr::none_or<false>(active) || !has_glint))
-            return 0.f;
-
         Float cos_theta_i = Frame3f::cos_theta(si.wi),
               cos_theta_o = Frame3f::cos_theta(wo);
 
         // Ensure incoming and outgoing directions are in the upper hemisphere
         active &= cos_theta_i > 0.f && cos_theta_o > 0.f;
 
-        // Compute the whitecap reflectance
-        Spectrum value(0.f);
+        if (unlikely(dr::none_or<false>(active) || !has_glint))
+            return 0.f;
+            
+        MicrofacetDistribution distr(
+            MicrofacetType::Beckmann, 
+            m_sigma,
+            true
+        );
+            
+        const Vector3f m = dr::normalize(si.wi + wo);
+        Float D = distr.eval(m);
+        Float G = distr.G_height_correlated(si.wi, wo, m);
+        UnpolarizedSpectrum result = D * G / (4 * cos_theta_i);
 
-        Mask shadowing  = m_shadowing & active;
+        active &= dr::neq(D, 0.f);
+
         Complex2u n_air(m_ext_eta->eval(si, active), 0.);
         Complex2u n_water(m_eta->eval(si, active), 
                           m_k->eval(si, active));
@@ -257,11 +257,9 @@ public:
         Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : si.wi,
                  wi_hat = ctx.mode == TransportMode::Radiance ? si.wi : wo;
 
+        Spectrum F;
         if constexpr (is_polarized_v<Spectrum>) {
-            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
-                                    shadowing);
-            value *= Frame3f::cos_theta(wo_hat) * dr::InvPi<Float>;
-
+            F = fresnel_sunglint_polarized(n_air, n_water, -wo_hat, wi_hat);
             // Compute the Stokes reference frame vectors of this matrix that
             // are perpendicular to the plane of reflection.
             Vector3f n(0.f, 0.f, 1.f);
@@ -278,125 +276,46 @@ public:
             dr::masked(p_axis_out, dr::any(dr::isnan(p_axis_out))) = 
                 Vector3f(0.f, 1.f, 0.f);
 
-            // Rotate in/out reference vector of `value` s.t. it aligns with the
+            // Rotate in/out reference vector of `F` s.t. it aligns with the
             // implicit Stokes bases of -wo_hat & wi_hat. */
-            value = mueller::rotate_mueller_basis(
-                value, -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
+            F = mueller::rotate_mueller_basis(
+                F, 
+                -wo_hat, p_axis_in, mueller::stokes_basis(-wo_hat),
                 wi_hat, p_axis_out, mueller::stokes_basis(wi_hat));
         } else {
-            value = eval_mishchenko(n_air, n_water, -wo_hat, wi_hat, m_sigma2,
-                                    shadowing)[0][0];
-            value *= Frame3f::cos_theta(wo_hat) * dr::InvPi<Float>;
+            F = 
+                UnpolarizedSpectrum(fresnel_sunglint_polarized(n_air, n_water, -wo_hat, wi_hat)[0][0]);
         }
 
-        return value & active;
+        return result*F & active;
     }
 
     Float pdf(const BSDFContext &ctx, const SurfaceInteraction3f &si,
               const Vector3f &wo, Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFEvaluate, active);
 
+        Float cos_theta_i = Frame3f::cos_theta(si.wi),
+              cos_theta_o = Frame3f::cos_theta(wo);
+
+        Vector3f m = dr::normalize(wo + si.wi);
+
+        active &= cos_theta_i > 0.f && cos_theta_o > 0.f &&
+                  dr::dot(si.wi, m) > 0.f && dr::dot(wo, m) > 0.f;
+
         if (unlikely(!ctx.is_enabled(BSDFFlags::GlossyReflection) ||
                      dr::none_or<false>(active)))
             return 0.f;
 
-        // Check if the normal has only zeros. If this is the case, use a
-        // default normal
-        Vector3f normal   = si.n;
-        Mask degen_normal = dr::all(dr::eq(normal, Vector3f(0.f)));
-        dr::masked(normal, degen_normal) = Vector3f(0.f, 0.f, 1.f);
+        MicrofacetDistribution distr(
+            MicrofacetType::Beckmann,
+            m_sigma, 
+            true
+        );
 
-        Vector3f half    = dr::normalize(si.wi + wo);
-        Float projection = dr::dot(half, normal);
-        Float D          = ((m_shininess + 2.f) /
-                   dr::TwoPi<Float>) *dr::pow(projection, m_shininess);
+        Float pdf = 
+            distr.eval(m) * distr.smith_g1(si.wi, m) / (4.f * cos_theta_i);
 
-        // We multiply the probability of the specular lobe with the pdf of
-        // the Blinn-Phong distribution and the probability of the diffuse lobe
-        // with the pdf of the cosine-weighted hemisphere.
-        Float pdf_specular = (D * projection) / (4.0f * dr::dot(si.wi, half));
-
-        Float pdf = pdf_specular;
-
-        // If the outgoing direction is in the lower hemisphere, we return zero
-        Float cos_theta_o = Frame3f::cos_theta(wo);
-
-        return dr::select(cos_theta_o > 0.f, pdf, 0.f);
-    }
-
-    /**
-     * @brief Evaluate ocean BRDF as implemented by Mishchenko.
-     *
-     * Evaluate the polarized BRDF of the ocean implemented by Mishchenko.
-     * This model accounts for mean square slope probability, polarized
-     * fresnel reflectance, and shadowing.
-     *
-     * @param n_ext Complex index of refraction outside of the medium.
-     * @param n_water Complex index of refraction of the water.
-     * @param wi Incident direction of light (physics convention).
-     * @param wo Outgoing direction of light (physics convention).
-     * @param sigma2 Mean square slope squared.
-     * @param shadowing Flag that indicates the inclusion of shadowing.
-     *
-     * @return Ocean BPDF as a mueller matrix.
-     */
-    MuellerMatrix<UnpolarizedSpectrum> eval_mishchenko(
-        const Complex2u &n_ext, const Complex2u &n_water, 
-        Vector3f wi, Vector3f wo,
-        const Float sigma2, Mask shadowing
-    ) const {
-
-        MuellerMatrix<UnpolarizedSpectrum> F =
-            fresnel_sunglint_polarized(n_ext, n_water, wi, wo);
-
-        Float mu_i = dr::abs(wi.z());
-        Float mu_o = dr::abs(wo.z());
-
-        dr::masked(wi, mu_i > 0.9999999f) =
-            dr::normalize(wi + Vector3f(0.00001f, 0.f, 0.f));
-        dr::masked(wo, mu_o > 0.9999999f) =
-            dr::normalize(wo + Vector3f(0.00001f, 0.f, 0.f));
-        dr::masked(mu_i, mu_i > 0.9999999f) = 0.9999999f;
-        dr::masked(mu_o, mu_o > 0.9999999f) = 0.9999999f;
-
-        // local surface normal k_d
-        const Vector3f k_d    = wi - wo;
-        const Float k_d_norm2 = dr::dot(k_d, k_d);
-
-        // Slope probability distribution (Cox and Munk, 1955)
-        Float coeff =
-            1.f / (dr::pow(k_d.z(), 4.f) * 4.f * mu_i * mu_o * 2.f * sigma2);
-        const Float exp = dr::exp(-(k_d.x() * k_d.x() + k_d.y() * k_d.y()) 
-                                  / (k_d.z() * k_d.z() * 2.f * sigma2));
-        coeff *= exp * (k_d_norm2 * k_d_norm2);
-
-        F = F * coeff;
-
-        // shadowing
-        if (dr::any_or<true>(shadowing)) {
-
-            Float shadow = 1.f / (1.f + gamma_shadowing(mu_i, sigma2) + gamma_shadowing(mu_o, sigma2));
-            dr::masked(F, shadowing) = F * shadow;
-        }
-
-        return F;
-    }
-
-    /**
-     * @brief Shadowing function
-     *
-     * @param mu absolute value of the cosine of theta.
-     * @param sigma2 Mean square slope squared.
-     */
-    Float gamma_shadowing(const Float mu, const Float sigma2) const {
-        Float cot = mu / dr::sqrt(1.f - mu * mu);
-        Float result = 
-            0.5f *
-            (dr::sqrt(2.f * (1.f - mu * mu) / dr::Pi<Float>) 
-             * dr::sqrt(sigma2) / mu 
-             * dr::exp(-cot * cot / (2.f * sigma2)) 
-             - (1.f - dr::erf(cot / dr::sqrt(2.f * sigma2))));
-        return result;
+        return dr::select(active, pdf, 0.f);
     }
 
     std::string to_string() const override {
@@ -417,10 +336,9 @@ private:
     ref<Texture> m_eta;
     ref<Texture> m_k;
     ref<Texture> m_ext_eta;
-    ScalarFloat m_shininess;
     bool m_shadowing;
 
-    ScalarFloat m_sigma2;
+    ScalarFloat m_sigma;
     OceanProperties<Float, Spectrum> m_ocean_props;
 };
 

--- a/src/eradiate_plugins/tests/bsdfs/test_ocean_legacy.py
+++ b/src/eradiate_plugins/tests/bsdfs/test_ocean_legacy.py
@@ -10,17 +10,16 @@ _bsdf_dict = {
     "wind_direction": 90.,
     "chlorinity": 19,
     "pigmentation": 0.3,
-    "shininess": 10.0,
+    "shadowing": False,
 }
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("shininess", [10.0, -1.0])
-def test_chi2_oceanic(variants_vec_backends_once_rgb, shininess):
+def test_chi2_oceanic(variants_vec_backends_once_rgb):
     """
     Test the consistency of the oceanic BSDF using the chi2 test.
     """
-    sample_func, pdf_func = mi.chi2.BSDFAdapter("ocean_legacy", {**_bsdf_dict, "shininess": shininess})
+    sample_func, pdf_func = mi.chi2.BSDFAdapter("ocean_legacy", {**_bsdf_dict, "shadowing": True})
 
     chi2 = mi.chi2.ChiSquareTest(
         domain=mi.chi2.SphericalDomain(),
@@ -89,7 +88,7 @@ def test_traverse_oceanic(variants_vec_backends_once_rgb):
 
     brdf_dr = brdf.eval(ctx, si, wo)
     brdf_np = brdf_dr.numpy()[:, 0]
-    assert dr.allclose(brdf_np, ref_1500_1, 0.001, 0.0001)
+    assert dr.allclose(brdf_np*dr.pi, ref_1500_1, 0.001, 0.0001)
 
     params = mi.traverse(brdf)
 
@@ -99,5 +98,4 @@ def test_traverse_oceanic(variants_vec_backends_once_rgb):
 
     brdf_dr = brdf.eval(ctx, si, wo)
     brdf_np = brdf_dr.numpy()[:, 0]
-
-    assert dr.allclose(brdf_np, ref2_550_30, 0.001, 0.0001)
+    assert dr.allclose(brdf_np*dr.pi, ref2_550_30, 0.001, 0.0001)

--- a/src/render/python/microfacet_v.cpp
+++ b/src/render/python/microfacet_v.cpp
@@ -32,10 +32,14 @@ MI_PY_EXPORT(MicrofacetDistribution) {
             D(MicrofacetDistribution, pdf))
         .def("smith_g1", &MicrofacetDistribution::smith_g1, "v"_a, "m"_a,
             D(MicrofacetDistribution, smith_g1))
+        .def("smith_lambda", &MicrofacetDistribution::smith_lambda, "v"_a, "m"_a,
+            D(MicrofacetDistribution, smith_lambda))
         .def("sample", &MicrofacetDistribution::sample, "wi"_a, "sample"_a,
             D(MicrofacetDistribution, sample))
         .def("G", &MicrofacetDistribution::G, "wi"_a, "wo"_a, "m"_a,
             D(MicrofacetDistribution, G))
+        .def("G_height_correlated", &MicrofacetDistribution::G_height_correlated, "wi"_a, "wo"_a, "m"_a,
+            D(MicrofacetDistribution, G_height_correlated))
         .def("sample_visible_11", &MicrofacetDistribution::sample_visible_11,
             "cos_theta_i"_a, "sample"_a, D(MicrofacetDistribution, sample_visible_11))
         .def_repr(MicrofacetDistribution);

--- a/src/render/python/microfacet_v.cpp
+++ b/src/render/python/microfacet_v.cpp
@@ -10,9 +10,9 @@ MI_PY_EXPORT(MicrofacetDistribution) {
         .def(py::init([](MicrofacetType t, ScalarFloat alpha, bool sv) {
             return MicrofacetDistribution(t, alpha, sv);
         }), "type"_a, "alpha"_a, "sample_visible"_a = true)
-        .def(py::init([](MicrofacetType t, ScalarFloat alpha_u, ScalarFloat alpha_v, bool sv) {
-            return MicrofacetDistribution(t, alpha_u, alpha_v, sv);
-        }), "type"_a, "alpha_u"_a, "alpha_v"_a, "sample_visible"_a = true)
+        .def(py::init([](MicrofacetType t, ScalarFloat alpha_u, ScalarFloat alpha_v, bool sv, ScalarFloat angle) {
+            return MicrofacetDistribution(t, alpha_u, alpha_v, sv, angle);
+        }), "type"_a, "alpha_u"_a, "alpha_v"_a, "sample_visible"_a = true, "angle"_a = 0.f)
         .def(py::init<MicrofacetType, const Float &, bool>(), "type"_a, "alpha"_a,
             "sample_visible"_a = true)
         .def(py::init<MicrofacetType, const Float &, const Float &, bool>(), "type"_a, "alpha_u"_a,
@@ -22,6 +22,7 @@ MI_PY_EXPORT(MicrofacetDistribution) {
         .def_method(MicrofacetDistribution, alpha)
         .def_method(MicrofacetDistribution, alpha_u)
         .def_method(MicrofacetDistribution, alpha_v)
+        .def_method(MicrofacetDistribution, angle)
         .def_method(MicrofacetDistribution, sample_visible)
         .def_method(MicrofacetDistribution, is_anisotropic)
         .def_method(MicrofacetDistribution, is_isotropic)
@@ -32,7 +33,7 @@ MI_PY_EXPORT(MicrofacetDistribution) {
             D(MicrofacetDistribution, pdf))
         .def("smith_g1", &MicrofacetDistribution::smith_g1, "v"_a, "m"_a,
             D(MicrofacetDistribution, smith_g1))
-        .def("smith_lambda", &MicrofacetDistribution::smith_lambda, "v"_a, "m"_a,
+        .def("smith_lambda", &MicrofacetDistribution::smith_lambda, "v"_a,
             D(MicrofacetDistribution, smith_lambda))
         .def("sample", &MicrofacetDistribution::sample, "wi"_a, "sample"_a,
             D(MicrofacetDistribution, sample))


### PR DESCRIPTION
## Description

This PR includes changes to Ocean Legacy and Ocean Mishchenko BRDF models. These changes were prompted by the poor sampling performance of the Ocean Legacy model ported from 6SV which was not built for Monte Carlo integration. 

Investigation in the Cox and Munk slope distribution revealed a key insight: at its core, the distribution is a 2D gaussian analogous to the Beckmann distribution function. It should therefore be possible to find a way to reuse the sampling code from `microfacet.h` to improve our situation. 

Indeed, in the case of the Ocean Mishchenko model, which assumes an isotropic slope distribution and no wind-direction, the `Microfacet` model can be used as is. The only modification required is to add a height correlated shadowing-masking function as done in the original implementation from Mishchenko. Otherwise, this model is actually nearly identical to the `roughconductor` model.

Porting microfacet to Ocean Legacy was a bit more tricky: not only is it anisotropic, but the slope distribution is also rotated by the wind direction, which adds correlation to the mix. Evaluation of the Beckmann function requires to first rotate the half-angle direction by the negative wind-direction in order to have an axis aligned anisotropic distribution. Similarly, sampling the visible distribution first requires to rotate the incoming direction, and unrotate the sampled direction. To achieve this, the `Microfacet` distribution was extended to include an `angle` field that can be used to perform such calculations. By default, the angle is equal to 0. and the rotations will simplify back to the original computations.

Lastly, the original Cox and Munk model expands the 2d gaussian using a Gram-Charlier series which further skews the distribution. This is just an additional coefficient that is multiplied to the original probability distribution, but care must be taken when evaluating it to make sure that we use the correct frame convention. Unfortunately, such a term is not accounted for in our sampling routine, and will therefore decrease the quality of the importance sampling. Still, this remains much better than an hemispherical cosine sampling.

The weights of each components were also revised to have a PDF that matches the evaluated BRDF more closely. The PDF is now : 

$$
\begin{split}
p_{\text{legacy}} &= p_{\text{diff}} + p_{\text{spec}} \\
p_{\text{diff}} &= \rho_{\text{wc}} + (1 - \rho_{\text{wc}})*t_i \\
p_{\text{spec}} &= \frac{ D G_1 }{4 \cos{\theta_i}} 
\end{split}
$$ 

with:
* $\rho_{\text{wc}}$ the whitecap reflectance,
* $t_i$ the fraction of transmitted incoming light in the water body,
* $D$ Beckmann's slope distribution function,
* $G_1$ the smith shadowing term,
* $\theta_i$ the incoming zenith angle.

As a byproduct, much of the plugin has been rewritten to match graphics conventions and now uses vectors rather than angles. This falls more in line with the rest of the kernel. It also does away with OceanUtils which just added a level of indirection and obfuscated the readability of the code. Any functions that were considered useful outside of the scope of Ocean Legacy were moved to `oceanprops.h`.

## Testing

Ocean legacy and Ocean Mishchenko were both validated against the MYSTIC model. The test suite was run accordingly. Further quantitative studies of the sampling improvement remain to be done.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [X] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [X] My changes generate no new warnings
- [X] My code also compiles for `llvm_*` variants. If you can't test this, please leave below
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I cleaned the commit history and removed any "Merge" commits
- [X] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)