### PR TITLE
sensors: Use parent (generic sensor-specific) wavelength sampling routine

### DIFF
--- a/src/eradiate_plugins/sensors/distantflux.cpp
+++ b/src/eradiate_plugins/sensors/distantflux.cpp
@@ -76,7 +76,7 @@ Ray origins are positioned outside of the scene's geometry.
 template <typename Float, typename Spectrum>
 class DistantFluxSensor final : public Sensor<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(Sensor, m_to_world, m_film)
+    MI_IMPORT_BASE(Sensor, m_to_world, m_film, sample_wavelengths)
     MI_IMPORT_TYPES(Scene, Shape)
 
     DistantFluxSensor(const Properties &props) : Base(props) {
@@ -145,7 +145,9 @@ public:
 
         // Sample spectrum
         auto [wavelengths, wav_weight] =
-            sample_wavelength<Float, Spectrum>(wavelength_sample);
+            sample_wavelengths(dr::zeros<SurfaceInteraction3f>(),
+                               wavelength_sample,
+                               active);
         ray.wavelengths = wavelengths;
 
         // Sample ray direction

--- a/src/eradiate_plugins/sensors/hdistant.cpp
+++ b/src/eradiate_plugins/sensors/hdistant.cpp
@@ -172,7 +172,7 @@ radiance is averaged over the targeted geometry.
 template <typename Float, typename Spectrum>
 class HemisphericalDistantSensor final : public Sensor<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(Sensor, m_to_world, m_film)
+    MI_IMPORT_BASE(Sensor, m_to_world, m_film, sample_wavelengths)
     MI_IMPORT_TYPES(Scene, Shape)
 
     HemisphericalDistantSensor(const Properties &props) : Base(props) {
@@ -236,7 +236,9 @@ public:
 
         // Sample spectrum
         auto [wavelengths, wav_weight] =
-            sample_wavelength<Float, Spectrum>(wavelength_sample);
+            sample_wavelengths(dr::zeros<SurfaceInteraction3f>(),
+                               wavelength_sample,
+                               active);
         ray.wavelengths = wavelengths;
 
         // Sample ray direction

--- a/src/eradiate_plugins/sensors/mdistant.cpp
+++ b/src/eradiate_plugins/sensors/mdistant.cpp
@@ -76,7 +76,7 @@ template <typename Float, typename Spectrum>
 class MultiDistantSensor final : public Sensor<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Sensor, m_to_world, m_film, m_needs_sample_2,
-                   m_needs_sample_3)
+                   m_needs_sample_3, sample_wavelengths)
     MI_IMPORT_TYPES(Scene, Shape)
 
     using Matrix = dr::Matrix<Float, Transform4f::Size>;
@@ -188,7 +188,9 @@ public:
 
         // Sample spectrum
         auto [wavelengths, wav_weight] =
-            sample_wavelength<Float, Spectrum>(wavelength_sample);
+            sample_wavelengths(dr::zeros<SurfaceInteraction3f>(),
+                               wavelength_sample,
+                               active);
         ray.wavelengths = wavelengths;
 
         // Select sub-sensor

--- a/src/eradiate_plugins/sensors/mradiancemeter.cpp
+++ b/src/eradiate_plugins/sensors/mradiancemeter.cpp
@@ -71,7 +71,7 @@ the other located at (0, 1, 0) and pointing in the direction (0, -1, 0).
 MI_VARIANT class MultiRadianceMeter final : public Sensor<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Sensor, m_film, m_to_world, m_needs_sample_2,
-                    m_needs_sample_3)
+                    m_needs_sample_3, sample_wavelengths)
     MI_IMPORT_TYPES()
 
     using Matrix = dr::Matrix<Float, Transform4f::Size>;
@@ -153,7 +153,9 @@ public:
 
         // 1. Sample spectrum
         auto [wavelengths, wav_weight] =
-            sample_wavelength<Float, Spectrum>(wavelength_sample);
+            sample_wavelengths(dr::zeros<SurfaceInteraction3f>(),
+                               wavelength_sample,
+                               active);
         ray.wavelengths = wavelengths;
 
         // 2. Set ray origin and direction


### PR DESCRIPTION
Most Eradiate-specific sensor plugins still used the CIE spectrum sampling routine and ignored registered SRFs when using a spectral film. This PR fixes this and ensures all plugins sample wavelengths from a distribution driven by the spectral response functions registered to the film.