### PR TITLE
Fix out-of-sync nodes in tabphase_polarized

### DIFF
--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -81,9 +81,9 @@ function of the cosine of the scattering angle.
  * \brief 1D array defined in terms of an *irregularly* sampled linear
  * interpolant
  *
- * This data structure represents an an array that is defined as a linear
+ * This data structure represents an array that is defined as a linear
  * interpolant of an irregularly discretized signal. The nodes represent
- * the irregular abscissa only which the array is represented.
+ * the irregular abscissa on which the array is represented.
  *
  * Notes: The data array can be different types as long as they are laid out in
  * a contiguous array of Float. The templated Value will specify the output
@@ -122,7 +122,6 @@ public:
         update();
 
     }
-
 
     /// Update the internal state. Must be invoked when changing the data or
     /// range.
@@ -348,7 +347,7 @@ public:
 
         Spectrum phase_val(0.f);
 
-        // Use m11 for the for the phase and pdf since it is used for sampling
+        // Use m11 for the phase and PDF since it is used for sampling
         // cos theta.
         Float m11      = m_m11.eval_pdf(cos_theta, active);
         Float m11_norm = m_m11.normalization();
@@ -403,12 +402,12 @@ public:
         cb->put("m34", m_mvec.data(3), ParamFlags::NonDifferentiable);
         cb->put("m44", m_mvec.data(4), ParamFlags::NonDifferentiable);
         cb->put("nodes", m_m11.nodes(), ParamFlags::NonDifferentiable);
-        cb->put("nodes", m_mvec.nodes(), ParamFlags::NonDifferentiable);
     }
 
     void
     parameters_changed(const std::vector<std::string> & /*keys*/) override {
         m_m11.update();
+        m_mvec.nodes() = m_m11.nodes();
         m_mvec.update();
     }
 

--- a/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
+++ b/src/eradiate_plugins/tests/phase/test_tabphase_polarized.py
@@ -1,4 +1,3 @@
-import pytest
 import drjit as dr
 import mitsuba as mi
 
@@ -206,10 +205,6 @@ def test_traverse(variant_scalar_mono_polarized):
     # Phase function table definition
     import numpy as np
 
-    ref_y = np.array([0.5, 1.0, 1.5])
-    ref_x = np.linspace(-1, 1, len(ref_y))
-    ref_integral = np.trapz(ref_y, ref_x)
-
     # Initialise as isotropic and update with parameters
     phase = mi.load_dict(
         {
@@ -241,7 +236,14 @@ def test_traverse(variant_scalar_mono_polarized):
     assert dr.allclose(params["m34"], [0.5, 1.0, 1.5])
     assert dr.allclose(params["nodes"], [-1.0, 0.5, 1.0])
 
+    # PDF and interpolator nodes are synced
+    assert "nodes = [-1, 0.5, 1]" in str(phase), f"{phase = }"
+
     # The plugin itself evaluates consistently
+    ref_y = np.array([0.5, 1.0, 1.5])
+    ref_x = np.array([-1, 0.5, 1])
+    ref_integral = np.trapezoid(ref_y, ref_x)
+
     ctx = mi.PhaseFunctionContext(None)
     mei = mi.MediumInteraction3f()
     mei.wi = np.array([0, 0.0000000001, -0.999999999])
@@ -262,4 +264,3 @@ def test_traverse(variant_scalar_mono_polarized):
     print(ref)
 
     assert dr.allclose(phase.eval_pdf(ctx, mei, wo)[0], ref, rtol=1e-5, atol=1e-6)
-


### PR DESCRIPTION
## Description

This commit fixes a bug where the node arrays of the encapsulated 1D distribution and interpolator would not synchronize properly when updated. This was not an issue with Eradiate's Aer v1 aerosol format, which has a fixed angular grid, but manifests as a bug with the new Aer-Core v2 format, which adapts angular sampling depending on the wavelength.

The fix simply makes sure that the updated node array is propagated to the interpolator.

## Testing

Existing unit tests pass. In addition, node values, displayed by the string repr of the instantiated plugin, are checked as well.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [ ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)