### PR TITLE
Refactor `EOVolpath` and extremum structures, add residual ratio tracking.

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -10519,6 +10519,15 @@ default implementation throws an exception.
 Even if the operation is provided, it may only return an
 approximation.)doc";
 
+static const char *__doc_mitsuba_Texture_min =
+R"doc(Return the maximum value of the spectrum
+
+Not every implementation necessarily provides this function. The
+default implementation throws an exception.
+
+Even if the operation is provided, it may only return an
+approximation.)doc";
+
 static const char *__doc_mitsuba_Texture_pdf_position = R"doc(Returns the probability per unit area of sample_position())doc";
 
 static const char *__doc_mitsuba_Texture_pdf_spectrum =
@@ -10643,6 +10652,56 @@ static const char *__doc_mitsuba_Timer_reset = R"doc()doc";
 static const char *__doc_mitsuba_Timer_start = R"doc()doc";
 
 static const char *__doc_mitsuba_Timer_value = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimator = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimatorType = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimatorType_RatioTracking = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimatorType_ResidualRatioTracking = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimator_estimator = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimator_ratio_tracking = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimator_residual_ratio_tracking = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingEstimator_transmittance = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_TrackingState = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_TrackingState_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_TrackingState_3 = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_fields = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_fields_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_labels = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_medium = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_name = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_operator_assign = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_operator_assign_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_ray = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_sampler = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_target_ot = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_tau_acc = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_transmittance_one = R"doc()doc";
+
+static const char *__doc_mitsuba_TrackingState_transmittance_two = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform =
 R"doc(Unified homogeneous coordinate transformation
@@ -10939,6 +10998,10 @@ static const char *__doc_mitsuba_VolumeGrid_m_max = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_m_max_per_channel = R"doc()doc";
 
+static const char *__doc_mitsuba_VolumeGrid_m_min = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeGrid_m_min_per_channel = R"doc()doc";
+
 static const char *__doc_mitsuba_VolumeGrid_m_size = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_max = R"doc(Return the precomputed maximum over the volume grid)doc";
@@ -10948,12 +11011,26 @@ R"doc(Return the precomputed maximum over the volume grid per channel
 
 Pointer allocation/deallocation must be performed by the caller.)doc";
 
+static const char *__doc_mitsuba_VolumeGrid_min = R"doc(Return the precomputed minimum over the volume grid)doc";
+
+static const char *__doc_mitsuba_VolumeGrid_min_per_channel =
+R"doc(Return the precomputed minimum over the volume grid per channel
+
+Pointer allocation/deallocation must be performed by the caller.)doc";
+
 static const char *__doc_mitsuba_VolumeGrid_read = R"doc()doc";
 
 static const char *__doc_mitsuba_VolumeGrid_set_max = R"doc(Set the precomputed maximum over the volume grid)doc";
 
 static const char *__doc_mitsuba_VolumeGrid_set_max_per_channel =
 R"doc(Set the precomputed maximum over the volume grid per channel
+
+Pointer allocation/deallocation must be performed by the caller.)doc";
+
+static const char *__doc_mitsuba_VolumeGrid_set_min = R"doc(Set the precomputed minimum over the volume grid)doc";
+
+static const char *__doc_mitsuba_VolumeGrid_set_min_per_channel =
+R"doc(Set the precomputed minimum over the volume grid per channel
 
 Pointer allocation/deallocation must be performed by the caller.)doc";
 
@@ -11066,6 +11143,14 @@ static const char *__doc_mitsuba_Volume_max = R"doc(Returns the maximum value of
 static const char *__doc_mitsuba_Volume_max_per_channel =
 R"doc(In the case of a multi-channel volume, this function returns the
 maximum value for each channel.
+
+Pointer allocation/deallocation must be performed by the caller.)doc";
+
+static const char *__doc_mitsuba_Volume_min = R"doc(Returns the minimum value of the volume over all dimensions.)doc";
+
+static const char *__doc_mitsuba_Volume_min_per_channel =
+R"doc(In the case of a multi-channel volume, this function returns the
+minimum value for each channel.
 
 Pointer allocation/deallocation must be performed by the caller.)doc";
 

--- a/include/mitsuba/render/eradiate/extremum.h
+++ b/include/mitsuba/render/eradiate/extremum.h
@@ -33,7 +33,13 @@ public:
 
     /**
      * \brief Traverse the extremum along a ray and applies a callback at each
-     * encountered segment.         .
+     * encountered segment.
+     * 
+     * This method traverses the extremum structure segment by segment. At each
+     * segment, the callback ``func`` is called to advance the ``state``. This
+     * is useful for example to implement Delta Tracking, Ratio Tracking, and
+     * Residual Ratio Tracking. The callback is typically defined in the
+     * integrator.
      *
      * \param ray           Ray along which to sample
      * \param mint          Minimum distance to consider
@@ -62,6 +68,7 @@ public:
         Mask active = true
     ) const;
 
+    // Note: this is currently dead code. It is kept in case it is needed in the future.
     /**
      * \brief Evaluate the minorant and majorant at a medium interaction point.
      *
@@ -75,8 +82,6 @@ public:
      *      The minorant and majorant values at the medium interaction point.
      *      Clamped values outside bounds.
      * 
-     * Note: this is currently dead code. It is kept in case it is needed in the
-     * future.
      */
     virtual std::tuple<Float, Float> eval_1(
         const Interaction3f & it,

--- a/include/mitsuba/render/eradiate/extremum.h
+++ b/include/mitsuba/render/eradiate/extremum.h
@@ -4,6 +4,7 @@
 #include <mitsuba/render/interaction.h>
 #include <mitsuba/render/volume.h>
 #include <mitsuba/render/eradiate/extremum_segment.h>
+#include <mitsuba/render/eradiate/tracking.h>
 #include <drjit/call.h>
 
 NAMESPACE_BEGIN(mitsuba)
@@ -15,7 +16,7 @@ NAMESPACE_BEGIN(mitsuba)
  * store local extrema (majorant/minorant) of volumetric extinction coefficients.
  * This enables efficient delta tracking with locally-adaptive majorants.
  *
- * To minimize virtual function overhead, the ``sample_segment()`` method 
+ * To minimize virtual function overhead, the ``traverse_extremum()`` method 
  * encapsulates the entire traversal loop internally, requiring only a single
  * virtual call per distance sample.
  */
@@ -24,36 +25,42 @@ class MI_EXPORT_LIB ExtremumStructure : public JitObject<ExtremumStructure<Float
 public:
     MI_IMPORT_TYPES(Medium, Sampler)
 
+    using TrackingState    = TrackingState<Float, Spectrum>;
+    using TrackingFunction = TrackingFunction<Float, Spectrum>;
+
     /// Destructor
     ~ExtremumStructure();
 
     /**
-     * \brief Sample a segment along a ray with desired optical thickness
-     *
-     * This method traverses the extremum structure (e.g., via DDA for grids)
-     * and returns a segment where the accumulated optical thickness reaches the
-     * desired value. The traversal logic is completely encapsulated within
-     * this method to minimize virtual call overhead.
+     * \brief Traverse the extremum along a ray and applies a callback at each
+     * encountered segment.         .
      *
      * \param ray           Ray along which to sample
      * \param mint          Minimum distance to consider
      * \param maxt          Maximum distance to consider
-     * \param target_ot     Target optical thickness to accumulate
+     * \param channel       Channel from which to sample
+     * \param state         Mutable tracking state carried through the traversal loop
+     * \param func          Callback function called at every segment.
      * \param active        Mask for active lanes
      *
      * \return 
-     *      ExtremumSegment containing the sampled distance (mint), segment
-     *      bounds, and local majorant/minorant values. If desired_tau cannot
-     *      be reached, mint is set to Infinity.
-     *      Accumulated optical thickness at segment start.
+     *      The final tracking state, that includes the medium interaction if 
+     *      a real scattering event was sampled, and the throughput and pdfs
+     *      accumulated throughout the traversal.
+     * 
+     * Note that this function cannot be made abstract because of it would
+     * force the requirement for bindings, which are incompatible with 
+     * function types.
      */
-    virtual std::tuple<ExtremumSegment, Float> sample_segment(
+    virtual TrackingState traverse_extremum(
         const Ray3f &ray,
         Float mint,
         Float maxt,
-        Float target_ot,
+        UInt32 channel,
+        TrackingState state,
+        TrackingFunction *func,
         Mask active = true
-    ) const = 0;
+    ) const;
 
     /**
      * \brief Evaluate the minorant and majorant at a medium interaction point.
@@ -64,8 +71,12 @@ public:
      * \param it            Interaction interaction point in local space
      * \param active        Mask for active lanes
      *
-     * \return The minorant and majorant values at the medium interaction point.
-     *         Clamped values outside bounds.
+     * \return 
+     *      The minorant and majorant values at the medium interaction point.
+     *      Clamped values outside bounds.
+     * 
+     * Note: this is currently dead code. It is kept in case it is needed in the
+     * future.
      */
     virtual std::tuple<Float, Float> eval_1(
         const Interaction3f & it,
@@ -100,7 +111,7 @@ NAMESPACE_END(mitsuba)
 // -----------------------------------------------------------------------
 
 DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::ExtremumStructure)
-    DRJIT_CALL_METHOD(sample_segment)
+    DRJIT_CALL_METHOD(traverse_extremum)
     DRJIT_CALL_METHOD(eval_1)
 DRJIT_CALL_END()
 

--- a/include/mitsuba/render/eradiate/extremum_segment.h
+++ b/include/mitsuba/render/eradiate/extremum_segment.h
@@ -71,12 +71,12 @@ struct ExtremumSegment {
     }
 
     /// Minorant value over the segment. Accessor to the first element of ``value``.
-    Float minorant() {
+    MI_INLINE Float minorant() const {
         return value.x();
     }
 
     /// Majorant value over the segment. Accessor to the second element of ``value``.
-    Float majorant() {
+    MI_INLINE Float majorant() const {
         return value.y();
     }
 

--- a/include/mitsuba/render/eradiate/tracking.h
+++ b/include/mitsuba/render/eradiate/tracking.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <mitsuba/render/fwd.h>
+#include <mitsuba/render/eradiate/extremum_segment.h>
+#include <drjit/random.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**
+ * \brief State carried through extremum traversal to accumulate the throughput 
+ * and its PDF.
+ * 
+ * Can be used to for delta tracking, ratio tracking, and residual ratio tracking.
+ * Note that a seperate ``rng`` is used as the number of required samples is 
+ * different for all samples.
+ * 
+ * Note that ``throughput`` is shared between algorithm and should be accumulated
+ * accordingly. If used for volpathmis, new members and data types will need to 
+ * be introduced.
+ */
+template< typename Float, typename Spectrum >
+struct TrackingState {
+    MI_IMPORT_TYPES()
+
+    Ray3f ray;
+    dr::PCG32<UInt32> rng;
+    MediumInteraction3f mei;
+    UnpolarizedSpectrum throughput;
+
+    DRJIT_STRUCT(TrackingState, ray, rng, mei, throughput)
+};
+
+/**
+ * \brief Signature of the tracking function callback accepted by 
+ * ``ExtremumStructures::traverse_extremum``.
+ * 
+ * \param segment
+ *      An extremum segment along a ray.
+ * \param state
+ *      The tracking state that holds interaction information and accumulates 
+ *      throughput and pdfs.
+ * \param channel
+ *      The channel to use for sampling.
+ * \param active
+ *      Represents the active lanes.
+ * 
+ * 
+ * \return A pair (advance, active):
+ *      advance:    If true, tracking has exited the segment and requires a
+ *                  new one. If false, repeat the loop with the same segment.
+ *      active:     Represent active lanes. Lanes that have sample a real 
+ *                  interaction or terminated for other reasons will return 
+ *                  ``false``, prompting the termination of the traversal.
+ */
+template< typename Float, typename Spectrum >
+using TrackingFunction = 
+    std::pair<dr::mask_t<Float>, dr::mask_t<Float>>(
+    const ExtremumSegment<Float, Spectrum>& /*segment*/,
+    TrackingState<Float, Spectrum>& /*state*/,
+    const dr::uint32_array_t<Float>& /*channel*/, 
+    dr::mask_t<Float> /*active*/
+);
+
+/// Helper function to index the channel of an ``UnpolarizedSpectrum``. 
+template< typename Float, typename Spectrum >
+MI_INLINE
+Float index_spectrum(
+    const unpolarized_spectrum_t<Spectrum> &spec, 
+    const dr::uint32_array_t<Float> &idx
+) {
+    Float m = spec[0];
+    if constexpr (is_rgb_v<Spectrum>) { // Handle RGB rendering
+        dr::masked(m, idx == 1u) = spec[1];
+        dr::masked(m, idx == 2u) = spec[2];
+    } else {
+        DRJIT_MARK_USED(idx);
+    }
+    return m;
+}
+
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/eradiate/tracking.h
+++ b/include/mitsuba/render/eradiate/tracking.h
@@ -11,12 +11,9 @@ NAMESPACE_BEGIN(mitsuba)
  * and its PDF.
  * 
  * Can be used to for delta tracking, ratio tracking, and residual ratio tracking.
- * Note that a seperate ``rng`` is used as the number of required samples is 
- * different for all samples.
+ * Note: Since the number of required dimensions is different for all pixel 
+ * samples, ``rng`` is used to sample distances and event types.
  * 
- * Note that ``throughput`` is shared between algorithm and should be accumulated
- * accordingly. If used for volpathmis, new members and data types will need to 
- * be introduced.
  */
 template< typename Float, typename Spectrum >
 struct TrackingState {
@@ -25,9 +22,17 @@ struct TrackingState {
     Ray3f ray;
     dr::PCG32<UInt32> rng;
     MediumInteraction3f mei;
+    Float target_ot;
+    Mask use_rrt;
+    Mask has_spectral_extinction;
+
+    // Note that ``throughput`` is shared between algorithm and should be accumulated
+    // accordingly. If used for volpathmis, new members and data types will need to 
+    // be introduced.
     UnpolarizedSpectrum throughput;
 
-    DRJIT_STRUCT(TrackingState, ray, rng, mei, throughput)
+    DRJIT_STRUCT(TrackingState, ray, rng, mei, target_ot, use_rrt, \
+        has_spectral_extinction, throughput)
 };
 
 /**
@@ -48,7 +53,7 @@ struct TrackingState {
  * \return A pair (advance, active):
  *      advance:    If true, tracking has exited the segment and requires a
  *                  new one. If false, repeat the loop with the same segment.
- *      active:     Represent active lanes. Lanes that have sample a real 
+ *      active:     Represent active lanes. Lanes that have sampled a real 
  *                  interaction or terminated for other reasons will return 
  *                  ``false``, prompting the termination of the traversal.
  */

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -25,6 +25,11 @@ public:
     get_majorant(const MediumInteraction3f &mi,
                  Mask active = true) const = 0;
 
+    /// Returns the medium's minorant used for residual ratio tracking
+     virtual UnpolarizedSpectrum
+     get_minorant(const MediumInteraction3f &/*mi*/,
+                  Mask /*active*/ = true) const { return UnpolarizedSpectrum(0.f); }
+
     /// Returns the medium coefficients Sigma_s, Sigma_n and Sigma_t evaluated
     /// at a given MediumInteraction mi
     virtual std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum,
@@ -100,15 +105,22 @@ public:
         return m_has_spectral_extinction;
     }
 
-// #ERADIATE_CHANGE_BEGIN: Extremum structure accessor
-    /// Returns the extremum structure for local majorant acceleration (nullptr if not used)
-    MI_INLINE const ExtremumStructure* extremum_structure() const {
+// #ERADIATE_CHANGE_BEGIN: Extremum Structure accessor and traversal helpers
+    std::tuple<MediumInteraction3f, Float, Float> 
+    prepare_medium_traversal(const Ray3f& ray, Mask active) const;
+
+    /// Returns the extremum structure for local extremum acceleration.
+    MI_INLINE const ExtremumStructure *extremum_structure() const {
         return m_extremum_structure.get();
     }
 
     /// Check if medium uses extremum structure
     MI_INLINE bool has_extremum_structure() const {
         return m_extremum_structure.get() != nullptr;
+    }
+
+    MI_INLINE bool use_rrt() const {
+        return m_use_rrt;
     }
 // #ERADIATE_CHANGE_END
 
@@ -129,8 +141,8 @@ protected:
     bool m_is_homogeneous;
     bool m_has_spectral_extinction;
 // #ERADIATE_CHANGE_BEGIN: Extremum structure support
-    bool m_has_local_extremum;
     ref<ExtremumStructure> m_extremum_structure;
+    bool m_use_rrt;
 // #ERADIATE_CHANGE_END
 
     MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure)
@@ -156,6 +168,10 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(sample_interaction_real)
     DRJIT_CALL_METHOD(eval_transmittance_pdf_real)
     DRJIT_CALL_METHOD(get_scattering_coefficients)
+    
+    DRJIT_CALL_GETTER(use_rrt)
+    DRJIT_CALL_GETTER(extremum_structure)
+    DRJIT_CALL_METHOD(prepare_medium_traversal)
 DRJIT_CALL_END()
 
 //! @}

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -106,6 +106,18 @@ public:
     }
 
 // #ERADIATE_CHANGE_BEGIN: Extremum Structure accessor and traversal helpers
+    /**
+     * \brief Intersects ray with the medium bbox and creates a medium interaction.
+     * 
+     * \param ray   The ray that is used to test the medium bbox.
+     *       
+     * \return
+     *      A tuple (mei, mint, maxt): ``mei`` is a  ``MediumInteraction3f``
+     *      object initialized with the current ray and medium data. ``mint`` 
+     *      and ``maxt`` represent the minimum and maximum intersection 
+     *      distances of the ray with the medium's bbox. In case there are no
+     *      valid intersection, the range defaults to [0, +Inf].
+     */
     std::tuple<MediumInteraction3f, Float, Float> 
     prepare_medium_traversal(const Ray3f& ray, Mask active) const;
 

--- a/include/mitsuba/render/texture.h
+++ b/include/mitsuba/render/texture.h
@@ -207,6 +207,18 @@ public:
      */
     virtual ScalarFloat max() const;
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    /**
+     * Return the maximum value of the spectrum
+     *
+     * Not every implementation necessarily provides this function. The default
+     * implementation throws an exception.
+     *
+     * Even if the operation is provided, it may only return an approximation.
+     */
+    virtual ScalarFloat min() const;
+// #ERADIATE_CHANGE_END
+
     //! @}
     // ======================================================================
 
@@ -247,5 +259,6 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Texture)
     DRJIT_CALL_METHOD(mean)
 
     DRJIT_CALL_GETTER(max)
+    DRJIT_CALL_GETTER(min)
     DRJIT_CALL_GETTER(is_spatially_varying)
 DRJIT_CALL_END()

--- a/include/mitsuba/render/volume.h
+++ b/include/mitsuba/render/volume.h
@@ -62,6 +62,19 @@ public:
      */
     virtual void max_per_channel(ScalarFloat *out) const;
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    /// Returns the minimum value of the volume over all dimensions.
+    virtual ScalarFloat min() const;
+
+    /**
+     * \brief In the case of a multi-channel volume, this function returns
+     * the minimum value for each channel.
+     *
+     * Pointer allocation/deallocation must be performed by the caller.
+     */
+    virtual void min_per_channel(ScalarFloat *out) const;
+// #ERADIATE_CHANGE_END
+
 // #ERADIATE_CHANGE_BEGIN: Local extremum support
     /**
      * \brief Compute local extrema over a spatial region

--- a/include/mitsuba/render/volumegrid.h
+++ b/include/mitsuba/render/volumegrid.h
@@ -82,6 +82,32 @@ public:
             m_max_per_channel[i] = max[i];
     }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    /// Return the precomputed minimum over the volume grid
+    ScalarFloat min() const { return m_min; }
+
+    /**
+     * \brief Return the precomputed minimum over the volume grid per channel
+     *
+     * Pointer allocation/deallocation must be performed by the caller.
+     */
+    void min_per_channel(ScalarFloat *out) const;
+
+    /// Set the precomputed minimum over the volume grid
+    void set_min(ScalarFloat min) { m_min = min; }
+
+    /**
+     * \brief Set the precomputed minimum over the volume grid per channel
+     *
+     * Pointer allocation/deallocation must be performed by the caller.
+     */
+    void set_min_per_channel(ScalarFloat *min) {
+        for (size_t i=0; i<m_channel_count; ++i)
+            m_min_per_channel[i] = min[i];
+    }
+// #ERADIATE_CHANGE_END
+
+
     /// Return the number bytes of storage used per voxel
     size_t bytes_per_voxel() const { return sizeof(ScalarFloat) * channel_count(); }
 
@@ -120,6 +146,10 @@ protected:
     ScalarBoundingBox3f m_bbox;
     ScalarFloat m_max;
     std::vector<ScalarFloat> m_max_per_channel;
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat m_min;
+    std::vector<ScalarFloat> m_min_per_channel;
+// #ERADIATE_CHANGE_END
 
     MI_TRAVERSE_CB(Object)
 };

--- a/src/eradiate_plugins/extremum/CMakeLists.txt
+++ b/src/eradiate_plugins/extremum/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MI_PLUGIN_PREFIX "extremumstructure")
 
-# #ERADIATE_CHANGE: Add extremum_grid plugin for local majorant acceleration
 add_plugin(extremum_grid extremum_grid.cpp)
 add_plugin(extremum_spherical extremum_spherical.cpp)
+add_plugin(extremum_global extremum_global.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/extremum/extremum_global.cpp
+++ b/src/eradiate_plugins/extremum/extremum_global.cpp
@@ -1,0 +1,147 @@
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/plugin.h>
+#include <mitsuba/render/medium.h>
+#include <mitsuba/render/eradiate/extremum.h>
+#include <mitsuba/render/volume.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+.. _extremum-extremum_grid:
+
+Extremum global structure (:monosp:`extremum_global`)
+-------------------------------------------------
+
+.. pluginparameters::
+
+ * - volume
+   - |volume|
+   - Extinction coefficient volume to build extremum grid from
+   - |exposed|
+
+ * - scale
+   - |float|
+   - Scale factor for the extremum values (Default: 1.0).
+
+This plugin holds the global minorant and majorant values of a volume.
+At runtime, traversal is performed via a single segment determined by the 
+passed ``mint`` and ``maxt`` values.
+*/
+
+template <typename Float, typename Spectrum>
+class ExtremumGlobal final : public ExtremumStructure<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(ExtremumStructure, m_bbox)
+    MI_IMPORT_TYPES(Volume)
+
+    using TrackingState    = TrackingState<Float, Spectrum>;
+    using TrackingFunction = TrackingFunction<Float, Spectrum>;
+
+    ExtremumGlobal(const Properties &props) : Base(props) {
+        // Volume Parameters
+        m_volume = nullptr;
+        for (auto &prop : props.objects()) {
+            if (auto *vol = prop.try_get<Volume>()) {
+                m_volume = vol;
+                break;
+            }
+        }
+
+        if (!m_volume)
+            Throw("ExtremumGlobal requires at least one volume");
+        
+        // Register the extremum structure to the volume to trigger 
+        // parameter_changed when the volume is modified.
+        m_volume->add_extremum_structure(this);
+        m_scale = props.get<ScalarFloat>("scale", 1.0f);
+        m_bbox = m_volume->bbox();
+
+        m_majorant = m_volume->max();
+        m_minorant = m_volume->min();
+    }
+
+    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
+        m_bbox = m_volume->bbox();
+        m_majorant = m_volume->max();
+        m_minorant = m_volume->min();
+    }
+
+
+    TrackingState traverse_extremum(
+        const Ray3f &ray,
+        Float mint,
+        Float maxt,
+        UInt32 channel,
+        TrackingState state,
+        TrackingFunction* func,
+        Mask active
+    ) const override {
+
+        // Clip the tracking interval to the volume's bounding box so that
+        // get_scattering_coefficients is never queried outside the volume's
+        // domain.  This matters when the containing shape is larger than the
+        // volume (the medium's AABB != the volume's AABB).
+        auto [bbox_hit, bbox_mint, bbox_maxt] = m_bbox.ray_intersect(ray);
+        mint  = dr::maximum(mint,  bbox_mint);
+        maxt  = dr::minimum(maxt,  bbox_maxt);
+        active &= bbox_hit && (mint < maxt);
+
+        ExtremumSegment segment(mint, maxt, m_scale*m_minorant, m_scale*m_majorant);
+
+        struct LoopState {
+            ExtremumSegment segment;
+            TrackingState state;
+            Mask advance;
+            Mask active;
+
+            DRJIT_STRUCT(LoopState, segment, state, advance, active)
+        } ls {
+            segment,
+            state,
+            /*advance =*/true,
+            active
+        };
+
+        dr::tie(ls) = dr::while_loop(
+        dr::make_tuple(ls),
+        [](const LoopState &ls){ return ls.active; },
+        [func, channel](LoopState &ls){
+            std::tie(ls.advance, ls.active) = 
+                func(ls.segment, ls.state, channel, ls.active);
+            ls.active &= !ls.advance;
+        });
+
+        return ls.state;
+    }
+
+    std::tuple<Float, Float> eval_1(const Interaction3f &/*it*/,
+                                    Mask /*active*/) const override {
+
+        return { m_scale*m_minorant, m_scale*m_majorant };
+    }
+
+    void traverse(TraversalCallback *cb) override {
+        Base::traverse(cb);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "ExtremumGlobal[" << std::endl
+            << "  minorant = " << m_minorant << "," << std::endl
+            << "  majorant = " << m_majorant << "," << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS(ExtremumGlobal)
+
+private:
+    ref<Volume> m_volume;
+    ScalarFloat m_scale;
+
+    ScalarFloat m_minorant;
+    ScalarFloat m_majorant;
+};
+
+MI_EXPORT_PLUGIN(ExtremumGlobal)
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/extremum/extremum_global.cpp
+++ b/src/eradiate_plugins/extremum/extremum_global.cpp
@@ -10,7 +10,7 @@ NAMESPACE_BEGIN(mitsuba)
 .. _extremum-extremum_grid:
 
 Extremum global structure (:monosp:`extremum_global`)
--------------------------------------------------
+-----------------------------------------------------
 
 .. pluginparameters::
 
@@ -53,7 +53,7 @@ public:
         // Register the extremum structure to the volume to trigger 
         // parameter_changed when the volume is modified.
         m_volume->add_extremum_structure(this);
-        m_scale = props.get<ScalarFloat>("scale", 1.0f);
+        m_scale = props.get<ScalarFloat>("scale", 1.f);
         m_bbox = m_volume->bbox();
 
         m_majorant = m_volume->max();
@@ -68,7 +68,7 @@ public:
 
 
     TrackingState traverse_extremum(
-        const Ray3f &ray,
+        const Ray3f &/*ray*/,
         Float mint,
         Float maxt,
         UInt32 channel,
@@ -76,16 +76,6 @@ public:
         TrackingFunction* func,
         Mask active
     ) const override {
-
-        // Clip the tracking interval to the volume's bounding box so that
-        // get_scattering_coefficients is never queried outside the volume's
-        // domain.  This matters when the containing shape is larger than the
-        // volume (the medium's AABB != the volume's AABB).
-        auto [bbox_hit, bbox_mint, bbox_maxt] = m_bbox.ray_intersect(ray);
-        mint  = dr::maximum(mint,  bbox_mint);
-        maxt  = dr::minimum(maxt,  bbox_maxt);
-        active &= bbox_hit && (mint < maxt);
-
         ExtremumSegment segment(mint, maxt, m_scale*m_minorant, m_scale*m_majorant);
 
         struct LoopState {

--- a/src/eradiate_plugins/extremum/extremum_grid.cpp
+++ b/src/eradiate_plugins/extremum/extremum_grid.cpp
@@ -1,5 +1,6 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/plugin.h>
+#include <mitsuba/render/medium.h>
 #include <mitsuba/render/eradiate/extremum.h>
 #include <mitsuba/render/volume.h>
 #include <mitsuba/render/volumegrid.h>
@@ -49,6 +50,8 @@ public:
     MI_IMPORT_BASE(ExtremumStructure, m_bbox)
     MI_IMPORT_TYPES(Volume)
 
+    using TrackingState    = TrackingState<Float, Spectrum>;
+    using TrackingFunction = TrackingFunction<Float, Spectrum>;
     using FloatStorage = DynamicBuffer<Float>;
 
     ExtremumGrid(const Properties &props) : Base(props) {
@@ -91,52 +94,25 @@ public:
         build_grid(m_volume.get(), m_resolution);
     }
 
-    std::tuple<ExtremumSegment, Float> sample_segment(
+
+    TrackingState traverse_extremum(
         const Ray3f &ray,
-        Float mint, 
+        Float mint,
         Float maxt,
-        Float target_ot,
+        UInt32 channel,
+        TrackingState state,
+        TrackingFunction* func,
         Mask active
     ) const override {
-        ExtremumSegment segment = dr::zeros<ExtremumSegment>();
-
-        struct DeltaTrackingState {
-            ExtremumSegment segment;
-            Float target_ot;
-            Float ot_acc;
-            DRJIT_STRUCT(DeltaTrackingState, segment, target_ot, ot_acc)
-        } state {
-            segment,
-            target_ot,
-            /*ot_acc =*/0.f
-        };
-
-        // if this works then we will be able to move this outside of the grid code
-        auto func = [](
-            ExtremumSegment& segment, 
-            DeltaTrackingState& state, 
-            Mask& /*advance*/,
-            Mask& active
-        ){
-            Float dt = segment.maxt - segment.mint;
-            Float next_ot = dr::fmadd(segment.majorant(), dt, state.ot_acc);
-            Mask exit = next_ot >= state.target_ot;
-            // update variables
-            dr::masked(state.segment, active &&  exit) = segment;
-            dr::masked(state.ot_acc, active && !exit) = next_ot;
-            active &= !exit;
-        };
-
-        state = traverse_dda(
+        return traverse_dda(
             func,
             state,
             ray,
             mint,
             maxt,
+            channel,
             active
         );
-
-        return {state.segment, state.ot_acc};
     }
 
     std::tuple<Float, Float> eval_1(const Interaction3f &it,
@@ -166,7 +142,7 @@ public:
         return oss.str();
     }
 
-    MI_DECLARE_CLASS(ExtremumStructure)
+    MI_DECLARE_CLASS(ExtremumGrid)
 
 private:
 
@@ -392,6 +368,7 @@ private:
         const Ray3f& ray, 
         Float mint,
         Float maxt,
+        UInt32 channel,
         Mask active
     ) const {
         using StateD = std::decay_t<StateT>;
@@ -476,7 +453,7 @@ private:
         dr::tie(ls) = dr::while_loop(
             dr::make_tuple(ls),
             [](const LoopState& ls) { return ls.active; },
-            [this, func, step, abs_rcp_d, t_max, mint](LoopState& ls) {
+            [this, func, step, abs_rcp_d, t_max, mint, channel](LoopState& ls) {
             
             ExtremumSegment& segment = ls.segment;
             StateD& state = ls.state;
@@ -506,10 +483,10 @@ private:
                 extremum
             );
 
-            func( segment, state, advance, active);
+            std::tie(advance, active) = func( segment, state, channel, active);
 
             // Advance
-            dt_v = dr::select(mask, abs_rcp_d, dt_v - dt);
+            dr::masked(dt_v, advance) = dr::select(mask, abs_rcp_d, dt_v - dt);
             dr::masked(pi, mask && advance) += step;
             dr::masked(t_rem, advance) -= dt;
 

--- a/src/eradiate_plugins/extremum/extremum_spherical.cpp
+++ b/src/eradiate_plugins/extremum/extremum_spherical.cpp
@@ -110,7 +110,6 @@ public:
     TrackingState traverse_extremum(const Ray3f &, Float, Float, UInt32, 
                     TrackingState, TrackingFunction*, Mask) const override {
         NotImplementedError("traverse_extremum");
-        return TrackingState();
     }
 
     std::tuple<Float, Float> eval_1(const Interaction3f &,

--- a/src/eradiate_plugins/extremum/extremum_spherical.cpp
+++ b/src/eradiate_plugins/extremum/extremum_spherical.cpp
@@ -1,5 +1,6 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/plugin.h>
+#include <mitsuba/render/medium.h>
 #include <mitsuba/render/eradiate/extremum.h>
 #include <mitsuba/render/volume.h>
 #include <mitsuba/render/volumegrid.h>
@@ -62,6 +63,9 @@ public:
     MI_IMPORT_BASE(ExtremumStructure, m_bbox)
     MI_IMPORT_TYPES(Volume)
 
+    using TrackingState    = TrackingState<Float, Spectrum>;
+    using TrackingFunction = TrackingFunction<Float, Spectrum>;
+
     ExtremumSpherical(const Properties &props) : Base(props), m_props(props) {
         ScalarVector3i resolution = props.get<ScalarVector3i>("resolution", ScalarVector3i(1, 1, 1));
 
@@ -103,10 +107,10 @@ public:
     }
 
     // Stub overrides — never called, expand() replaces this object
-    std::tuple<ExtremumSegment, Float> sample_segment(const Ray3f &, Float, Float, Float,
-                           Mask) const override {
-        NotImplementedError("sample_segment");
-        return {dr::zeros<ExtremumSegment>(), Float(0.f)};
+    TrackingState traverse_extremum(const Ray3f &, Float, Float, UInt32, 
+                    TrackingState, TrackingFunction*, Mask) const override {
+        NotImplementedError("traverse_extremum");
+        return TrackingState();
     }
 
     std::tuple<Float, Float> eval_1(const Interaction3f &,
@@ -133,6 +137,8 @@ public:
     MI_IMPORT_BASE(ExtremumStructure, m_bbox)
     MI_IMPORT_TYPES(Volume)
 
+    using TrackingState    = TrackingState<Float, Spectrum>;
+    using TrackingFunction = TrackingFunction<Float, Spectrum>;
     using FloatStorage = DynamicBuffer<Float>;
 
     ExtremumSphericalImpl(const Properties &props) : Base(props) {
@@ -177,57 +183,29 @@ public:
         build_grid(m_volume.get());
     }
 
-    std::tuple<ExtremumSegment, Float> sample_segment(
+    TrackingState traverse_extremum(
         const Ray3f &ray,
-        Float mint, Float maxt,
-        Float target_ot,
+        Float mint,
+        Float maxt,
+        UInt32 channel,
+        TrackingState state,
+        TrackingFunction* func,
         Mask active
     ) const override {
-
-        ExtremumSegment segment = dr::zeros<ExtremumSegment>();
-
-        struct DeltaTrackingState {
-            ExtremumSegment segment;
-            Float target_ot;
-            Float ot_acc;
-            DRJIT_STRUCT(DeltaTrackingState, segment, target_ot, ot_acc)
-        } state {
-            segment,
-            target_ot,
-            /*ot_acc =*/0.f
-        };
-
-        // To be moved to tracking.h in future iterations
-        auto func = [](
-            ExtremumSegment& segment, 
-            DeltaTrackingState& state, 
-            Mask& /*advance*/,
-            Mask& active
-        ){
-            Float dt = segment.maxt - segment.mint;
-            Float next_ot = dr::fmadd(segment.majorant(), dt, state.ot_acc);
-            Mask exit = next_ot >= state.target_ot;
-            // update variables
-            dr::masked(state.segment, active &&  exit) = segment;
-            dr::masked(state.ot_acc, active && !exit) = next_ot;
-            active &= !exit;
-        };
-
         if constexpr (TraversalType == SphericalTraversalType::RadialOnly) {
-            state = traverse_radial(
+            return traverse_radial(
                 func,
                 state, 
                 ray, 
                 mint,
                 maxt,
+                channel,
                 active
             );            
         } else {
             Throw("Full3D spherical traversal is not yet implemented!");
-            return {dr::zeros<ExtremumSegment>(), 0.f};
+            return TrackingState();
         }
-
-        return {state.segment, state.ot_acc};
     }
 
     std::tuple<Float, Float> eval_1(
@@ -412,6 +390,7 @@ private:
         const Ray3f ray,
         Float mint,
         Float maxt,
+        UInt32 channel,
         Mask active
     ) const {
         using StateD = std::decay_t<StateT>;
@@ -478,7 +457,7 @@ private:
         dr::tie(ls) = dr::while_loop(
             dr::make_tuple(ls),
             [](const LoopState &ls) { return ls.active; },
-            [this, func, maxt, a, inv_a, disc_base, b_half](LoopState &ls) {
+            [this, func, maxt, a, inv_a, disc_base, b_half, channel](LoopState &ls) {
 
             // Compute radius at current position
             const Float eps = dr::Epsilon<Float> * 2.f;
@@ -538,7 +517,10 @@ private:
                 );
                 
                 Mask active_update = ls.active && update;
-                func( ls.segment, ls.state, ls.advance, active_update);
+                auto result = 
+                    func( ls.segment, ls.state, channel, active_update);
+                ls.advance    = result.first;
+                active_update &= result.second;
 
                 // Advance state for lanes that haven't reached target
                 dr::masked(ls.current_t, ls.advance && update) = t_next;

--- a/src/eradiate_plugins/integrators/eovolpath.cpp
+++ b/src/eradiate_plugins/integrators/eovolpath.cpp
@@ -1,11 +1,15 @@
 #include <mitsuba/core/ray.h>
 #include <mitsuba/core/properties.h>
 #include <mitsuba/render/bsdf.h>
+#include <mitsuba/core/random.h>
 #include <mitsuba/render/emitter.h>
 #include <mitsuba/render/integrator.h>
 #include <mitsuba/render/records.h>
 #include <mitsuba/render/medium.h>
 #include <mitsuba/render/phase.h>
+#include <mitsuba/render/eradiate/tracking.h>
+#include <mitsuba/render/eradiate/extremum.h>
+#include <mitsuba/render/eradiate/extremum_segment.h>
 
 
 NAMESPACE_BEGIN(mitsuba)
@@ -73,8 +77,10 @@ class EOVolumetricPathIntegrator : public MonteCarloIntegrator<Float, Spectrum> 
 
 public:
     MI_IMPORT_BASE(MonteCarloIntegrator, m_max_depth, m_rr_depth, m_hide_emitters)
-    MI_IMPORT_TYPES(Scene, Sampler, Emitter, EmitterPtr, BSDF, BSDFPtr,
-                     Medium, MediumPtr, PhaseFunctionContext)
+    MI_IMPORT_TYPES(Scene, Sampler, Emitter, EmitterPtr, BSDF, BSDFPtr, Medium, 
+                    MediumPtr, PhaseFunctionContext, ExtremumStructure)
+
+    using TrackingState = TrackingState<Float, Spectrum>;
 
     EOVolumetricPathIntegrator(const Properties &props) : Base(props) {
         m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
@@ -87,16 +93,16 @@ public:
             Throw("`rr_factor` is outside range [0.,1.].");
     }
 
+    /// Create seed and offsets that can be used to generate a new PCG32 rng.
     MI_INLINE
-    Float index_spectrum(const UnpolarizedSpectrum &spec, const UInt32 &idx) const {
-        Float m = spec[0];
-        if constexpr (is_rgb_v<Spectrum>) { // Handle RGB rendering
-            dr::masked(m, idx == 1u) = spec[1];
-            dr::masked(m, idx == 2u) = spec[2];
-        } else {
-            DRJIT_MARK_USED(idx);
-        }
-        return m;
+    std::pair<UInt64, UInt64> new_seed_offset(
+            Float sample1, Float sample2) const {
+        UInt32 s0 = UInt32(sample1 * 4294967296.f);  // [0,1) -> [0, 2^32)                                                  
+        UInt32 s1 = UInt32(sample2 * 4294967296.f);                                                                         
+        UInt64 seed, offset;
+        seed   = sample_tea_64(s0, s1);                                                                                                             
+        offset = sample_tea_64(s1, s0);
+        return {seed, offset};
     }
 
     std::pair<Spectrum, Mask> sample(const Scene *scene,
@@ -106,7 +112,7 @@ public:
                                      Float * /* aovs */,
                                      Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::SamplingIntegratorSample, active);
-
+        
         // If there is an environment emitter and emitters are visible: all rays will be valid
         // Otherwise, it will depend on whether a valid interaction is sampled
         Mask valid_ray = !m_hide_emitters && (scene->environment() != nullptr);
@@ -130,7 +136,6 @@ public:
         }
 
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-        Mask needs_intersection = true;
         Interaction3f last_scatter_event = dr::zeros<Interaction3f>();
         Float last_scatter_direction_pdf = 1.f;
 
@@ -149,14 +154,13 @@ public:
             Float eta;
             Interaction3f last_scatter_event;
             Float last_scatter_direction_pdf;
-            Mask needs_intersection;
             Mask specular_chain;
             Mask valid_ray;
             Sampler* sampler;
 
             DRJIT_STRUCT(LoopState, active, depth, ray, throughput, result, \
                 si, mei, medium, eta, last_scatter_event, \
-                last_scatter_direction_pdf, needs_intersection, \
+                last_scatter_direction_pdf, \
                 specular_chain, valid_ray, sampler)
         } ls = {
             active,
@@ -170,7 +174,6 @@ public:
             eta,
             last_scatter_event,
             last_scatter_direction_pdf,
-            needs_intersection,
             specular_chain,
             valid_ray,
             sampler
@@ -191,7 +194,6 @@ public:
             Float& eta = ls.eta;
             Interaction3f& last_scatter_event = ls.last_scatter_event;
             Float& last_scatter_direction_pdf = ls.last_scatter_direction_pdf;
-            Mask& needs_intersection = ls.needs_intersection;
             Mask& specular_chain = ls.specular_chain;
             Mask& valid_ray = ls.valid_ray;
             Sampler* sampler = ls.sampler;
@@ -212,9 +214,14 @@ public:
 
             // ----------------------- Sampling the RTE -----------------------
             Mask active_medium  = active && (medium != nullptr);
-            Mask active_surface = active && !active_medium;
+            Mask active_surface = active;
+
             Mask act_null_scatter = false, act_medium_scatter = false,
                  escaped_medium = false;
+
+            dr::masked(si, active) = scene->ray_intersect(ray, active);
+            dr::masked(ray.maxt, active) = si.t; 
+            active_surface &= si.is_valid();
 
             // If the medium does not have a spectrally varying extinction,
             // we can perform a few optimizations to speed up rendering
@@ -226,34 +233,118 @@ public:
             }
 
             if (dr::any_or<true>(active_medium)) {
-                mei = medium->sample_interaction(ray, sampler->next_1d(active_medium), channel, active_medium);
-                dr::masked(ray.maxt, active_medium && medium->is_homogeneous() && mei.is_valid()) = mei.t;
-                Mask intersect = needs_intersection && active_medium;
-                if (dr::any_or<true>(intersect))
-                    dr::masked(si, intersect) = scene->ray_intersect(ray, intersect);
-                needs_intersection &= !active_medium;
+                // Prepare Extremum traversal
+                auto extremum = medium->extremum_structure();
+                Float mint, maxt;
+                std::tie(mei, mint, maxt) = 
+                    medium->prepare_medium_traversal(ray, active_medium);
 
-                dr::masked(mei.t, active_medium && (si.t < mei.t)) = dr::Infinity<Float>;
-                if (dr::any_or<true>(is_spectral)) {
-                    auto [tr, free_flight_pdf] = medium->transmittance_eval_pdf(mei, si, is_spectral);
-                    Float tr_pdf = index_spectrum(free_flight_pdf, channel);
-                    dr::masked(throughput, is_spectral) *= dr::select(tr_pdf > 0.f, tr / tr_pdf, 0.f);
-                }
+                Float sample1 = sampler->next_1d();
+                Float sample2 = sampler->next_1d();
+                auto [seed, offset] = new_seed_offset(sample1, sample2);
+                PCG32<UInt32> rng;
+                rng.seed(seed, offset);
+
+                TrackingState state {
+                    ray,
+                    rng,
+                    mei,
+                    /*throughput=*/UnpolarizedSpectrum(1.f),
+                };
+
+                // Traverse extremum segments and perform delta tracking
+                state = extremum->traverse_extremum(
+                ray, mint, maxt, channel, state,
+                [](const ExtremumSegment& segment, TrackingState& state, 
+                   const UInt32& channel, Mask active) {
+
+                    UnpolarizedSpectrum &throughput = state.throughput;
+                    PCG32<UInt32> &rng              = state.rng;
+                    MediumInteraction3f& mei        = state.mei; 
+                    
+                    MediumPtr medium      = mei.medium;
+                    Mask act_spectral     = medium->has_spectral_extinction() && active;
+                    Mask act_not_spectral = !medium->has_spectral_extinction() && active;
+
+                    // Check if the last iteration had a valid interaction within the segment
+                    Float mint = dr::select(
+                        mei.is_valid(),
+                        dr::maximum(segment.mint, mei.t), 
+                        segment.mint
+                    );
+                    
+                    // Sample a new potential interaction
+                    Float target_ot = 
+                        -dr::log( 1.f - state.rng.template next_float<Float>(active) );
+                    Float sampled_t =
+                        mint
+                        + (target_ot) / dr::maximum(segment.majorant(), dr::Epsilon<Float>);
+                    
+                    Mask sampled = (sampled_t < segment.maxt) && active;
+                    Float dt = dr::select(sampled, sampled_t - mint, segment.maxt - mint);
+
+                    if( dr::any_or<true>(act_spectral) ) {
+                        // Accumulate transmittance in the throughput and pdf (spectral only).
+                        UnpolarizedSpectrum tr = dr::exp(-dt*segment.majorant());
+                        Float pdf = index_spectrum<Float, Spectrum>(
+                            dr::select(sampled, tr*segment.majorant(), tr), 
+                            channel);
+                        dr::masked(throughput, act_spectral)  *= tr/pdf;
+                    } 
+
+                    if (dr::any_or<true>(sampled)) {
+                        mei.t = sampled_t;
+                        mei.p = state.ray(sampled_t);
+
+                        // Retrieve scattering coefficients at position.
+                        UnpolarizedSpectrum sigma_s, sigma_n, sigma_t;
+                        std::tie(sigma_s, std::ignore, sigma_t) = 
+                            medium->get_scattering_coefficients(mei, sampled);
+                        sigma_n = segment.majorant() - sigma_t;
+
+                        // Sample event type
+                        Float null_scatter_prob = dr::mean(sigma_n / segment.majorant());
+                        Mask null_scatter = 
+                            (rng.template next_float<Float>(sampled) < null_scatter_prob) && sampled;
+                        Mask real_scatter = !null_scatter && sampled;
+                        
+                        // Accumulate throughput and pdf given the event type and is_spectral.
+                        if (dr::any_or<true>(null_scatter && act_spectral)) {
+                            dr::masked(throughput, null_scatter && act_spectral) *= 
+                                sigma_n / null_scatter_prob;
+                        }
+
+                        if (dr::any_or<true>(real_scatter)) {
+                            if(dr::any_or<true>(act_spectral)) {
+                                dr::masked(throughput, real_scatter && act_spectral) *= 
+                                    sigma_s / (1.0f - null_scatter_prob);
+                            }
+
+                            if(dr::any_or<true>(act_not_spectral)) {
+                                // pdf = sigma_t / sigma_maj, sigma_maj gets cancelled from sigma_s/sigma_maj 
+                                dr::masked(throughput, real_scatter && act_not_spectral) *= 
+                                    sigma_s / sigma_t;
+                            }
+
+                            // disable the loop once we encounter a real scattering interaction
+                            active &= !real_scatter;
+                        }
+                    }
+
+                    dr::masked(mei.t, !sampled) = dr::Infinity<Float>;
+
+                    Mask step = !sampled;
+                    return std::pair<Mask, Mask>(step, active);
+                });
+
+                // Update throughput by the transmittance and pdf weight
+                dr::masked(throughput, active_medium) *= state.throughput;
+                dr::masked(mei, active_medium) = state.mei; 
 
                 escaped_medium = active_medium && !mei.is_valid();
                 active_medium &= mei.is_valid();
 
-                // Handle null and real scatter events
-                Float null_scatter_prob = dr::mean(mei.sigma_n / mei.combined_extinction);
-                Mask null_scatter = sampler->next_1d(active_medium) < null_scatter_prob;
-
-                act_null_scatter |= null_scatter && active_medium;
-                act_medium_scatter |= !act_null_scatter && active_medium;
-
-                if (dr::any_or<true>(is_spectral && act_null_scatter))
-                    dr::masked(throughput, is_spectral && act_null_scatter) *=
-                        mei.sigma_n / null_scatter_prob;
-
+                act_medium_scatter = !escaped_medium && active_medium;
                 dr::masked(depth, act_medium_scatter) += 1;
                 dr::masked(last_scatter_event, act_medium_scatter) = mei;
             }
@@ -262,17 +353,7 @@ public:
             active &= depth < (uint32_t) m_max_depth;
             act_medium_scatter &= active;
 
-            if (dr::any_or<true>(act_null_scatter)) {
-                dr::masked(ray.o, act_null_scatter) = mei.p;
-                dr::masked(si.t, act_null_scatter) = si.t - mei.t;
-            }
-
             if (dr::any_or<true>(act_medium_scatter)) {
-                if (dr::any_or<true>(is_spectral))
-                    dr::masked(throughput, is_spectral && act_medium_scatter) *=
-                        mei.sigma_s / dr::mean(mei.sigma_t / mei.combined_extinction);
-                if (dr::any_or<true>(not_spectral))
-                    dr::masked(throughput, not_spectral && act_medium_scatter) *= mei.sigma_s / mei.sigma_t;
 
                 PhaseFunctionContext phase_ctx(sampler);
                 auto phase = mei.medium->phase_function();
@@ -336,17 +417,15 @@ public:
 
                 Ray3f new_ray  = mei.spawn_ray(wo);
                 dr::masked(ray, act_medium_scatter) = new_ray;
-                needs_intersection |= act_medium_scatter;
                 dr::masked(last_scatter_direction_pdf, act_medium_scatter) = phase_pdf;
                 dr::masked(throughput, act_medium_scatter) *= phase_weight;
             }
 
             // --------------------- Surface Interactions ---------------------
-            active_surface |= escaped_medium;
-            Mask intersect = active_surface && needs_intersection;
-            if (dr::any_or<true>(intersect))
-                dr::masked(si, intersect) = scene->ray_intersect(ray, intersect);
-
+            // Interact with the surface only if we haven't interacted with the 
+            // medium before and there is a valid intersection (already accounted).
+            active_surface &= !act_medium_scatter;
+            
             if (dr::any_or<true>(active_surface)) {
                 // ---------------------- Hide area emitters ----------------------
                 if (m_hide_emitters && dr::any_or<true>(ls.depth == 0u)) {
@@ -354,8 +433,7 @@ public:
                     // If so, skip all area emitters along this ray
                     Mask skip_emitters = si.is_valid() &&
                                          (si.shape->emitter() != nullptr) &&
-                                         (ls.depth == 0) &&
-                                         intersect;
+                                         (ls.depth == 0);
 
                     if (dr::any_or<true>(skip_emitters)) {
                         Ray3f ray = si.spawn_ray(ls.ray.d);
@@ -394,6 +472,7 @@ public:
                 Mask active_e = active_surface && has_flag(bsdf->flags(), BSDFFlags::Smooth) && (depth + 1 < (uint32_t) m_max_depth);
 
                 if (likely(dr::any_or<true>(active_e))) {
+                    // auto [emitted, ds] = sample_emitter(si, scene, sampler, medium, channel, active_e);
                     auto [emitted, ds] = sample_emitter(si, scene, sampler, medium, channel, active_e);
 
                     // Query the BSDF for that emitter-sampled direction
@@ -417,7 +496,6 @@ public:
 
                 Ray3f bsdf_ray                  = si.spawn_ray(si.to_world(bs.wo));
                 dr::masked(ray, active_surface) = bsdf_ray;
-                needs_intersection |= active_surface;
 
                 Mask non_null_bsdf = active_surface && !has_flag(bs.sampled_type, BSDFFlags::Null);
                 dr::masked(depth, non_null_bsdf) += 1;
@@ -439,7 +517,6 @@ public:
 
         return { ls.result, ls.valid_ray };
     }
-
 
     /// Samples an emitter in the scene and evaluates its attenuated contribution
     template <typename Interaction>
@@ -467,32 +544,26 @@ public:
 
         Float total_dist = 0.f;
         SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
-        Mask needs_intersection = true;
         DirectionSample3f dir_sample = ds;
 
         struct LoopState {
             Mask active;
             Ray3f ray;
             Float total_dist;
-            Mask needs_intersection;
             MediumPtr medium;
             SurfaceInteraction3f si;
             Spectrum transmittance;
-            DirectionSample3f dir_sample;
             Sampler* sampler;
 
             DRJIT_STRUCT(LoopState, active, ray, total_dist, \
-                needs_intersection, medium, si, transmittance, \
-                dir_sample, sampler)
+                medium, si, transmittance, sampler)
         } ls = {
             active,
             ray,
             total_dist,
-            needs_intersection,
             medium,
             si,
             transmittance,
-            dir_sample,
             sampler
         };
 
@@ -503,11 +574,9 @@ public:
             Mask& active = ls.active;
             Ray3f& ray = ls.ray;
             Float& total_dist = ls.total_dist;
-            Mask& needs_intersection = ls.needs_intersection;
             MediumPtr& medium = ls.medium;
             SurfaceInteraction3f& si = ls.si;
             Spectrum& transmittance = ls.transmittance;
-            DirectionSample3f& dir_sample = ls.dir_sample;
             Sampler* sampler = ls.sampler;
 
             Float remaining_dist = max_dist - total_dist;
@@ -516,61 +585,114 @@ public:
             if (dr::none_or<false>(active))
                 return;
 
-            Mask escaped_medium = false;
             Mask active_medium  = active && (medium != nullptr);
-            Mask active_surface = active && !active_medium;
 
+            dr::masked(si, active) = scene->ray_intersect(ray, active);
+            dr::masked(ray.maxt, active) = dr::minimum(si.t, remaining_dist); 
+            dr::masked(total_dist, active) += ray.maxt;
+            
             if (dr::any_or<true>(active_medium)) {
-                auto mei = medium->sample_interaction(ray, sampler->next_1d(active_medium), channel, active_medium);
-                dr::masked(ray.maxt, active_medium && medium->is_homogeneous() && mei.is_valid()) = dr::minimum(mei.t, remaining_dist);
-                Mask intersect = needs_intersection && active_medium;
-                if (dr::any_or<true>(intersect))
-                    dr::masked(si, intersect) = scene->ray_intersect(ray, intersect);
+                // Prepare extremum traversal
+                auto extremum = medium->extremum_structure();
+                auto [mei, mint, maxt] = 
+                    medium->prepare_medium_traversal(ray, active_medium);
 
-                dr::masked(mei.t, active_medium && (si.t < mei.t)) = dr::Infinity<Float>;
-                needs_intersection &= !active_medium;
+                Float sample1 = sampler->next_1d();
+                Float sample2 = sampler->next_1d();
+                auto [seed, offset] = new_seed_offset(sample1, sample2);
+                PCG32<UInt32> rng;
+                rng.seed(seed, offset);
 
-                Mask is_spectral = medium->has_spectral_extinction() && active_medium;
-                Mask not_spectral = !is_spectral && active_medium;
-                if (dr::any_or<true>(is_spectral)) {
-                    Float t      = dr::minimum(remaining_dist, dr::minimum(mei.t, si.t)) - mei.mint;
-                    UnpolarizedSpectrum tr  = dr::exp(-t * mei.combined_extinction);
-                    UnpolarizedSpectrum free_flight_pdf = dr::select(si.t < mei.t || mei.t > remaining_dist, tr, tr * mei.combined_extinction);
-                    Float tr_pdf = index_spectrum(free_flight_pdf, channel);
-                    dr::masked(transmittance, is_spectral) *= dr::select(tr_pdf > 0.f, tr / tr_pdf, 0.f);
-                }
+                TrackingState state {
+                    ray,
+                    rng,
+                    mei,
+                    /*throughput=*/UnpolarizedSpectrum(1.f),
+                };
 
-                // Handle exceeding the maximum distance by medium sampling
-                dr::masked(total_dist, active_medium && (mei.t > remaining_dist) && mei.is_valid()) = dir_sample.dist;
-                dr::masked(mei.t, active_medium && (mei.t > remaining_dist)) = dr::Infinity<Float>;
+                // Unified Ratio Tracking and Residual Ratio Tracking approach:
+                // if `use_rrt` is false, set control to 0., which automatically
+                // devolves the algorithm to Ratio Tracking.
+                state = extremum->traverse_extremum(
+                ray, mint, maxt, channel, state,
+                [](const ExtremumSegment& segment, TrackingState& state, 
+                   const UInt32& channel, Mask active) {
 
-                escaped_medium = active_medium && !mei.is_valid();
-                active_medium &= mei.is_valid();
-                is_spectral &= active_medium;
-                not_spectral &= active_medium;
+                    UnpolarizedSpectrum &throughput = state.throughput;
+                    PCG32<UInt32> &rng       = state.rng;
+                    MediumInteraction3f& mei = state.mei; 
+                    Mask use_rrt             = mei.medium->use_rrt();
+                    MediumPtr medium         = mei.medium;
+                    Mask act_spectral     = medium->has_spectral_extinction() && active;
+                    Mask act_not_spectral = !medium->has_spectral_extinction() && active;
+                    
+                    Float control = dr::select(use_rrt, segment.minorant(), 0.f);
+                    Float residual_majorant = segment.majorant() - control;
 
-                dr::masked(total_dist, active_medium) += mei.t;
+                    Float mint = dr::select(
+                        mei.is_valid(),
+                        dr::maximum(segment.mint, mei.t), 
+                        segment.mint
+                    );
 
-                if (dr::any_or<true>(active_medium)) {
-                    dr::masked(ray.o, active_medium)    = mei.p;
-                    dr::masked(si.t, active_medium) = si.t - mei.t;
+                    Float target_ot = 
+                        -dr::log( 1.f - rng.template next_float<Float>(active) );
+                    Float sampled_t =
+                        mint
+                        + (target_ot) / dr::maximum(residual_majorant, dr::Epsilon<Float>);
+                    
+                    Mask sampled = (sampled_t < segment.maxt) && active;
+                    Float dt = dr::select(sampled, sampled_t - mint, segment.maxt - mint);
 
-                    if (dr::any_or<true>(is_spectral))
-                        dr::masked(transmittance, is_spectral) *= mei.sigma_n;
-                    if (dr::any_or<true>(not_spectral))
-                        dr::masked(transmittance, not_spectral) *= mei.sigma_n / mei.combined_extinction;
-                }
+                    if(dr::any_or<true>(use_rrt)) {
+                        // We accumulate control transmittance every interaction
+                        // instead of accumulating the optical thickness.
+                        // Choice of simplicity vs performance.
+                        dr::masked(throughput, active && use_rrt) *= dr::exp( -dt * control );
+                    }
+
+                    if(dr::any_or<true>(act_spectral)) {
+                        // Account for distance sampling weight in spectral mode
+                        UnpolarizedSpectrum tr = dr::exp(-dt*residual_majorant);
+                        // dr::masked(throughput, act_spectral)  *= tr;
+                        Float pdf = index_spectrum<Float, Spectrum>(
+                            dr::select(sampled, tr*residual_majorant, tr), 
+                            channel);
+                        dr::masked(throughput, act_spectral)  *= tr / pdf;
+                    } 
+
+                    if (dr::any_or<true>(sampled)) {
+                        mei.t = sampled_t;
+                        mei.p = state.ray(sampled_t);
+
+                        // Retrieve scattering coefficients at position.
+                        UnpolarizedSpectrum sigma_t, sigma_n;
+                        std::tie( std::ignore, std::ignore, sigma_t) = 
+                            medium->get_scattering_coefficients(mei, sampled);
+                        sigma_n = segment.majorant() - sigma_t;
+
+                        if(dr::any_or<true>(act_spectral)) {
+                            // Both RT and RRT spectral mode simplify to sigma_n.
+                            dr::masked(throughput, sampled && act_spectral) *= sigma_n;
+                        }
+                        
+                        if(dr::any_or<true>(act_not_spectral)) {
+                            dr::masked(throughput, sampled && act_not_spectral) *= 
+                                dr::maximum((1.f - (sigma_t - control)/residual_majorant), 0.f);
+                        }
+                    }
+                    dr::masked(mei.t, !sampled) = dr::Infinity<Float>;
+                    
+                    // Never disable the loop, continue until maxt
+                    Mask step = !sampled;
+                    return std::pair<Mask,Mask>(step, active);
+                });
+
+                dr::masked(transmittance, active_medium) *= state.throughput;
             }
 
             // Handle interactions with surfaces
-            Mask intersect = active_surface && needs_intersection;
-            if (dr::any_or<true>(intersect))
-                dr::masked(si, intersect)    = scene->ray_intersect(ray, intersect);
-            needs_intersection &= !intersect;
-            active_surface |= escaped_medium;
-            dr::masked(total_dist, active_surface) += si.t;
-
-            active_surface &= si.is_valid() && active && !active_medium;
+            Mask active_surface = si.is_valid() && active;
             if (dr::any_or<true>(active_surface)) {
                 auto bsdf         = si.bsdf(ray);
                 Spectrum bsdf_val = bsdf->eval_null_transmission(si, active_surface);
@@ -581,10 +703,9 @@ public:
             // Update the ray with new origin & t parameter
             dr::masked(ray, active_surface) = si.spawn_ray(ray.d);
             ray.maxt = remaining_dist;
-            needs_intersection |= active_surface;
 
             // Continue tracing through scene if non-zero weights exist
-            active &= (active_medium || active_surface) &&
+            active &= active_surface &&
                       dr::any(unpolarized_spectrum(transmittance) != 0.f);
 
             // If a medium transition is taking place: Update the medium pointer
@@ -593,7 +714,7 @@ public:
                 dr::masked(medium, has_medium_trans) = si.target_medium(ray.d);
             }
         },
-        "Volpath integrator emitter sampling");
+        "Volpath integrator emitter sampling special edition");
 
         return { ls.transmittance * emitter_val, dir_sample };
     }
@@ -602,7 +723,7 @@ public:
     // =============================================================
 
     std::string to_string() const override {
-        return tfm::format("EOVolumetricSimplePathIntegrator[\n"
+        return tfm::format("EOVolumetricPathIntegrator[\n"
                            "  max_depth = %i,\n"
                            "  rr_depth = %i\n"
                            "]",

--- a/src/eradiate_plugins/integrators/eovolpath.cpp
+++ b/src/eradiate_plugins/integrators/eovolpath.cpp
@@ -112,7 +112,6 @@ public:
                                      Float * /* aovs */,
                                      Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::SamplingIntegratorSample, active);
-        
         // If there is an environment emitter and emitters are visible: all rays will be valid
         // Otherwise, it will depend on whether a valid interaction is sampled
         Mask valid_ray = !m_hide_emitters && (scene->environment() != nullptr);
@@ -214,14 +213,13 @@ public:
 
             // ----------------------- Sampling the RTE -----------------------
             Mask active_medium  = active && (medium != nullptr);
-            Mask active_surface = active;
+            Mask active_surface = active && !active_medium;
 
             Mask act_null_scatter = false, act_medium_scatter = false,
                  escaped_medium = false;
 
             dr::masked(si, active) = scene->ray_intersect(ray, active);
             dr::masked(ray.maxt, active) = si.t; 
-            active_surface &= si.is_valid();
 
             // If the medium does not have a spectrally varying extinction,
             // we can perform a few optimizations to speed up rendering
@@ -232,12 +230,17 @@ public:
                 not_spectral = !is_spectral && active_medium;
             }
 
+            Float mint, maxt;
+            if (dr::any_or<true>(active_medium)) {
+                std::tie(mei, mint, maxt) = 
+                    medium->prepare_medium_traversal(ray, active_medium);
+                escaped_medium = active_medium && !dr::isfinite(maxt);
+                active_medium &= !escaped_medium;
+            }
+
             if (dr::any_or<true>(active_medium)) {
                 // Prepare Extremum traversal
                 auto extremum = medium->extremum_structure();
-                Float mint, maxt;
-                std::tie(mei, mint, maxt) = 
-                    medium->prepare_medium_traversal(ray, active_medium);
 
                 Float sample1 = sampler->next_1d();
                 Float sample2 = sampler->next_1d();
@@ -245,103 +248,123 @@ public:
                 PCG32<UInt32> rng;
                 rng.seed(seed, offset);
 
+                Float target_ot = -dr::log( 1.f - sampler->next_1d(active_medium));
+
                 TrackingState state {
                     ray,
                     rng,
                     mei,
+                    target_ot,
+                    medium->use_rrt(),
+                    medium->has_spectral_extinction(),
                     /*throughput=*/UnpolarizedSpectrum(1.f),
                 };
 
                 // Traverse extremum segments and perform delta tracking
                 state = extremum->traverse_extremum(
                 ray, mint, maxt, channel, state,
-                [](const ExtremumSegment& segment, TrackingState& state, 
-                   const UInt32& channel, Mask active) {
-
+                [](const ExtremumSegment &segment, TrackingState &state,
+                    const UInt32 &channel, Mask active) {
                     UnpolarizedSpectrum &throughput = state.throughput;
                     PCG32<UInt32> &rng              = state.rng;
-                    MediumInteraction3f& mei        = state.mei; 
-                    
-                    MediumPtr medium      = mei.medium;
-                    Mask act_spectral     = medium->has_spectral_extinction() && active;
-                    Mask act_not_spectral = !medium->has_spectral_extinction() && active;
+                    MediumInteraction3f &mei        = state.mei;
 
-                    // Check if the last iteration had a valid interaction within the segment
+                    MediumPtr medium = mei.medium;
+                    Mask act_spectral = state.has_spectral_extinction && active;
+                    Mask act_not_spectral = !state.has_spectral_extinction && active;
+
+                    // Check if the last iteration had a valid interaction
+                    // within the segment
                     Float mint = dr::select(
-                        mei.is_valid(),
-                        dr::maximum(segment.mint, mei.t), 
-                        segment.mint
-                    );
-                    
-                    // Sample a new potential interaction
-                    Float target_ot = 
-                        -dr::log( 1.f - state.rng.template next_float<Float>(active) );
-                    Float sampled_t =
-                        mint
-                        + (target_ot) / dr::maximum(segment.majorant(), dr::Epsilon<Float>);
-                    
-                    Mask sampled = (sampled_t < segment.maxt) && active;
-                    Float dt = dr::select(sampled, sampled_t - mint, segment.maxt - mint);
+                        mei.is_valid(), dr::maximum(segment.mint, mei.t),
+                        segment.mint);
 
-                    if( dr::any_or<true>(act_spectral) ) {
-                        // Accumulate transmittance in the throughput and pdf (spectral only).
-                        UnpolarizedSpectrum tr = dr::exp(-dt*segment.majorant());
-                        Float pdf = index_spectrum<Float, Spectrum>(
-                            dr::select(sampled, tr*segment.majorant(), tr), 
-                            channel);
-                        dr::masked(throughput, act_spectral)  *= tr/pdf;
-                    } 
+                    Float segment_ot =
+                        (segment.maxt - mint) * segment.majorant();
+                    Mask sampled = (state.target_ot < segment_ot) && active;
+                    Float maxt   = segment.maxt;
 
                     if (dr::any_or<true>(sampled)) {
-                        mei.t = sampled_t;
-                        mei.p = state.ray(sampled_t);
+                        dr::masked(maxt, sampled) =
+                            mint + state.target_ot /
+                                        dr::maximum(segment.majorant(),
+                                                    dr::Epsilon<Float>);
+                    }
+
+                    Float dt = maxt - mint;
+
+                    if (dr::any_or<true>(act_spectral)) {
+                        // Accumulate transmittance in the throughput and
+                        // pdf (spectral only).
+                        UnpolarizedSpectrum tr =
+                            dr::exp(-dt * segment.majorant());
+                        Float pdf = index_spectrum<Float, Spectrum>(
+                            dr::select(sampled, tr * segment.majorant(), tr),
+                            channel);
+                        dr::masked(throughput, act_spectral) *= tr / pdf;
+                    }
+
+                    if (dr::any_or<true>(sampled)) {
+
+                        mei.t = maxt;
+                        mei.p = state.ray(maxt);
 
                         // Retrieve scattering coefficients at position.
                         UnpolarizedSpectrum sigma_s, sigma_n, sigma_t;
-                        std::tie(sigma_s, std::ignore, sigma_t) = 
+                        std::tie(sigma_s, std::ignore, sigma_t) =
                             medium->get_scattering_coefficients(mei, sampled);
                         sigma_n = segment.majorant() - sigma_t;
 
                         // Sample event type
-                        Float null_scatter_prob = dr::mean(sigma_n / segment.majorant());
-                        Mask null_scatter = 
-                            (rng.template next_float<Float>(sampled) < null_scatter_prob) && sampled;
+                        Float null_scatter_prob =
+                            dr::mean(sigma_n / segment.majorant());
+                        Mask null_scatter =
+                            (rng.template next_float<Float>(sampled) < null_scatter_prob) 
+                            && sampled;
                         Mask real_scatter = !null_scatter && sampled;
-                        
-                        // Accumulate throughput and pdf given the event type and is_spectral.
+
+                        // Accumulate throughput and pdf given the event
+                        // type and is_spectral.
                         if (dr::any_or<true>(null_scatter && act_spectral)) {
-                            dr::masked(throughput, null_scatter && act_spectral) *= 
+                            dr::masked(throughput, null_scatter && act_spectral) *=
                                 sigma_n / null_scatter_prob;
                         }
 
                         if (dr::any_or<true>(real_scatter)) {
-                            if(dr::any_or<true>(act_spectral)) {
-                                dr::masked(throughput, real_scatter && act_spectral) *= 
+                            if (dr::any_or<true>(act_spectral)) {
+                                dr::masked(throughput, real_scatter && act_spectral) *=
                                     sigma_s / (1.0f - null_scatter_prob);
                             }
 
-                            if(dr::any_or<true>(act_not_spectral)) {
-                                // pdf = sigma_t / sigma_maj, sigma_maj gets cancelled from sigma_s/sigma_maj 
-                                dr::masked(throughput, real_scatter && act_not_spectral) *= 
+                            if (dr::any_or<true>(act_not_spectral)) {
+                                // pdf = sigma_t / sigma_maj, sigma_maj gets
+                                // cancelled from sigma_s/sigma_maj
+                                dr::masked(throughput, real_scatter && act_not_spectral) *=
                                     sigma_s / sigma_t;
                             }
 
-                            // disable the loop once we encounter a real scattering interaction
+                            // disable the loop once we encounter a real
+                            // scattering interaction
                             active &= !real_scatter;
                         }
+
+                        dr::masked(state.target_ot, sampled) = 
+                            -dr::log(1.f - state.rng.template next_float<Float>(sampled));
                     }
 
                     dr::masked(mei.t, !sampled) = dr::Infinity<Float>;
+                    dr::masked(state.target_ot, !sampled && active) -=
+                        segment_ot;
 
                     Mask step = !sampled;
                     return std::pair<Mask, Mask>(step, active);
-                });
+                }, active_medium);
 
                 // Update throughput by the transmittance and pdf weight
                 dr::masked(throughput, active_medium) *= state.throughput;
                 dr::masked(mei, active_medium) = state.mei; 
 
-                escaped_medium = active_medium && !mei.is_valid();
+                escaped_medium |= active_medium && !mei.is_valid();
                 active_medium &= mei.is_valid();
 
                 act_medium_scatter = !escaped_medium && active_medium;
@@ -424,8 +447,8 @@ public:
             // --------------------- Surface Interactions ---------------------
             // Interact with the surface only if we haven't interacted with the 
             // medium before and there is a valid intersection (already accounted).
-            active_surface &= !act_medium_scatter;
-            
+            active_surface |= escaped_medium;
+
             if (dr::any_or<true>(active_surface)) {
                 // ---------------------- Hide area emitters ----------------------
                 if (m_hide_emitters && dr::any_or<true>(ls.depth == 0u)) {
@@ -591,11 +614,19 @@ public:
             dr::masked(ray.maxt, active) = dr::minimum(si.t, remaining_dist); 
             dr::masked(total_dist, active) += ray.maxt;
             
+            MediumInteraction3f mei;
+            Float mint, maxt;
+            if (dr::any_or<true>(active_medium)) {
+                std::tie(mei, mint, maxt) = 
+                    medium->prepare_medium_traversal(ray, active_medium);
+                active_medium &= dr::isfinite(maxt);
+            }
+
             if (dr::any_or<true>(active_medium)) {
                 // Prepare extremum traversal
                 auto extremum = medium->extremum_structure();
-                auto [mei, mint, maxt] = 
-                    medium->prepare_medium_traversal(ray, active_medium);
+                // auto [mei, mint, maxt] = 
+                //     medium->prepare_medium_traversal(ray, active_medium);
 
                 Float sample1 = sampler->next_1d();
                 Float sample2 = sampler->next_1d();
@@ -603,10 +634,15 @@ public:
                 PCG32<UInt32> rng;
                 rng.seed(seed, offset);
 
+                Float target_ot = -dr::log( 1.f - sampler->next_1d(active_medium));
+
                 TrackingState state {
                     ray,
                     rng,
                     mei,
+                    target_ot,
+                    medium->use_rrt(),
+                    medium->has_spectral_extinction(),
                     /*throughput=*/UnpolarizedSpectrum(1.f),
                 };
 
@@ -621,10 +657,12 @@ public:
                     UnpolarizedSpectrum &throughput = state.throughput;
                     PCG32<UInt32> &rng       = state.rng;
                     MediumInteraction3f& mei = state.mei; 
-                    Mask use_rrt             = mei.medium->use_rrt();
+                    Mask use_rrt             = state.use_rrt;
                     MediumPtr medium         = mei.medium;
-                    Mask act_spectral     = medium->has_spectral_extinction() && active;
-                    Mask act_not_spectral = !medium->has_spectral_extinction() && active;
+                    Mask act_spectral = 
+                        state.has_spectral_extinction && active;
+                    Mask act_not_spectral = 
+                        !state.has_spectral_extinction && active;
                     
                     Float control = dr::select(use_rrt, segment.minorant(), 0.f);
                     Float residual_majorant = segment.majorant() - control;
@@ -635,26 +673,30 @@ public:
                         segment.mint
                     );
 
-                    Float target_ot = 
-                        -dr::log( 1.f - rng.template next_float<Float>(active) );
-                    Float sampled_t =
-                        mint
-                        + (target_ot) / dr::maximum(residual_majorant, dr::Epsilon<Float>);
-                    
-                    Mask sampled = (sampled_t < segment.maxt) && active;
-                    Float dt = dr::select(sampled, sampled_t - mint, segment.maxt - mint);
+                    Float segment_ot = (segment.maxt - mint)*residual_majorant;
+                    Mask sampled = (state.target_ot < segment_ot) && active;
+                    Float maxt = segment.maxt;
+
+                    if (dr::any_or<true>(sampled)) {
+                        dr::masked(maxt, sampled) =
+                            mint +
+                            state.target_ot / dr::maximum(residual_majorant,
+                                                          dr::Epsilon<Float>);
+                    }
+
+                    Float dt = maxt - mint;
 
                     if(dr::any_or<true>(use_rrt)) {
                         // We accumulate control transmittance every interaction
                         // instead of accumulating the optical thickness.
                         // Choice of simplicity vs performance.
-                        dr::masked(throughput, active && use_rrt) *= dr::exp( -dt * control );
+                        dr::masked(state.throughput, active && use_rrt) *= 
+                            dr::exp(-dt * control);
                     }
 
                     if(dr::any_or<true>(act_spectral)) {
                         // Account for distance sampling weight in spectral mode
                         UnpolarizedSpectrum tr = dr::exp(-dt*residual_majorant);
-                        // dr::masked(throughput, act_spectral)  *= tr;
                         Float pdf = index_spectrum<Float, Spectrum>(
                             dr::select(sampled, tr*residual_majorant, tr), 
                             channel);
@@ -662,8 +704,8 @@ public:
                     } 
 
                     if (dr::any_or<true>(sampled)) {
-                        mei.t = sampled_t;
-                        mei.p = state.ray(sampled_t);
+                        mei.t = maxt;
+                        mei.p = state.ray(maxt);
 
                         // Retrieve scattering coefficients at position.
                         UnpolarizedSpectrum sigma_t, sigma_n;
@@ -680,13 +722,17 @@ public:
                             dr::masked(throughput, sampled && act_not_spectral) *= 
                                 dr::maximum((1.f - (sigma_t - control)/residual_majorant), 0.f);
                         }
+
+                        dr::masked(state.target_ot, sampled) =
+                            -dr::log( 1.f - rng.template next_float<Float>(active) );
                     }
                     dr::masked(mei.t, !sampled) = dr::Infinity<Float>;
+                    dr::masked(state.target_ot, !sampled && active) -= segment_ot;
                     
                     // Never disable the loop, continue until maxt
                     Mask step = !sampled;
                     return std::pair<Mask,Mask>(step, active);
-                });
+                }, active_medium);
 
                 dr::masked(transmittance, active_medium) *= state.throughput;
             }
@@ -714,7 +760,7 @@ public:
                 dr::masked(medium, has_medium_trans) = si.target_medium(ray.d);
             }
         },
-        "Volpath integrator emitter sampling special edition");
+        "Volpath integrator emitter sampling with Extremum traversal & RRT.");
 
         return { ls.transmittance * emitter_val, dir_sample };
     }

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -176,10 +176,11 @@ public:
 
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
 
-        // Create a default global extremum structure
+        // Create a default global extremum structure.
         Properties props_extr("extremum_global");
         props_extr.set("volume", (Object *) m_sigmat.get());
-        m_extremum_structure = 
+        props_extr.set("scale", m_scale);
+        m_extremum_structure =
             PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
 
         precompute_optical_thickness();
@@ -548,9 +549,9 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "PiecewiseMedium[" << std::endl
-            << "  albedo        = " << string::indent(m_albedo) << std::endl
-            << "  sigma_t       = " << string::indent(m_sigmat) << std::endl
-            << "  scale         = " << string::indent(m_scale) << std::endl
+            << "  albedo        = " << string::indent(m_albedo) << "," << std::endl
+            << "  sigma_t       = " << string::indent(m_sigmat) << "," << std::endl
+            << "  scale         = " << string::indent(m_scale) << "," << std::endl
             << "  extremum      = " << string::indent(m_extremum_structure) << std::endl
             << "]";
         return oss.str();

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -9,6 +9,7 @@
 #include <mitsuba/render/sampler.h>
 #include <mitsuba/render/scene.h>
 #include <mitsuba/render/volume.h>
+#include <mitsuba/render/eradiate/extremum.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -154,8 +155,8 @@ template <typename Float, typename Spectrum>
 class PiecewiseMedium final : public Medium<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
-                   m_phase_function)
-    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume)
+                   m_phase_function, m_extremum_structure)
+    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure)
 
     // Use 32 bit indices to keep track of indices to conserve memory
     using ScalarIndex     = uint32_t;
@@ -174,6 +175,12 @@ public:
             props.get<bool>("has_spectral_extinction", true);
 
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+
+        // Create a default global extremum structure
+        Properties props_extr("extremum_global");
+        props_extr.set("volume", (Object *) m_sigmat.get());
+        m_extremum_structure = 
+            PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
 
         precompute_optical_thickness();
     }
@@ -544,6 +551,7 @@ public:
             << "  albedo        = " << string::indent(m_albedo) << std::endl
             << "  sigma_t       = " << string::indent(m_sigmat) << std::endl
             << "  scale         = " << string::indent(m_scale) << std::endl
+            << "  extremum      = " << string::indent(m_extremum_structure) << std::endl
             << "]";
         return oss.str();
     }

--- a/src/eradiate_plugins/volumes/sphericalcoords.cpp
+++ b/src/eradiate_plugins/volumes/sphericalcoords.cpp
@@ -153,6 +153,8 @@ public:
     }
 
     ScalarFloat max() const override { return dr::maximum(dr::maximum(m_volume->max(), m_fillmin), m_fillmax); }
+    
+    ScalarFloat min() const override { return dr::minimum(dr::minimum(m_volume->min(), m_fillmin), m_fillmax); }
 
     ScalarVector3i resolution() const override { return m_volume->resolution(); };
 

--- a/src/media/heterogeneous.cpp
+++ b/src/media/heterogeneous.cpp
@@ -150,7 +150,7 @@ template <typename Float, typename Spectrum>
 class HeterogeneousMedium final : public Medium<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
-                    m_phase_function, m_extremum_structure, m_has_local_extremum)
+                    m_phase_function, m_extremum_structure)
     MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure, ExtremumStructurePtr)
 
     HeterogeneousMedium(const Properties &props) : Base(props) {
@@ -162,10 +162,25 @@ public:
         m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
 
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
 
-        if (m_has_local_extremum && m_has_spectral_extinction) {
-            Throw("Local majorants of spectral volumes are not supported.");
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
+        for (auto &prop : props.objects()) {
+            if (auto *extremum = prop.try_get<ExtremumStructure>()) {
+                if (m_extremum_structure)
+                    Throw("Only a single extremum structure can be specified per medium");
+                m_extremum_structure = extremum;
+            }
         }
+
+        if (!m_extremum_structure) {
+            // Create a default global extremum structure
+            Properties props_extr("extremum_global");
+            props_extr.set("volume", (Object *) m_sigmat.get());
+            m_extremum_structure = 
+                PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+        }
+// #ERADIATE_CHANGE_END
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -177,6 +192,7 @@ public:
 
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
     }
 
     UnpolarizedSpectrum
@@ -184,6 +200,13 @@ public:
                  Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
         return m_max_density;
+    }
+
+    UnpolarizedSpectrum
+    get_minorant(const MediumInteraction3f & /* mi */,
+                 Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+        return m_min_density;
     }
 
     std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum, UnpolarizedSpectrum>
@@ -196,17 +219,7 @@ public:
             sigmat *= m_phase_function->projected_area(mi, active);
 
         auto sigmas = sigmat * m_albedo->eval(mi, active);
-        
-// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
-        Float min, max;
-        if (m_has_local_extremum)
-            std::tie(min, max) = m_extremum_structure->eval_1(mi, active);
-        else
-            max = m_max_density;
-
-        auto sigman = max - sigmat;
-// #ERADIATE_CHANGE_END    
-    
+        auto sigman = m_max_density - sigmat;
         return { sigmas, sigman, sigmat };
     }
 
@@ -221,6 +234,7 @@ public:
             << "  albedo  = " << string::indent(m_albedo) << std::endl
             << "  sigma_t = " << string::indent(m_sigmat) << std::endl
             << "  scale   = " << string::indent(m_scale) << std::endl
+            << "  extremum = "<< string::indent(m_extremum_structure) << std::endl
             << "]";
         return oss.str();
     }
@@ -230,6 +244,7 @@ private:
     ref<Volume> m_sigmat, m_albedo;
     ScalarFloat m_scale;
     Float m_max_density;
+    Float m_min_density;
 
     MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)
 };

--- a/src/media/heterogeneous.cpp
+++ b/src/media/heterogeneous.cpp
@@ -8,7 +8,9 @@
 #include <mitsuba/render/sampler.h>
 #include <mitsuba/render/scene.h>
 #include <mitsuba/render/volume.h>
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
 #include <mitsuba/render/eradiate/extremum.h>
+// #ERADIATE_CHANGE_END
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -174,10 +176,11 @@ public:
         }
 
         if (!m_extremum_structure) {
-            // Create a default global extremum structure
+            // Create a default global extremum structure.
             Properties props_extr("extremum_global");
             props_extr.set("volume", (Object *) m_sigmat.get());
-            m_extremum_structure = 
+            props_extr.set("scale", m_scale);
+            m_extremum_structure =
                 PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
         }
 // #ERADIATE_CHANGE_END
@@ -192,7 +195,9 @@ public:
 
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
         m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
+// #ERADIATE_CHANGE_END
     }
 
     UnpolarizedSpectrum
@@ -202,12 +207,14 @@ public:
         return m_max_density;
     }
 
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
     UnpolarizedSpectrum
     get_minorant(const MediumInteraction3f & /* mi */,
                  Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
         return m_min_density;
     }
+// #ERADIATE_CHANGE_END
 
     std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum, UnpolarizedSpectrum>
     get_scattering_coefficients(const MediumInteraction3f &mi,
@@ -231,10 +238,12 @@ public:
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "HeterogeneousMedium[" << std::endl
-            << "  albedo  = " << string::indent(m_albedo) << std::endl
-            << "  sigma_t = " << string::indent(m_sigmat) << std::endl
-            << "  scale   = " << string::indent(m_scale) << std::endl
+            << "  albedo  = " << string::indent(m_albedo) <<  "," << std::endl
+            << "  sigma_t = " << string::indent(m_sigmat) << "," << std::endl
+            << "  scale   = " << string::indent(m_scale) << "," << std::endl
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
             << "  extremum = "<< string::indent(m_extremum_structure) << std::endl
+// #ERADIATE_CHANGE_END
             << "]";
         return oss.str();
     }
@@ -244,7 +253,9 @@ private:
     ref<Volume> m_sigmat, m_albedo;
     ScalarFloat m_scale;
     Float m_max_density;
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
     Float m_min_density;
+// #ERADIATE_CHANGE_END
 
     MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)
 };

--- a/src/media/homogeneous.cpp
+++ b/src/media/homogeneous.cpp
@@ -8,6 +8,7 @@
 #include <mitsuba/render/sampler.h>
 #include <mitsuba/render/scene.h>
 #include <mitsuba/render/volume.h>
+#include <mitsuba/render/eradiate/extremum.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -131,8 +132,8 @@ However, it supports the use of a spatially varying albedo.
 template <typename Float, typename Spectrum>
 class HomogeneousMedium final : public Medium<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction, m_phase_function)
-    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume)
+    MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction, m_phase_function, m_extremum_structure)
+    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure)
 
     HomogeneousMedium(const Properties &props) : Base(props) {
         m_is_homogeneous = true;
@@ -141,6 +142,14 @@ public:
 
         m_scale = props.get<ScalarFloat>("scale", 1.0f);
         m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
+
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
+        // Create a default global extremum structure
+        Properties props_extr("extremum_global");
+        props_extr.set("volume", (Object *) m_sigmat.get());
+        m_extremum_structure = 
+            PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+// #ERADIATE_CHANGE_END
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -159,6 +168,13 @@ public:
 
     UnpolarizedSpectrum
     get_majorant(const MediumInteraction3f &mi,
+                 Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+        return eval_sigmat(mi, active) & active;
+    }
+
+    UnpolarizedSpectrum
+    get_minorant(const MediumInteraction3f &mi,
                  Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
         return eval_sigmat(mi, active) & active;

--- a/src/media/homogeneous.cpp
+++ b/src/media/homogeneous.cpp
@@ -8,7 +8,9 @@
 #include <mitsuba/render/sampler.h>
 #include <mitsuba/render/scene.h>
 #include <mitsuba/render/volume.h>
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
 #include <mitsuba/render/eradiate/extremum.h>
+// #ERADIATE_CHANGE_END
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -132,6 +134,7 @@ However, it supports the use of a spatially varying albedo.
 template <typename Float, typename Spectrum>
 class HomogeneousMedium final : public Medium<Float, Spectrum> {
 public:
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction, m_phase_function, m_extremum_structure)
     MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure)
 
@@ -143,10 +146,10 @@ public:
         m_scale = props.get<ScalarFloat>("scale", 1.0f);
         m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
 
-// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
         // Create a default global extremum structure
         Properties props_extr("extremum_global");
         props_extr.set("volume", (Object *) m_sigmat.get());
+        props_extr.set("scale", m_scale);
         m_extremum_structure = 
             PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
 // #ERADIATE_CHANGE_END
@@ -173,12 +176,14 @@ public:
         return eval_sigmat(mi, active) & active;
     }
 
+// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
     UnpolarizedSpectrum
     get_minorant(const MediumInteraction3f &mi,
                  Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
         return eval_sigmat(mi, active) & active;
     }
+// #ERADIATE_CHANGE_END
 
     std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum, UnpolarizedSpectrum>
     get_scattering_coefficients(const MediumInteraction3f &mi,

--- a/src/render/CMakeLists.txt
+++ b/src/render/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(mitsuba-render OBJECT
 
   ${ER_SRC}/extremum.cpp    ${ER_INC}/extremum.h
                             ${ER_INC}/extremum_segment.h
+                            ${ER_INC}/tracking.h
                             
   ${LIBRENDER_EXTRA_SRC}
 )

--- a/src/render/eradiate/extremum.cpp
+++ b/src/render/eradiate/extremum.cpp
@@ -14,5 +14,20 @@ MI_VARIANT ExtremumStructure<Float, Spectrum>::ExtremumStructure(const Propertie
 MI_VARIANT ExtremumStructure<Float, Spectrum>::~ExtremumStructure() {
 }
 
+MI_VARIANT 
+TrackingState<Float, Spectrum> 
+ExtremumStructure<Float, Spectrum>::traverse_extremum(
+    const Ray3f &/*ray*/,
+    Float /*mint*/,
+    Float /*maxt*/,
+    UInt32 /*channel*/,
+    TrackingState /*state*/,
+    TrackingFunction * /*func*/,
+    Mask /*active*/
+) const {
+    NotImplementedError("traverse_extremum");
+    return TrackingState();
+}
+
 MI_INSTANTIATE_CLASS(ExtremumStructure)
 NAMESPACE_END(mitsuba)

--- a/src/render/eradiate/extremum.cpp
+++ b/src/render/eradiate/extremum.cpp
@@ -26,7 +26,6 @@ ExtremumStructure<Float, Spectrum>::traverse_extremum(
     Mask /*active*/
 ) const {
     NotImplementedError("traverse_extremum");
-    return TrackingState();
 }
 
 MI_INSTANTIATE_CLASS(ExtremumStructure)

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -12,28 +12,20 @@ NAMESPACE_BEGIN(mitsuba)
 MI_VARIANT Medium<Float, Spectrum>::Medium()
     : JitObject<Medium>(""),
       m_is_homogeneous(false),
-      m_has_spectral_extinction(true),
-      m_has_local_extremum(false) {
+      m_has_spectral_extinction(true) {
 }
 
 MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props)
     : JitObject<Medium>(props.id()) {
-
-// #ERADIATE_CHANGE_BEGIN: Initialize extremum structure from properties
     for (auto &prop : props.objects()) {
         if (PhaseFunction *phase = prop.try_get<PhaseFunction>()) {
             if (m_phase_function)
                 Throw("Only a single phase function can be specified per medium");
             m_phase_function = phase;
         }
-        if (auto *extremum = prop.try_get<ExtremumStructure>()) {
-            if (m_extremum_structure)
-                Throw("Only a single extremum structure can be specified per medium");
-            m_extremum_structure = extremum;
-        }
     }
-
-    m_has_local_extremum = m_extremum_structure != nullptr;
+// #ERADIATE_CHANGE_BEGIN: tracking property.
+    m_use_rrt = props.get<bool>("use_rrt", true);
 // #ERADIATE_CHANGE_END
 
     if (!m_phase_function) {
@@ -54,22 +46,19 @@ MI_VARIANT void Medium<Float, Spectrum>::traverse(TraversalCallback *cb) {
 // #ERADIATE_CHANGE_END
 }
 
-// #ERADIATE_CHANGE_BEGIN: Refactored for extremum structure support
 MI_VARIANT
 typename Medium<Float, Spectrum>::MediumInteraction3f
 Medium<Float, Spectrum>::sample_interaction(const Ray3f &ray, Float sample,
                                             UInt32 channel, Mask active) const {
     MI_MASKED_FUNCTION(ProfilerPhase::MediumSample, active);
 
-    // Initialize basic medium interaction fields
+    // initialize basic medium interaction fields
     MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
     mei.wi          = -ray.d;
     mei.sh_frame    = Frame3f(mei.wi);
     mei.time        = ray.time;
     mei.wavelengths = ray.wavelengths;
-    mei.medium      = this;
 
-    // Intersect AABB
     auto [aabb_its, mint, maxt] = intersect_aabb(ray);
     aabb_its &= (dr::isfinite(mint) || dr::isfinite(maxt));
     active &= aabb_its;
@@ -78,53 +67,28 @@ Medium<Float, Spectrum>::sample_interaction(const Ray3f &ray, Float sample,
 
     mint = dr::maximum(0.f, mint);
     maxt = dr::minimum(ray.maxt, maxt);
-    mei.mint = mint;
 
-    Float target_ot = -dr::log(1.f - sample);
-    Float sampled_t;
-    UnpolarizedSpectrum combined_extinction;
-
-    if (m_has_local_extremum) {
-        // Use extremum structure with local majorants
-        auto [segment, ot_acc] = m_extremum_structure->sample_segment(ray, mint, maxt, target_ot, active);
-        sampled_t = segment.mint +
-                (target_ot - ot_acc) / dr::maximum(segment.majorant(), dr::Epsilon<Float>);
-                
-        // Store local majorant in combined_extinction
-        combined_extinction[0] = segment.majorant();
-        if constexpr (is_rgb_v<Spectrum>) {
-            combined_extinction[1] = segment.majorant();
-            combined_extinction[2] = segment.majorant();
-        } else {
-            DRJIT_MARK_USED(channel);
-        }
+    auto combined_extinction = get_majorant(mei, active);
+    Float m                  = combined_extinction[0];
+    if constexpr (is_rgb_v<Spectrum>) { // Handle RGB rendering
+        dr::masked(m, channel == 1u) = combined_extinction[1];
+        dr::masked(m, channel == 2u) = combined_extinction[2];
     } else {
-        // Traditional global majorant sampling
-        combined_extinction = get_majorant(mei, active);
-        Float m = combined_extinction[0];
-        if constexpr (is_rgb_v<Spectrum>) {
-            dr::masked(m, channel == 1u) = combined_extinction[1];
-            dr::masked(m, channel == 2u) = combined_extinction[2];
-        } else {
-            DRJIT_MARK_USED(channel);
-        }
-        sampled_t = mint + (target_ot / m);
+        DRJIT_MARK_USED(channel);
     }
 
-    // Finalize interaction
-    Mask valid_mi = active && (sampled_t <= maxt);
-    mei.t = dr::select(valid_mi, sampled_t, dr::Infinity<Float>);
-    mei.p = ray(sampled_t);
+    Float sampled_t = mint + (-dr::log(1 - sample) / m);
+    Mask valid_mi   = active && (sampled_t <= maxt);
+    mei.t           = dr::select(valid_mi, sampled_t, dr::Infinity<Float>);
+    mei.p           = ray(sampled_t);
+    mei.medium      = this;
+    mei.mint        = mint;
 
-    // TODO: with local extremum structures, this triggers a redundant evaluation
-    // of the extremum grid. To fix this we probably need to change the medium interface.
     std::tie(mei.sigma_s, mei.sigma_n, mei.sigma_t) =
         get_scattering_coefficients(mei, valid_mi);
     mei.combined_extinction = combined_extinction;
-    
     return mei;
 }
-// #ERADIATE_CHANGE_END
 
 MI_VARIANT
 std::pair<typename Medium<Float, Spectrum>::UnpolarizedSpectrum,
@@ -134,14 +98,7 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
                                                 Mask active) const {
     MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
 
-    // TODO: The maximum check is a hack to ensure we don't get nans. This function
-    // is technically incorrect in the presence of local majorant because the value of
-    // the transmittance is dependent on the on traversed local majorant and not just
-    // the last encountered majorant. We could probably use the segment's accumulated
-    // OD in some way but would then need to traverse it again if si.t < mi.t.
-    // We might need to shift around some of the integrators operations but this 
-    // decreases the chances of having it integrated within Mitsuba.
-    Float t      = dr::maximum(dr::minimum(mi.t, si.t) - mi.mint, 0.f); 
+    Float t      = dr::minimum(mi.t, si.t) - mi.mint;
     UnpolarizedSpectrum tr  = dr::exp(-t * mi.combined_extinction);
     UnpolarizedSpectrum pdf = dr::select(si.t < mi.t, tr, tr * mi.combined_extinction);
     return { tr, pdf };
@@ -169,6 +126,33 @@ Medium<Float, Spectrum>::eval_transmittance_pdf_real(const Ray3f &/*ray*/,
     return {0.f, 0.f, false};
 }
 // #RAY_CHANGE_END
+
+// #ERADIATE_CHANGE_BEGIN: Extremum structure accessor
+MI_VARIANT
+std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float, Float>
+Medium<Float, Spectrum>::prepare_medium_traversal(const Ray3f& ray, Mask active) const {
+    // Initialize basic medium interaction fields
+    MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
+    mei.wi          = -ray.d;
+    mei.sh_frame    = Frame3f(mei.wi);
+    mei.time        = ray.time;
+    mei.wavelengths = ray.wavelengths;
+    mei.medium      = this;
+
+    // Intersect AABB
+    auto [aabb_its, mint, maxt] = intersect_aabb(ray);
+    aabb_its &= (dr::isfinite(mint) || dr::isfinite(maxt));
+    active &= aabb_its;
+    dr::masked(mint, !active) = 0.f;
+    dr::masked(maxt, !active) = dr::Infinity<Float>;
+
+    mint = dr::maximum(0.f, mint);
+    maxt = dr::minimum(ray.maxt, maxt);
+    mei.mint = mint;
+
+    return {mei, mint, maxt};
+}
+// #ERADIATE_CHANGE_END
 
 MI_IMPLEMENT_TRAVERSE_CB(Medium, Object)
 MI_INSTANTIATE_CLASS(Medium)

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -146,8 +146,8 @@ Medium<Float, Spectrum>::prepare_medium_traversal(const Ray3f& ray, Mask active)
     dr::masked(mint, !active) = 0.f;
     dr::masked(maxt, !active) = dr::Infinity<Float>;
 
-    mint = dr::maximum(0.f, mint);
-    maxt = dr::minimum(ray.maxt, maxt);
+    dr::masked(mint, active) = dr::maximum(0.f, mint);
+    dr::masked(maxt, active) = dr::minimum(ray.maxt, maxt);
     mei.mint = mint;
 
     return {mei, mint, maxt};

--- a/src/render/python/eradiate/extremum_v.cpp
+++ b/src/render/python/eradiate/extremum_v.cpp
@@ -35,22 +35,15 @@ MI_PY_EXPORT(ExtremumSegment) {
 }
 
 /// Trampoline for derived types implemented in Python
+// Note that `traverse_extremum` does not appear in this list. This is because
+// it accepts a concrete function pointer as parameter, the binding of which
+// has not been solved yet.
 MI_VARIANT class PyExtremumStructure : public ExtremumStructure<Float, Spectrum> {
 public:
     MI_IMPORT_TYPES(ExtremumStructure)
     NB_TRAMPOLINE(ExtremumStructure, 4);
 
     PyExtremumStructure(const Properties &props) : ExtremumStructure(props) {}
-
-    std::tuple<ExtremumSegment, Float> sample_segment(
-        const Ray3f &ray,
-        Float mint,
-        Float maxt,
-        Float target_ot,
-        Mask active
-    ) const override {
-        NB_OVERRIDE_PURE(sample_segment, ray, mint, maxt, target_ot, active);
-    }
 
     std::tuple<Float, Float> eval_1(
         const Interaction3f &it,
@@ -77,21 +70,13 @@ public:
 template <typename Ptr, typename Cls> void bind_extremum_structure_generic(Cls &cls) {
     MI_PY_IMPORT_TYPES(ExtremumStructure, Medium)
 
-    cls.def("sample_segment",
-            [](Ptr ptr, const Ray3f &ray, Float mint, Float maxt,
-               Float target_ot, Mask active) {
-                return ptr->sample_segment(ray, mint, maxt, target_ot, active);
-            },
-            "ray"_a, "mint"_a, "maxt"_a, "target_ot"_a, "active"_a = true,
-            D(ExtremumStructure, sample_segment))
-        .def("eval_1",
+    cls.def("eval_1",
             [](Ptr ptr, const Interaction3f &it, Mask active) {
                 return ptr->eval_1(it, active);
             },
             "it"_a, "active"_a = true,
             D(ExtremumStructure, eval_1));
 }
-
 
 
 MI_PY_EXPORT(ExtremumStructure) {

--- a/src/render/python/texture_v.cpp
+++ b/src/render/python/texture_v.cpp
@@ -67,6 +67,12 @@ public:
         NB_OVERRIDE_PURE(max);
     }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override {
+        NB_OVERRIDE_PURE(min);
+    }
+// #ERADIATE_CHANGE_END
+
     ScalarVector2i resolution() const override {
         NB_OVERRIDE(resolution);
     }
@@ -148,6 +154,11 @@ template <typename Ptr, typename Cls> void bind_texture_generic(Cls &cls) {
         .def("max",
              [](Ptr texture) { return texture->max(); },
              D(Texture, max))
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension        
+        .def("min",
+             [](Ptr texture) { return texture->min(); },
+             D(Texture, min))
+// #ERADIATE_CHANGE_END
         .def("is_spatially_varying",
              [](Ptr texture) { return texture->is_spatially_varying(); },
              D(Texture, is_spatially_varying));

--- a/src/render/python/volume_v.cpp
+++ b/src/render/python/volume_v.cpp
@@ -47,6 +47,12 @@ public:
     ScalarFloat max() const override {
         NB_OVERRIDE_PURE(max);
     }
+    
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override {
+        NB_OVERRIDE_PURE(min);
+    }
+// #ERADIATE_CHANGE_END
 
     ScalarVector3i resolution() const override {
         NB_OVERRIDE(resolution);
@@ -85,6 +91,16 @@ MI_PY_EXPORT(Volume) {
                 return max_values;
             },
             D(Volume, max_per_channel))
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+        .def_method(Volume, min)
+        .def("min_per_channel",
+            [] (const Volume *volume) {
+                std::vector<ScalarFloat> min_values(volume->channel_count());
+                volume->min_per_channel(min_values.data());
+                return min_values;
+            },
+            D(Volume, min_per_channel))
+// #ERADIATE_CHANGE_END
         .def_method(Volume, eval, "it"_a, "active"_a = true)
         .def_method(Volume, eval_1, "it"_a, "active"_a = true)
         .def_method(Volume, eval_3, "it"_a, "active"_a = true)

--- a/src/render/python/volumegrid_v.cpp
+++ b/src/render/python/volumegrid_v.cpp
@@ -13,8 +13,9 @@ MI_PY_EXPORT(VolumeGrid) {
 
     using CpuNdArray = nb::ndarray<ScalarFloat, nb::c_contig, nb::device::cpu>;
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
     auto init_cpu_ndarray = [](VolumeGrid* t, 
-        CpuNdArray obj, bool compute_max = true) {
+        CpuNdArray obj, bool compute_max = true, bool compute_min = true) {
         if (obj.ndim() != 3 && obj.ndim() != 4)
             throw nb::type_error("Expected an array of size 3 or 4");
 
@@ -31,18 +32,45 @@ MI_PY_EXPORT(VolumeGrid) {
 
         ScalarFloat max = 0.f;
         std::vector<ScalarFloat> max_per_channel(channel_count, -dr::Infinity<ScalarFloat>);
-        if (compute_max) {
+
+        ScalarFloat min = dr::Infinity<ScalarFloat>;
+        std::vector<ScalarFloat> min_per_channel(channel_count, dr::Infinity<ScalarFloat>);
+
+        if (compute_max || compute_min) {
+            ScalarFloat max_ = 0.f;
+            std::vector<ScalarFloat> max_per_channel_(channel_count, -dr::Infinity<ScalarFloat>);
+            ScalarFloat min_ = dr::Infinity<ScalarFloat>;
+            std::vector<ScalarFloat> min_per_channel_(channel_count, dr::Infinity<ScalarFloat>);
+
             size_t ch_index = 0;
             for (size_t i = 0; i < dr::prod(size) * channel_count; ++i) {
-                max = dr::maximum(max, volumegrid->data()[i]);
+                max_ = dr::maximum(max_, volumegrid->data()[i]);
+                min_ = dr::minimum(min_, volumegrid->data()[i]);
+
                 ch_index = i % channel_count;
-                max_per_channel[ch_index] = dr::maximum(
-                    max_per_channel[ch_index], volumegrid->data()[i]);
+                max_per_channel_[ch_index] = dr::maximum(
+                    max_per_channel_[ch_index], volumegrid->data()[i]);
+                min_per_channel_[ch_index] = dr::minimum(
+                    min_per_channel_[ch_index], volumegrid->data()[i]);
+            }
+
+            if (compute_max) {
+                max = max_;
+                max_per_channel = max_per_channel_;
+            }
+
+            if (compute_min) {
+                min = min_;
+                min_per_channel = min_per_channel_;
             }
         }
 
         volumegrid->set_max(max);
         volumegrid->set_max_per_channel(max_per_channel.data());
+
+        volumegrid->set_min(min);
+        volumegrid->set_min_per_channel(min_per_channel.data());
+// #ERADIATE_CHANGE_END
     };
 
     auto volume_grid = MI_PY_CLASS(VolumeGrid, Object)
@@ -50,10 +78,12 @@ MI_PY_EXPORT(VolumeGrid) {
             nb::call_guard<nb::gil_scoped_release>())
         .def(nb::init<Stream *>(), "stream"_a,
             nb::call_guard<nb::gil_scoped_release>())
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
         .def("__init__", init_cpu_ndarray
-            , "array"_a, "compute_max"_a = true, "Initialize a VolumeGrid from a CPU-visible ndarray")
+            , "array"_a, "compute_max"_a = true, "compute_min"_a = true, "Initialize a VolumeGrid from a CPU-visible ndarray")
         .def("__init__",
-            [&init_cpu_ndarray](VolumeGrid* t, TensorXf& obj, bool compute_max = true) {
+            [&init_cpu_ndarray](VolumeGrid* t, TensorXf& obj, bool compute_max = true, bool compute_min = true) {
+// #ERADIATE_CHANGE_END
 
             DynamicBuffer<ScalarFloat> cpu_array;
 
@@ -65,11 +95,12 @@ MI_PY_EXPORT(VolumeGrid) {
                 cpu_array = dr::zeros<DynamicBuffer<ScalarFloat>>(buffer_size);
                 dr::store(cpu_array.data(), obj.array());
             }
-
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
             init_cpu_ndarray(t,
                 CpuNdArray(cpu_array.data(), obj.ndim(), &obj.shape()[0], nb::handle()),
-                compute_max);
-         }, "array"_a, "compute_max"_a = true, "Initialize a VolumeGrid from a drjit tensor")
+                compute_max, compute_min);
+         }, "array"_a, "compute_max"_a = true, "compute_min"_a = true, "Initialize a VolumeGrid from a drjit tensor")
+// #ERADIATE_CHANGE_END
         .def_method(VolumeGrid, size)
         .def_method(VolumeGrid, channel_count)
         .def_method(VolumeGrid, max)
@@ -86,6 +117,22 @@ MI_PY_EXPORT(VolumeGrid) {
                 volgrid->set_max_per_channel(max_values.data());
             },
             D(VolumeGrid, set_max_per_channel))
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+        .def_method(VolumeGrid, min)
+        .def("min_per_channel",
+            [] (const VolumeGrid *volgrid) {
+                std::vector<ScalarFloat> min_values(volgrid->channel_count());
+                volgrid->min_per_channel(min_values.data());
+                return min_values;
+            },
+            D(VolumeGrid, min_per_channel))
+        .def_method(VolumeGrid, set_min)
+        .def("set_min_per_channel",
+            [] (VolumeGrid *volgrid, std::vector<ScalarFloat> &min_values) {
+                volgrid->set_min_per_channel(min_values.data());
+            },
+            D(VolumeGrid, set_min_per_channel))
+// #ERADIATE_CHANGE_END
         .def_method(VolumeGrid, bytes_per_voxel)
         .def_method(VolumeGrid, buffer_size)
         .def("write", nb::overload_cast<Stream *>(&VolumeGrid::write, nb::const_),

--- a/src/render/tests/test_volumegrid.py
+++ b/src/render/tests/test_volumegrid.py
@@ -12,14 +12,15 @@ def test01_numpy_conversion(variants_all_scalar, np_rng):
     assert dr.allclose(np.max(a), grid.max())
     assert dr.allclose([a.shape[2], a.shape[1], a.shape[0]], grid.size())
     assert dr.allclose(a.shape[3], grid.channel_count())
-
+# #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
     # Don't ask for computation of the maximum value
-    grid = mi.VolumeGrid(a, False)
+    grid = mi.VolumeGrid(a, False, False)
     assert dr.allclose(a, np.array(grid), atol=1e-3, rtol=1e-5)
     assert dr.allclose(grid.max(), 0.0)
     assert dr.allclose([a.shape[2], a.shape[1], a.shape[0]], grid.size())
     assert dr.allclose(a.shape[3], grid.channel_count())
-
+    assert dr.isinf(grid.min())
+# #ERADIATE_CHANGE_END
 
 def test02_read_write(variants_all_scalar, tmpdir, np_rng):
     tmp_file = os.path.join(str(tmpdir), "out.vol")
@@ -46,3 +47,21 @@ def test03_max_per_channel(variants_all_scalar, tmpdir, np_rng):
     grid = mi.VolumeGrid(tmp_file)
     mi_max_per_channel = grid.max_per_channel()
     assert dr.allclose(np_max_per_channel, mi_max_per_channel)
+
+# #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+def test04_min_per_channel(variants_all_scalar, tmpdir, np_rng):
+    tmp_file = os.path.join(str(tmpdir), "out.vol")
+    data = np_rng.random((4, 8, 16, 3))
+    grid = mi.VolumeGrid(data)
+    grid.write(tmp_file)
+    np_min_per_channel = np.array([np.min(data[:,:,:,0]),
+                                   np.min(data[:,:,:,1]),
+                                   np.min(data[:,:,:,2])])
+    # Check direct construction compute the minimum values
+    mi_min_per_channel = grid.min_per_channel()
+    assert dr.allclose(np_min_per_channel, mi_min_per_channel)
+    # Check disk construction compute the minimum values
+    grid = mi.VolumeGrid(tmp_file)
+    mi_min_per_channel = grid.min_per_channel()
+    assert dr.allclose(np_min_per_channel, mi_min_per_channel)
+# #ERADIATE_CHANGE_END

--- a/src/render/texture.cpp
+++ b/src/render/texture.cpp
@@ -108,5 +108,12 @@ Texture<Float, Spectrum>::max() const {
     NotImplementedError("max");
 }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+MI_VARIANT typename Texture<Float, Spectrum>::ScalarFloat
+Texture<Float, Spectrum>::min() const {
+    NotImplementedError("min");
+}
+// #ERADIATE_CHANGE_END
+
 MI_INSTANTIATE_CLASS(Texture)
 NAMESPACE_END(mitsuba)

--- a/src/render/volume.cpp
+++ b/src/render/volume.cpp
@@ -57,6 +57,16 @@ Volume<Float, Spectrum>::max_per_channel(ScalarFloat * /*out*/) const {
     NotImplementedError("max_per_channel");
 }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+MI_VARIANT typename Volume<Float, Spectrum>::ScalarFloat
+Volume<Float, Spectrum>::min() const { NotImplementedError("min"); }
+
+MI_VARIANT void
+Volume<Float, Spectrum>::min_per_channel(ScalarFloat * /*out*/) const {
+    NotImplementedError("min_per_channel");
+}
+// #ERADIATE_CHANGE_END
+
 // #ERADIATE_CHANGE_BEGIN: Local extremum support
 MI_VARIANT std::pair<Float, Float>
 Volume<Float, Spectrum>::extremum(BoundingBox3f /*bbox*/, Mask /*local*/) const {

--- a/src/render/volumegrid.cpp
+++ b/src/render/volumegrid.cpp
@@ -20,7 +20,10 @@ VolumeGrid<Float, Spectrum>::VolumeGrid(ScalarVector3u size,
                                         ScalarUInt32 channel_count)
     : m_size(size), m_channel_count(channel_count),
       m_bbox(ScalarBoundingBox3f(ScalarPoint3f(0.f), ScalarPoint3f(1.f))),
-      m_max_per_channel(channel_count, 0.f) {
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+      m_max_per_channel(channel_count, 0.f),
+      m_min_per_channel(channel_count, 0.f) {
+// #ERADIATE_CHANGE_END
     m_data = std::unique_ptr<ScalarFloat[]>(
         new ScalarFloat[dr::prod(m_size) * m_channel_count]);
 }
@@ -65,6 +68,9 @@ void VolumeGrid<Float, Spectrum>::read(Stream *stream) {
 
     m_max = -dr::Infinity<ScalarFloat>;
     m_max_per_channel.resize(m_channel_count, -dr::Infinity<ScalarFloat>);
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    m_min = dr::Infinity<ScalarFloat>;
+    m_min_per_channel.resize(m_channel_count, dr::Infinity<ScalarFloat>);
 
     m_data = std::unique_ptr<ScalarFloat[]>(new ScalarFloat[size * m_channel_count]);
     size_t k = 0;
@@ -75,9 +81,14 @@ void VolumeGrid<Float, Spectrum>::read(Stream *stream) {
             m_data[k] = val;
             m_max     = dr::maximum(m_max, val);
             m_max_per_channel[j] = dr::maximum(m_max_per_channel[j], val);
+            
+            m_min     = dr::minimum(m_min, val);
+            m_min_per_channel[j] = dr::minimum(m_min_per_channel[j], val);
+            
             ++k;
         }
     }
+// #ERADIATE_CHANGE_END
     Log(Debug, "Loaded grid volume data from file: dimensions %s, max value %f",
         m_size, m_max);
 }
@@ -87,6 +98,14 @@ void VolumeGrid<Float, Spectrum>::max_per_channel(ScalarFloat *out) const {
     for (size_t i=0; i<m_channel_count; ++i)
         out[i] = m_max_per_channel[i];
 }
+
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+MI_VARIANT
+void VolumeGrid<Float, Spectrum>::min_per_channel(ScalarFloat *out) const {
+    for (size_t i=0; i<m_channel_count; ++i)
+        out[i] = m_min_per_channel[i];
+}
+// #ERADIATE_CHANGE_END
 
 MI_VARIANT
 void VolumeGrid<Float, Spectrum>::write(const fs::path &path) const {
@@ -133,6 +152,14 @@ std::string VolumeGrid<Float, Spectrum>::to_string() const {
     for (uint32_t i=0; i<m_max_per_channel.size(); ++i)
         oss << m_max_per_channel[i] << ", ";
     oss << std::endl;
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    oss << "  ],"  << std::endl
+        << "  min = " << m_min << "," << std::endl
+        << "  min_channels = [" << std::endl << "    ";
+    for (uint32_t i=0; i<m_min_per_channel.size(); ++i)
+        oss << m_min_per_channel[i] << ", ";
+    oss << std::endl;
+// #ERADIATE_CHANGE_END
     oss << "  ],"  << std::endl
         << "  data = [ " << util::mem_string(buffer_size())
         << " of volume data ]" << std::endl

--- a/src/spectra/d65.cpp
+++ b/src/spectra/d65.cpp
@@ -292,6 +292,21 @@ public:
         }
     }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override {
+        if constexpr (is_spectral_v<Spectrum>) {
+            if (m_nested_texture)
+                return m_nested_texture->min();
+            else if (m_has_value)
+                return dr::min_nested(srgb_model_mean(m_value));
+            else
+                return 1.f;
+        } else {
+            NotImplementedError("min");
+        }
+    }
+// #ERADIATE_CHANGE_END
+
     bool is_spatially_varying() const override {
         if (m_nested_texture)
             return m_nested_texture->is_spatially_varying();

--- a/src/spectra/srgb.cpp
+++ b/src/spectra/srgb.cpp
@@ -128,6 +128,15 @@ public:
             return dr::max_nested(m_value);
     }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override {
+        if constexpr (is_spectral_v<Spectrum>)
+            return dr::min_nested(srgb_model_mean(m_value));
+        else
+            return dr::min_nested(m_value);
+    }
+// #ERADIATE_CHANGE_END
+
     std::string to_string() const override {
         std::ostringstream oss;
         oss << "SRGBReflectanceSpectrum[" << std::endl

--- a/src/spectra/uniform.cpp
+++ b/src/spectra/uniform.cpp
@@ -123,6 +123,12 @@ public:
         return dr::slice(dr::max(m_value));
     }
 
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override {
+        return dr::slice(dr::min(m_value));
+    }
+// #ERADIATE_CHANGE_END
+
     std::string to_string() const override {
         return tfm::format("UniformSpectrum[value=%f]", m_value);
     }

--- a/src/volumes/const.cpp
+++ b/src/volumes/const.cpp
@@ -82,6 +82,9 @@ public:
     }
 
     ScalarFloat max() const override { return m_value->max(); }
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override { return m_value->min(); }
+// #ERADIATE_CHANGE_END
 
     std::string to_string() const override {
         std::ostringstream oss;

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -243,6 +243,8 @@ public:
                     std::unique_ptr<ScalarFloat[]>(new ScalarFloat[size * 4]);
                 ScalarFloat *scaled_data_ptr = scaled_data.get();
                 ScalarFloat max = 0.0;
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+                ScalarFloat min = 0.0;
                 for (ScalarUInt32 i = 0; i < size; ++i) {
                     ScalarColor3f rgb = dr::load<ScalarColor3f>(ptr);
                     // TODO: Make this scaling optional if the RGB values are
@@ -252,12 +254,14 @@ public:
                         rgb / dr::maximum((ScalarFloat) 1e-8, scale);
                     ScalarVector3f coeff = srgb_model_fetch(rgb_norm);
                     max = dr::maximum(max, scale);
+                    min = dr::maximum(min, scale);
                     dr::store(scaled_data_ptr,
                               dr::concat(coeff, dr::Array<ScalarFloat, 1>(scale)));
                     ptr += 3;
                     scaled_data_ptr += 4;
                 }
                 m_max = (float) max;
+                m_min = (float) min;
 
                 size_t shape[4] = {
                     (size_t) res.z(),
@@ -275,10 +279,15 @@ public:
                     channel_count
                 };
                 m_texture = Texture3f(TensorXf(volume_grid->data(), 4, shape),
-                                      m_accel, m_accel, filter_mode, wrap_mode);
+                                      m_accel, m_accel, filter_mode, wrap_mode);             
                 m_max = volume_grid->max();
                 m_max_per_channel.resize(volume_grid->channel_count());
                 volume_grid->max_per_channel(m_max_per_channel.data());
+                
+                m_min = volume_grid->min();
+                m_min_per_channel.resize(volume_grid->channel_count());
+                volume_grid->min_per_channel(m_min_per_channel.data());
+
                 m_channel_count = channel_count;
             } else if (tensor) {
                 size_t shape[4] = {
@@ -290,7 +299,9 @@ public:
                 m_texture = Texture3f(TensorXf(tensor->array(), 4, shape),
                                       m_accel, m_accel, filter_mode, wrap_mode);
                 m_max = (float) dr::max_nested(dr::detach(m_texture.value()));
+                m_min = (float) dr::min_nested(dr::detach(m_texture.value()));
                 m_channel_count = channel_count;
+// #ERADIATE_CHANGE_END
             }
         }
 
@@ -301,10 +312,14 @@ public:
             update_bbox();
         }
 
-// #ERADIATE_CHANGE_BEGIN: Local extremum support
         if (props.has_property("max_value")) {
             m_fixed_max = true;
             m_max = props.get<ScalarFloat>("max_value");
+        }
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+        if (props.has_property("min_value")) {
+            m_fixed_min = true;
+            m_min = props.get<ScalarFloat>("min_value");
         }
 // #ERADIATE_CHANGE_END
     }
@@ -327,11 +342,16 @@ public:
             if (!m_fixed_max)
                 m_max = (float) dr::max_nested(dr::detach(m_texture.value()));
 
+            if (!m_fixed_min)
+                m_min = (float) dr::min_nested(dr::detach(m_texture.value()));
+
+// #ERADIATE_CHANGE_BEGIN: Spatial extremum queries for grid volumes
             for (auto extremum : m_extremum_structures) {
                 if(extremum != nullptr)
                     extremum->parameters_changed(keys);
             }
         }
+// #ERADIATE_CHANGE_END
     }
 
     UnpolarizedSpectrum eval(const Interaction3f &it,
@@ -441,6 +461,15 @@ public:
         for (size_t i=0; i<m_max_per_channel.size(); ++i)
             out[i] = m_max_per_channel[i];
     }
+
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    ScalarFloat min() const override { return m_min; }
+
+    void min_per_channel(ScalarFloat *out) const override {
+        for (size_t i=0; i<m_min_per_channel.size(); ++i)
+            out[i] = m_min_per_channel[i];
+    }
+// #ERADIATE_CHANGE_END
 
 // #ERADIATE_CHANGE_BEGIN: Spatial extremum queries for grid volumes
     std::pair<Float, Float>
@@ -569,6 +598,9 @@ public:
             << "  bbox = " << string::indent(m_bbox) << "," << std::endl
             << "  dimensions = " << resolution() << "," << std::endl
             << "  max = " << m_max << "," << std::endl
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+            << "  min = " << m_min << "," << std::endl
+// #ERADIATE_CHANGE_END
             << "  channels = " << m_texture.shape()[3] << std::endl
             << "]";
         return oss.str();
@@ -759,6 +791,11 @@ protected:
     bool m_fixed_max = false;
     ScalarFloat m_max;
     std::vector<ScalarFloat> m_max_per_channel;
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
+    bool m_fixed_min = false;
+    ScalarFloat m_min;
+    std::vector<ScalarFloat> m_min_per_channel;
+// #ERADIATE_CHANGE_END
     
 // #ERADIATE_CHANGE_BEGIN: Local extremum support
     mutable const ScalarFloat* m_pinned_data = nullptr;

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -254,7 +254,7 @@ public:
                         rgb / dr::maximum((ScalarFloat) 1e-8, scale);
                     ScalarVector3f coeff = srgb_model_fetch(rgb_norm);
                     max = dr::maximum(max, scale);
-                    min = dr::maximum(min, scale);
+                    min = dr::minimum(min, scale);
                     dr::store(scaled_data_ptr,
                               dr::concat(coeff, dr::Array<ScalarFloat, 1>(scale)));
                     ptr += 3;


### PR DESCRIPTION
## Description

Hello, 
This PR offers a second pass on `EOVolumetricPathIntegrator`, `ExtremumStructure`, and adds residual ratio tracking as a transmittance estimator.

### Why was a refactoring already needed?
It came to light that the previous design whereby `Medium` passed callables to `ExtremumStructures` had major flaws: the implementation did not work with spectrally varying extinction coefficient, and this could not be fixed without breaking existing integrators.

### How does the new design fix this?
By delegating all the responsibility to the integrator. `ExtremumStructure` now exposes one function, `traverse_extremum` that loops through its extremum segments and calls a callback function at each iteration. Instead of calling `traverse_extremum` from the `Medium`, it is *directly called from the integrator*. This means that it is the integrator's choice to include extremum structures or not, and what to do within them (ratio tracking, residual ratio tracking, spectral MIS or not). The extremum structure only provides the framework for delivering extremum segments. 

Important consideration:
- Existing integrators are not compatible with Extremum Structures anymore, only `EOVolumetricPathIntegrator` is.
- For this to work, a shared `TrackingState` and `TrackingFunction` signature is available for all callers of `traverse_extremum`. It also means that if a caller needs to extend this structure, it will impact other callers.
- Every medium now has a default global majorant if none were provided.

### You mentioned Residual Ratio Tracking?
Rewriting EOVolPath gave us the opportunity to implement Residual Ratio Tracking, which at best reduces variance of transmittance estimation and improves performance, and at worst performs as well as ratio tracking. It utilizes a control coefficient along with the majorant. The implementation hinges on the fact that when the control coefficient is equal to 0, the algorithm devolves to ratio tracking. It is therefore possible to specify which transmittance estimator to use through the `use_rrt` parameter in medium. 

## Testing

We ran all `test_renders` scenes that include participating media to ensure the correct function of the integrator.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)