### PR TITLE
[Bug Fix] Fix `piecewise_volpath` for non spectral medium. Update analytical functions of the `Medium` interface.

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -2934,9 +2934,9 @@ that store local extrema (majorant/minorant) of volumetric extinction
 coefficients. This enables efficient delta tracking with locally-
 adaptive majorants.
 
-To minimize virtual function overhead, the ``sample_segment()`` method
-encapsulates the entire traversal loop internally, requiring only a
-single virtual call per distance sample.)doc";
+To minimize virtual function overhead, the ``traverse_extremum()``
+method encapsulates the entire traversal loop internally, requiring
+only a single virtual call per distance sample.)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_2 = R"doc()doc";
 
@@ -2980,13 +2980,15 @@ Returns:
 
 static const char *__doc_mitsuba_ExtremumStructure_m_bbox = R"doc(Bounding box of the extremum structure in world space)doc";
 
-static const char *__doc_mitsuba_ExtremumStructure_sample_segment =
-R"doc(Sample a segment along a ray with desired optical thickness
+static const char *__doc_mitsuba_ExtremumStructure_traverse_extremum =
+R"doc(Traverse the extremum along a ray and applies a callback at each
+encountered segment.
 
-This method traverses the extremum structure (e.g., via DDA for grids)
-and returns a segment where the accumulated optical thickness reaches
-the desired value. The traversal logic is completely encapsulated
-within this method to minimize virtual call overhead.
+This method traverses the extremum structure segment by segment. At
+each segment, the callback ``func`` is called to advance the
+``state``. This is useful for example to implement Delta Tracking,
+Ratio Tracking, and Residual Ratio Tracking. The callback is typically
+defined in the integrator.
 
 Parameter ``ray``:
     Ray along which to sample
@@ -2997,17 +2999,26 @@ Parameter ``mint``:
 Parameter ``maxt``:
     Maximum distance to consider
 
-Parameter ``target_ot``:
-    Target optical thickness to accumulate
+Parameter ``channel``:
+    Channel from which to sample
+
+Parameter ``state``:
+    Mutable tracking state carried through the traversal loop
+
+Parameter ``func``:
+    Callback function called at every segment.
 
 Parameter ``active``:
     Mask for active lanes
 
 Returns:
-    ExtremumSegment containing the sampled distance (mint), segment
-    bounds, and local majorant/minorant values. If desired_tau cannot
-    be reached, mint is set to Infinity. Accumulated optical thickness
-    at segment start.)doc";
+    The final tracking state, that includes the medium interaction if
+    a real scattering event was sampled, and the throughput and pdfs
+    accumulated throughout the traversal.
+
+Note that this function cannot be made abstract because of it would
+force the requirement for bindings, which are incompatible with
+function types.)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_type = R"doc()doc";
 
@@ -4750,13 +4761,11 @@ static const char *__doc_mitsuba_Medium_Medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_class_name = R"doc()doc";
 
-static const char *__doc_mitsuba_Medium_eval_transmittance_pdf_real = R"doc()doc";
-
-static const char *__doc_mitsuba_Medium_extremum_structure =
-R"doc(Returns the extremum structure for local majorant acceleration
-(nullptr if not used))doc";
+static const char *__doc_mitsuba_Medium_extremum_structure = R"doc(Returns the extremum structure for local extremum acceleration.)doc";
 
 static const char *__doc_mitsuba_Medium_get_majorant = R"doc(Returns the medium's majorant used for delta tracking)doc";
+
+static const char *__doc_mitsuba_Medium_get_minorant = R"doc(Returns the medium's minorant used for residual ratio tracking)doc";
 
 static const char *__doc_mitsuba_Medium_get_scattering_coefficients =
 R"doc(Returns the medium coefficients Sigma_s, Sigma_n and Sigma_t evaluated
@@ -4772,8 +4781,6 @@ static const char *__doc_mitsuba_Medium_is_homogeneous = R"doc(Returns whether t
 
 static const char *__doc_mitsuba_Medium_m_extremum_structure = R"doc()doc";
 
-static const char *__doc_mitsuba_Medium_m_has_local_extremum = R"doc()doc";
-
 static const char *__doc_mitsuba_Medium_m_has_spectral_extinction = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_m_is_homogeneous = R"doc()doc";
@@ -4782,7 +4789,22 @@ static const char *__doc_mitsuba_Medium_m_phase_function = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_m_sample_emitters = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_m_use_rrt = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium_phase_function = R"doc(Return the phase function of this medium)doc";
+
+static const char *__doc_mitsuba_Medium_prepare_medium_traversal =
+R"doc(Intersects ray with the medium bbox and creates a medium interaction.
+
+Parameter ``ray``:
+    The ray that is used to test the medium bbox.
+
+Returns:
+    A tuple (mei, mint, maxt): ``mei`` is a ``MediumInteraction3f``
+    object initialized with the current ray and medium data. ``mint``
+    and ``maxt`` represent the minimum and maximum intersection
+    distances of the ray with the medium's bbox. In case there are no
+    valid intersection, the range defaults to [0, +Inf].)doc";
 
 static const char *__doc_mitsuba_Medium_sample_interaction =
 R"doc(Sample a free-flight distance in the medium.
@@ -4807,9 +4829,46 @@ Returns:
     will always be valid, except if the ray missed the Medium's
     bounding box.)doc";
 
-static const char *__doc_mitsuba_Medium_sample_interaction_real = R"doc()doc";
+static const char *__doc_mitsuba_Medium_sample_interaction_analytical =
+R"doc(Sample a free-flight distance in the medium analytically.
+
+This function samples a (tentative) free-flight distance according to
+an exponential transmittance. It is then up to the integrator to then
+decide whether the MediumInteraction corresponds to a real or null
+scattering event.
+
+Parameter ``ray``:
+    Ray, along which a distance should be sampled
+
+Parameter ``it``:
+    The boundary interaction that the sampled distance cannot exceed.
+
+Parameter ``sample``:
+    A uniformly distributed random sample
+
+Parameter ``channel``:
+    The channel according to which we will sample the free-flight
+    distance. This argument is only used when rendering in RGB modes.
+
+Returns:
+    This method returns a MediumInteraction. The MediumInteraction
+    will always be valid, except if the ray missed the Medium's
+    bounding box.)doc";
 
 static const char *__doc_mitsuba_Medium_to_string = R"doc(Return a human-readable representation of the Medium)doc";
+
+static const char *__doc_mitsuba_Medium_transmittance_eval_analytical =
+R"doc(Compute the analytical transmittance along a ray to an interaction.
+
+Parameter ``ray``:
+    Ray, along which to compute the transmittance, use mint
+
+Parameter ``si``:
+    Interaction that marks the end of the segment along which to
+    compute the transmittance.
+
+Returns:
+    The transmittance along a ray)doc";
 
 static const char *__doc_mitsuba_Medium_transmittance_eval_pdf =
 R"doc(Compute the transmittance and PDF
@@ -4839,6 +4898,8 @@ static const char *__doc_mitsuba_Medium_traverse_1_cb_rw = R"doc()doc";
 static const char *__doc_mitsuba_Medium_type = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_use_emitter_sampling = R"doc(Returns whether this specific medium instance uses emitter sampling)doc";
+
+static const char *__doc_mitsuba_Medium_use_rrt = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_variant_name = R"doc()doc";
 
@@ -10653,23 +10714,14 @@ static const char *__doc_mitsuba_Timer_start = R"doc()doc";
 
 static const char *__doc_mitsuba_Timer_value = R"doc()doc";
 
-static const char *__doc_mitsuba_TrackingEstimator = R"doc()doc";
+static const char *__doc_mitsuba_TrackingState =
+R"doc(State carried through extremum traversal to accumulate the throughput
+and its PDF.
 
-static const char *__doc_mitsuba_TrackingEstimatorType = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimatorType_RatioTracking = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimatorType_ResidualRatioTracking = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimator_estimator = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimator_ratio_tracking = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimator_residual_ratio_tracking = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingEstimator_transmittance = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingState = R"doc()doc";
+Can be used to for delta tracking, ratio tracking, and residual ratio
+tracking. Note: Since the number of required dimensions is different
+for all pixel samples, ``rng`` is used to sample distances and event
+types.)doc";
 
 static const char *__doc_mitsuba_TrackingState_TrackingState = R"doc()doc";
 
@@ -10681,9 +10733,11 @@ static const char *__doc_mitsuba_TrackingState_fields = R"doc()doc";
 
 static const char *__doc_mitsuba_TrackingState_fields_2 = R"doc()doc";
 
+static const char *__doc_mitsuba_TrackingState_has_spectral_extinction = R"doc()doc";
+
 static const char *__doc_mitsuba_TrackingState_labels = R"doc()doc";
 
-static const char *__doc_mitsuba_TrackingState_medium = R"doc()doc";
+static const char *__doc_mitsuba_TrackingState_mei = R"doc()doc";
 
 static const char *__doc_mitsuba_TrackingState_name = R"doc()doc";
 
@@ -10693,15 +10747,13 @@ static const char *__doc_mitsuba_TrackingState_operator_assign_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_TrackingState_ray = R"doc()doc";
 
-static const char *__doc_mitsuba_TrackingState_sampler = R"doc()doc";
+static const char *__doc_mitsuba_TrackingState_rng = R"doc()doc";
 
 static const char *__doc_mitsuba_TrackingState_target_ot = R"doc()doc";
 
-static const char *__doc_mitsuba_TrackingState_tau_acc = R"doc()doc";
+static const char *__doc_mitsuba_TrackingState_throughput = R"doc()doc";
 
-static const char *__doc_mitsuba_TrackingState_transmittance_one = R"doc()doc";
-
-static const char *__doc_mitsuba_TrackingState_transmittance_two = R"doc()doc";
+static const char *__doc_mitsuba_TrackingState_use_rrt = R"doc()doc";
 
 static const char *__doc_mitsuba_Transform =
 R"doc(Unified homogeneous coordinate transformation
@@ -11136,7 +11188,8 @@ static const char *__doc_mitsuba_Volume_m_to_local = R"doc(Used to bring points 
 static const char *__doc_mitsuba_Volume_majorant =
 R"doc(Compute local majorant (maximum) over a spatial region
 
-Convenience method that returns only the majorant.)doc";
+Convenience method that returns only the majorant. The default
+implementation calls `extremum()` and returns the second element.)doc";
 
 static const char *__doc_mitsuba_Volume_max = R"doc(Returns the maximum value of the volume over all dimensions.)doc";
 
@@ -11157,7 +11210,8 @@ Pointer allocation/deallocation must be performed by the caller.)doc";
 static const char *__doc_mitsuba_Volume_minorant =
 R"doc(Compute local minorant (minimum) over a spatial region
 
-Convenience method that returns only the minorant.)doc";
+Convenience method that returns only the minorant. The default
+implementation calls `extremum()` and returns the first element.)doc";
 
 static const char *__doc_mitsuba_Volume_pin = R"doc()doc";
 
@@ -11941,6 +11995,8 @@ static const char *__doc_mitsuba_hash_combine = R"doc()doc";
 static const char *__doc_mitsuba_hasher = R"doc()doc";
 
 static const char *__doc_mitsuba_hasher_operator_call = R"doc()doc";
+
+static const char *__doc_mitsuba_index_spectrum = R"doc(Helper function to index the channel of an ``UnpolarizedSpectrum``.)doc";
 
 static const char *__doc_mitsuba_ior_from_file = R"doc()doc";
 

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -79,8 +79,34 @@ public:
                            Mask active) const;
 
 // #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
-    virtual std::tuple<MediumInteraction3f, Float, Float> 
-    sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
+    /**
+     * \brief Sample a free-flight distance in the medium analytically.
+     *
+     * This function samples a (tentative) free-flight distance according to an
+     * exponential transmittance. It is then up to the integrator to then decide
+     * whether the MediumInteraction corresponds to a real or null scattering
+     * event.
+     *
+     * \param ray      Ray, along which a distance should be sampled
+     * \param it       The boundary interaction that the sampled distance cannot
+     * exceed.
+     * \param sample   A uniformly distributed random sample
+     * \param channel  The channel according to which we will sample the
+     * free-flight distance. This argument is only used when rendering in RGB
+     * modes.
+     *
+     * \return         This method returns a tuple 
+     *                 (MediumInteraction, Transmittance, PDF).
+     *                 The MediumInteraction if an interaction was sampled within
+     *                 the medium boudning box and before the bouding iteraction 
+     *                 \ref it.
+     *                 The transmittance and PDF are both computed for all channels
+     *                 even if the sampling operation is performed on one channel.
+     *                 
+     */
+    virtual 
+    std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum> 
+    sample_interaction_analytical(const Ray3f &ray, const Interaction3f &it,
                             Float sample, UInt32 channel, Mask active) const;
 
     /** \brief Compute the analytical transmittance along a ray to an interaction.
@@ -185,8 +211,8 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(intersect_aabb)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
-    DRJIT_CALL_METHOD(sample_interaction_real)
 // #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf 
+    DRJIT_CALL_METHOD(sample_interaction_analytical)
     DRJIT_CALL_METHOD(transmittance_eval_analytical)
 // #ERADIATE_CHANGE_END
     DRJIT_CALL_METHOD(get_scattering_coefficients)

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -78,21 +78,24 @@ public:
                            const SurfaceInteraction3f &si,
                            Mask active) const;
 
-// #RAY_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
     virtual std::tuple<MediumInteraction3f, Float, Float> 
     sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
                             Float sample, UInt32 channel, Mask active) const;
-    
-    /** \brief Eval the analytical transmittance from the ray start to si.
+
+    /** \brief Compute the analytical transmittance along a ray to an interaction.
+     * 
+     * \param ray      Ray, along which to compute the transmittance, use mint
+     * \param si       Interaction that marks the end of the segment along which
+     *                 to compute the transmittance.
      * 
      * \return
-     *      The transmittance between the ray start and si.
+     *      The transmittance along a ray
     */
-    virtual Float
-    eval_analytical_transmittance(const Ray3f &ray, 
-                                  const SurfaceInteraction3f &si,
-                                  UInt32 channel, Mask active) const;
-// #RAY_CHANGE_END
+    virtual UnpolarizedSpectrum
+    transmittance_eval_analytical(const Ray3f &ray, const Interaction3f &it, 
+                                  Mask active) const;
+// #ERADIATE_CHANGE_END
 
     /// Return the phase function of this medium
     MI_INLINE const PhaseFunction *phase_function() const {
@@ -183,7 +186,9 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
     DRJIT_CALL_METHOD(sample_interaction_real)
-    DRJIT_CALL_METHOD(eval_analytical_transmittance)
+// #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf 
+    DRJIT_CALL_METHOD(transmittance_eval_analytical)
+// #ERADIATE_CHANGE_END
     DRJIT_CALL_METHOD(get_scattering_coefficients)
     
     DRJIT_CALL_GETTER(use_rrt)

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -83,10 +83,15 @@ public:
     sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
                             Float sample, UInt32 channel, Mask active) const;
     
-    virtual std::tuple<Float, Float, Mask>
-    eval_transmittance_pdf_real(const Ray3f &ray, 
-                                    const SurfaceInteraction3f &si,
-                                    UInt32 channel, Mask active) const;
+    /** \brief Eval the analytical transmittance from the ray start to si.
+     * 
+     * \return
+     *      The transmittance between the ray start and si.
+    */
+    virtual Float
+    eval_analytical_transmittance(const Ray3f &ray, 
+                                  const SurfaceInteraction3f &si,
+                                  UInt32 channel, Mask active) const;
 // #RAY_CHANGE_END
 
     /// Return the phase function of this medium
@@ -178,7 +183,7 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
     DRJIT_CALL_METHOD(sample_interaction_real)
-    DRJIT_CALL_METHOD(eval_transmittance_pdf_real)
+    DRJIT_CALL_METHOD(eval_analytical_transmittance)
     DRJIT_CALL_METHOD(get_scattering_coefficients)
     
     DRJIT_CALL_GETTER(use_rrt)

--- a/src/eradiate_plugins/integrators/piecewise_volpath.cpp
+++ b/src/eradiate_plugins/integrators/piecewise_volpath.cpp
@@ -471,7 +471,6 @@ public:
 
             dr::masked(si, active) = scene->ray_intersect(ray, active);
 
-            Mask escaped_medium = false;
             Mask active_medium  = active && (medium != nullptr);
             Mask active_surface = active && si.is_valid();
 
@@ -481,22 +480,13 @@ public:
             dr::masked(total_dist, active_surface && !active_medium) += si.t;
 
             if (dr::any_or<true>(active_medium)) {
+                UnpolarizedSpectrum tr =
+                    medium->eval_analytical_transmittance(ray, si, channel,
+                                                        active_medium);
+                dr::masked(transmittance, active_medium) *= tr; // exact estimation
 
-                Mask is_spectral =
-                    medium->has_spectral_extinction() && active_medium;
-
-                if (dr::any_or<true>(is_spectral)) {
-                    UnpolarizedSpectrum tr = dr::zeros<UnpolarizedSpectrum>();
-                    UnpolarizedSpectrum free_flight_pdf =
-                        dr::zeros<UnpolarizedSpectrum>();
-
-                    std::tie(tr, free_flight_pdf, escaped_medium) =
-                        medium->eval_transmittance_pdf_real(ray, si, channel,
-                                                            active_medium);
-                    dr::masked(transmittance, is_spectral) *= tr; // exact estimation
-                }
-
-                active_medium &= !escaped_medium;
+                // consider we automatically escape the medium.
+                active_medium &= false;
             }
 
             if (dr::any_or<true>(active_surface)) {

--- a/src/eradiate_plugins/integrators/piecewise_volpath.cpp
+++ b/src/eradiate_plugins/integrators/piecewise_volpath.cpp
@@ -281,7 +281,7 @@ public:
                 Mask active_e = act_medium_scatter && sample_emitters;
                 if (dr::any_or<true>(active_e)) {
                     auto [emitted, ds] = sample_emitter(
-                        mei, scene, sampler, medium, channel, active_e);
+                        mei, scene, sampler, medium, active_e);
                     auto [phase_val, phase_pdf] =
                         phase->eval_pdf(phase_ctx, mei, ds.d, active_e);
                     dr::masked(result, active_e) +=
@@ -348,7 +348,7 @@ public:
 
                 if (likely(dr::any_or<true>(active_e))) {
                     auto [emitted, ds] = sample_emitter(
-                        si, scene, sampler, medium, channel, active_e);
+                        si, scene, sampler, medium, active_e);
 
                     // Query the BSDF for that emitter-sampled direction
                     Vector3f wo       = si.to_local(ds.d);
@@ -405,8 +405,7 @@ public:
     template <typename Interaction>
     std::tuple<Spectrum, DirectionSample3f>
     sample_emitter(const Interaction &ref_interaction, const Scene *scene,
-                   Sampler *sampler, MediumPtr medium, UInt32 channel,
-                   Mask active) const {
+                   Sampler *sampler, MediumPtr medium, Mask active) const {
 
         Spectrum transmittance(1.0f);
 
@@ -454,7 +453,7 @@ public:
         dr::tie(ls) = dr::while_loop(dr::make_tuple(ls),
             [](const LoopState& ls) { return dr::detach(ls.active); },
             // uncomment this if needed to access any member variable or functions.
-            [/*this,*/ scene, channel, max_dist](LoopState& ls) {
+            [/*this,*/ scene, max_dist](LoopState& ls) {
 
             Mask& active = ls.active;
             Ray3f& ray = ls.ray;
@@ -481,8 +480,7 @@ public:
 
             if (dr::any_or<true>(active_medium)) {
                 UnpolarizedSpectrum tr =
-                    medium->eval_analytical_transmittance(ray, si, channel,
-                                                        active_medium);
+                    medium->transmittance_eval_analytical(ray, si, active_medium);
                 dr::masked(transmittance, active_medium) *= tr; // exact estimation
 
                 // consider we automatically escape the medium.

--- a/src/eradiate_plugins/integrators/piecewise_volpath.cpp
+++ b/src/eradiate_plugins/integrators/piecewise_volpath.cpp
@@ -221,8 +221,8 @@ public:
             }
 
             if (dr::any_or<true>(active_medium)) {
-                Float tr  = dr::zeros<Float>();
-                Float pdf = dr::zeros<Float>();
+                UnpolarizedSpectrum tr  = dr::zeros<UnpolarizedSpectrum>();
+                UnpolarizedSpectrum pdf = dr::zeros<UnpolarizedSpectrum>();
 
                 Mask intersect = needs_intersection && active_medium;
                 if (dr::any_or<true>(intersect))
@@ -230,7 +230,7 @@ public:
                         scene->ray_intersect(ray, intersect);
                 needs_intersection &= !active_medium;
 
-                std::tie(mei, tr, pdf) = medium->sample_interaction_real(
+                std::tie(mei, tr, pdf) = medium->sample_interaction_analytical(
                     ray, si, sampler->next_1d(active_medium), channel,
                     active_medium);
                 dr::masked(ray.maxt, active_medium &&

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -186,9 +186,8 @@ public:
         precompute_optical_thickness();
     }
 
-    std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float,
-               Float>
-    sample_interaction_real(const Ray3f &ray, const SurfaceInteraction3f &si,
+    std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum>
+    sample_interaction_analytical(const Ray3f &ray, const Interaction3f &it,
                             Float sample, UInt32 channel,
                             Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumSample, active);
@@ -201,7 +200,7 @@ public:
         dr::masked(maxt, !active) = dr::Infinity<Float>;
 
         mint = dr::maximum(0.f, mint);
-        maxt = dr::minimum(si.t, dr::minimum(ray.maxt, maxt));
+        maxt = dr::minimum(it.t, dr::minimum(ray.maxt, maxt));
 
         Mask escaped = !active;
 
@@ -223,10 +222,10 @@ public:
         const ScalarPoint3f min = m_sigmat->bbox().min;
 
         const ScalarVector3f layer_norm(0.f, 0.f, 1.f);
-        Float cum_opt_thick = dr::zeros<Float>();
-        Float sampled_t     = dr::Infinity<Float>;
-        Float tr            = dr::zeros<Float>();
-        Float pdf           = dr::zeros<Float>();
+        Float sampled_t                   = dr::Infinity<Float>;
+        UnpolarizedSpectrum cum_opt_thick = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum tr            = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum pdf           = dr::zeros<UnpolarizedSpectrum>();
 
         // Calculate the distance between layers used as multiplication factor
         // to the distance
@@ -262,36 +261,33 @@ public:
         s_mei.p                   = ray(mint);
         std::tie(s_mei.sigma_s, s_mei.sigma_n, s_mei.sigma_t) =
             get_scattering_coefficients(s_mei, active);
-        Float sigma_t = extract_channel(s_mei.sigma_t[0], channel);
+        Float sigma_t = extract_channel(s_mei.sigma_t0;, channel);
 
-        Float opt_thick_offset = dr::zeros<Float>();
-        opt_thick_offset       = dr::select(
+        UnpolarizedSpectrum opt_thick_offset = dr::select(
             going_up,
-            extract_channel(dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, opt_start_idx, active), channel),
-            extract_channel(dr::gather<UnpolarizedSpectrum>(m_reverse_cum_opt_thickness, opt_start_idx, active),channel));
-        opt_thick_offset -= start_height * sigma_t;
+            dr::gather<UnpolarizedSpectrum>(
+                m_cum_opt_thickness, opt_start_idx, active),
+            dr::gather<UnpolarizedSpectrum>(
+                m_reverse_cum_opt_thickness, opt_start_idx, active));
+        opt_thick_offset -= start_height * s_mei.sigma_t;
+        Float opt_thick_offset_c = extract_channel(opt_thick_offset, channel);
 
         Float log_sample = dr::log(1.f - sample);
         Mask sampled     = dr::zeros<Mask>();
         Mask search      = active && !same_cell;
 
         if (dr::any_or<true>(search)) {
-            UnpolarizedSpectrum spectral_value =
-                dr::zeros<UnpolarizedSpectrum>();
-
             // Find the piecewise boundary in CDF space using binary search
             dr::masked(index, search) = dr::binary_search<Index>(
                 opt_start_idx, opt_end_idx,
                 [&](Index index) DRJIT_INLINE_LAMBDA {
-                    spectral_value = dr::select(
+                    Float value = dr::select(
                         going_up,
-                        dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, index, search),
-                        dr::gather<UnpolarizedSpectrum>(m_reverse_cum_opt_thickness, index,
-                                          search));
-                    Float value = extract_channel(spectral_value, channel);
+                        gather_channel(m_cum_opt_thickness, index, channel, search),
+                        gather_channel(m_reverse_cum_opt_thickness, index, channel, search));
 
                     Float a = -log_sample * idelta;
-                    Float b = (value - opt_thick_offset);
+                    Float b = (value - opt_thick_offset_c);
                     return a > b;
                 });
         }
@@ -302,13 +298,14 @@ public:
         dr::masked(mei.t, search) +=
             (start_height + (Float) (index - opt_start_idx - 1)) * delta;
 
-        Float cum_opt_at_index                 = dr::zeros<Float>();
-        dr::masked(cum_opt_at_index, going_up) = extract_channel(
-            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, index_minus_one, search),channel);
-        dr::masked(cum_opt_at_index, !going_up) = extract_channel(
-            dr::gather<UnpolarizedSpectrum>(m_reverse_cum_opt_thickness,index_minus_one, search),channel);
+        UnpolarizedSpectrum cum_opt_at_index    = dr::zeros<UnpolarizedSpectrum>();
+        dr::masked(cum_opt_at_index, going_up)  =
+            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, index_minus_one, search);
+        dr::masked(cum_opt_at_index, !going_up) =
+            dr::gather<UnpolarizedSpectrum>(m_reverse_cum_opt_thickness,index_minus_one, search);
         dr::masked(cum_opt_thick, search) =
             (cum_opt_at_index - opt_thick_offset) * delta;
+        Float cum_opt_thick_c = extract_channel(cum_opt_thick, channel);
 
         mei.p = min + voxel_size * 0.5 +
                 (Float) dr::select(going_up, index, res.z() - 1 - index) * step;
@@ -321,16 +318,16 @@ public:
         sampled |= !escaped;
 
         dr::masked(sampled_t, sampled) =
-            -dr::rcp(sigma_t) * (log_sample + cum_opt_thick) + mei.t;
+            -dr::rcp(sigma_t) * (log_sample + cum_opt_thick_c) + mei.t;
         escaped |= (sampled && sampled_t > maxt);
         sampled |= escaped;
 
         // need to calculate transmittance and pdf for escaped rays too
         dr::masked(sampled_t, sampled) = dr::select(escaped, maxt, sampled_t);
         dr::masked(tr, sampled) =
-            dr::exp(-(sampled_t - mei.t) * sigma_t - cum_opt_thick);
+            dr::exp(-(sampled_t - mei.t) * mei.sigma_t - cum_opt_thick);
         dr::masked(pdf, sampled) =
-            dr::select(sampled_t == maxt, tr, tr * sigma_t);
+            dr::select(sampled_t == maxt, tr, tr * mei.sigma_t);
 
         mei.t = dr::select(!escaped, sampled_t, dr::Infinity<Float>);
         dr::masked(mei.p, !escaped)                   = ray(mei.t);
@@ -559,6 +556,18 @@ public:
         }
 
         return result;
+    }
+
+    // Gather a single float from a spectral storage buffer for a given layer
+    // index and channel, avoiding fetching the full UnpolarizedSpectrum packet.
+    static Float gather_channel(const FloatStorage &storage, Index layer_idx,
+                                UInt32 channel, Mask active) {
+        static constexpr uint32_t SpectralSize =
+            (uint32_t) dr::size_v<UnpolarizedSpectrum>;
+        Index flat_idx = layer_idx * SpectralSize;
+        if constexpr (is_rgb_v<Spectrum>)
+            flat_idx += channel;
+        return dr::gather<Float>(storage, flat_idx, active);
     }
 
     MI_DECLARE_CLASS(PiecewiseMedium)

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -339,10 +339,10 @@ public:
         return { mei, tr, pdf };
     }
 
-    std::tuple<Float, Float, Mask>
-    eval_transmittance_pdf_real(const Ray3f &ray,
-                                const SurfaceInteraction3f &si, UInt32 channel,
-                                Mask active) const override {
+    Float eval_analytical_transmittance(const Ray3f &ray,
+                                        const SurfaceInteraction3f &si, 
+                                        UInt32 channel,
+                                        Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
 
         // Initial intersection with the medium
@@ -350,8 +350,6 @@ public:
         aabb_its &= (dr::isfinite(mint) || dr::isfinite(maxt));
         active &= aabb_its;
         mint         = dr::maximum(0.f, mint);
-        Mask escaped = active && ((maxt >= ray.maxt) || (maxt >= si.t));
-
         maxt =
             dr::select(active, dr::minimum(ray.maxt, dr::minimum(maxt, si.t)),
                        dr::Infinity<Float>);
@@ -428,12 +426,9 @@ public:
             dr::select(same_cell, (maxt - mint) * s_sigma_t, cum_opt_thick);
 
         Float tr               = dr::zeros<Float>();
-        Float pdf              = dr::zeros<Float>();
         dr::masked(tr, active) = dr::exp(-opt_thick);
-        dr::masked(pdf, active) =
-            dr::select(si.t < maxt || ray.maxt < maxt, tr, tr * e_sigma_t);
 
-        return { tr, pdf, escaped };
+        return tr;
     }
 
     void traverse(TraversalCallback *cb) override {

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -339,9 +339,8 @@ public:
         return { mei, tr, pdf };
     }
 
-    Float eval_analytical_transmittance(const Ray3f &ray,
-                                        const SurfaceInteraction3f &si, 
-                                        UInt32 channel,
+    UnpolarizedSpectrum transmittance_eval_analytical(const Ray3f &ray,
+                                        const Interaction3f &it,
                                         Mask active) const override {
         MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
 
@@ -351,7 +350,7 @@ public:
         active &= aabb_its;
         mint         = dr::maximum(0.f, mint);
         maxt =
-            dr::select(active, dr::minimum(ray.maxt, dr::minimum(maxt, si.t)),
+            dr::select(active, dr::minimum(ray.maxt, dr::minimum(maxt, it.t)),
                        dr::Infinity<Float>);
         maxt = dr::maximum(0.f, maxt);
 
@@ -396,8 +395,8 @@ public:
             get_scattering_coefficients(s_mei, active);
         std::tie(e_mei.sigma_s, e_mei.sigma_n, e_mei.sigma_t) =
             get_scattering_coefficients(e_mei, active);
-        Float s_sigma_t = extract_channel(s_mei.sigma_t, channel);
-        Float e_sigma_t = extract_channel(e_mei.sigma_t, channel);
+        UnpolarizedSpectrum s_sigma_t = s_mei.sigma_t;
+        UnpolarizedSpectrum e_sigma_t = e_mei.sigma_t;
 
         Int32 max_idx = dr::select(
             active, dr::maximum(dr::maximum(start_idx, end_idx) - 1, 0), 0);
@@ -405,17 +404,15 @@ public:
             active, dr::maximum(dr::minimum(start_idx, end_idx), 0), 0);
         Mask use_precomputed = active && max_idx > min_idx;
 
-        Float opt_thick     = dr::zeros<Float>();
-        Float cum_opt_thick = dr::zeros<Float>();
-        Float start_cum_opt = dr::zeros<Float>();
-        Float end_cum_opt   = dr::zeros<Float>();
+        UnpolarizedSpectrum opt_thick     = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum cum_opt_thick = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum start_cum_opt = dr::zeros<UnpolarizedSpectrum>();
+        UnpolarizedSpectrum end_cum_opt   = dr::zeros<UnpolarizedSpectrum>();
 
-        dr::masked(start_cum_opt, use_precomputed) = extract_channel(
-            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, min_idx, use_precomputed),
-            channel);
-        dr::masked(end_cum_opt, use_precomputed) = extract_channel(
-            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, max_idx, use_precomputed),
-            channel);
+        dr::masked(start_cum_opt, use_precomputed) =
+            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, min_idx, use_precomputed);
+        dr::masked(end_cum_opt, use_precomputed) =
+            dr::gather<UnpolarizedSpectrum>(m_cum_opt_thickness, max_idx, use_precomputed);
         dr::masked(cum_opt_thick, use_precomputed) =
             end_cum_opt - start_cum_opt;
 
@@ -425,10 +422,10 @@ public:
         dr::masked(opt_thick, active) =
             dr::select(same_cell, (maxt - mint) * s_sigma_t, cum_opt_thick);
 
-        Float tr               = dr::zeros<Float>();
+        UnpolarizedSpectrum tr = dr::zeros<UnpolarizedSpectrum>();
         dr::masked(tr, active) = dr::exp(-opt_thick);
 
-        return tr;
+        return UnpolarizedSpectrum(tr);
     }
 
     void traverse(TraversalCallback *cb) override {

--- a/src/eradiate_plugins/tests/media/test_piecewise.py
+++ b/src/eradiate_plugins/tests/media/test_piecewise.py
@@ -22,9 +22,11 @@ def create_medium_dict():
     exp_volume_grid = mi.VolumeGrid(ext_coefs)
     sigma_scale = 1.0
 
-    medium_transform = mi.ScalarTransform4f().translate(
-        [-100000 / 2, -100000 / 2, 0.0]
-    ).scale([100000.0, 100000.0, 100000.0])
+    medium_transform = (
+        mi.ScalarTransform4f()
+        .translate([-100000 / 2, -100000 / 2, 0.0])
+        .scale([100000.0, 100000.0, 100000.0])
+    )
 
     return mi.load_dict(
         {
@@ -66,7 +68,7 @@ def test01_sample_distances_down(variant_scalar_mono_double):
     trs = []
     pdfs = []
     for sample in samples:
-        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, sample, 0, True)
         dists.append(mei.t)
         trs.append(tr)
         pdfs.append(pdf)
@@ -100,7 +102,7 @@ def test02_sample_distances_up(variant_scalar_mono_double):
     trs = []
     pdfs = []
     for sample in samples:
-        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, sample, 0, True)
 
         dists.append(mei.t)
         trs.append(tr)
@@ -135,7 +137,7 @@ def test03_sample_distances_horizontal(variant_scalar_mono_double):
     trs = []
     pdfs = []
     for sample in samples:
-        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, sample, 0, True)
 
         dists.append(mei.t)
         trs.append(tr)
@@ -162,7 +164,7 @@ def test04_sample_distances_diag(variant_scalar_mono_double):
     trs = []
     pdfs = []
     for idx, sample in enumerate(samples):
-        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, sample, 0, True)
         dists.append(mei.t)
         trs.append(tr)
         pdfs.append(pdf)
@@ -203,7 +205,7 @@ def test05_sample_distances_heights(variant_scalar_mono_double):
     trs = []
     pdfs = []
     for idx, ray in enumerate(rays):
-        mei, tr, pdf = medium.sample_interaction_real(ray, si, sample, 0, True)
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, sample, 0, True)
         dists.append(mei.t)
         trs.append(tr)
         pdfs.append(pdf)
@@ -240,11 +242,9 @@ def test06_eval_transmittance_up(variant_scalar_mono_double):
         rays.append(mi.Ray3f(origin, direction))
 
     trs = []
-    pdfs = []
     for ray in rays:
-        tr, pdf, _ = medium.eval_transmittance_pdf_real(ray, si, 0, True)
+        tr = medium.transmittance_eval_analytical(ray, si, True)
         trs.append(tr)
-        pdfs.append(pdf)
 
     assert dr.allclose(trs, gt_trs)
 
@@ -273,10 +273,90 @@ def test07_eval_transmittance_down(variant_scalar_mono):
         rays.append(mi.Ray3f(origin, direction))
 
     trs = []
-    pdfs = []
     for ray in rays:
-        tr, pdf, _ = medium.eval_transmittance_pdf_real(ray, si, 0, True)
+        tr = medium.transmittance_eval_analytical(ray, si, True)
         trs.append(tr)
-        pdfs.append(pdf)
 
     assert dr.allclose(trs, gt_trs)
+
+
+# ── RGB tests ─────────────────────────────────────────────────────────────────
+
+# 2-layer unit medium, z ∈ [0, 1], sigma_t per channel.
+_RGB_SIGMA_T = np.array(
+    [[1.0, 2.0, 3.0], [3.0, 1.0, 2.0]],
+    dtype=np.float64,
+)
+_LAYER_H = 0.5  # 2 layers over height 1.0
+
+
+def _create_rgb_medium():
+    n = len(_RGB_SIGMA_T)
+    grid = _RGB_SIGMA_T.reshape(n, 1, 1, 3).astype(np.float32)
+    return mi.load_dict(
+        {
+            "type": "piecewise",
+            "albedo": 0.5,
+            "sigma_t": {
+                "type": "gridvolume",
+                "grid": mi.VolumeGrid(grid),
+                "use_grid_bbox": True,
+                "filter_type": "nearest",
+                "to_world": mi.ScalarTransform4f.translate([-0.5, -0.5, 0.0]),
+            },
+        }
+    )
+
+
+def _ref_tr_rgb(z_start, z_end):
+    """Per-channel transmittance for segment [z_start, z_end] (upward ray)."""
+    ot = np.zeros(3)
+    for i, sigma in enumerate(_RGB_SIGMA_T):
+        seg = min(z_end, (i + 1) * _LAYER_H) - max(z_start, i * _LAYER_H)
+        if seg > 0:
+            ot += sigma * seg
+    return np.exp(-ot)
+
+
+def _ref_distance_rgb(xi, channel):
+    """
+    Scatter distance along an upward ray from z=0 for sample xi in channel.
+    Returns (t, layer_idx), or (inf, -1) if the ray escapes.
+    """
+    log_target = -np.log(1.0 - xi)
+    cum = 0.0
+    for i, sigma in enumerate(_RGB_SIGMA_T):
+        contrib = sigma[channel] * _LAYER_H
+        if cum + contrib >= log_target:
+            return i * _LAYER_H + (log_target - cum) / sigma[channel], i
+        cum += contrib
+    return np.inf, -1
+
+
+def test09_sample_interaction_rgb(variant_scalar_rgb):
+    medium = _create_rgb_medium()
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    ray = mi.Ray3f(mi.Point3f(0.0, 0.0, 0.0), mi.Vector3f(0.0, 0.0, 1.0))
+
+    # (xi, channel): chosen so each channel scatters in a different layer
+    for xi, channel in ((0.5, 0), (0.5, 1), (0.3, 2)):
+        mei, tr, pdf = medium.sample_interaction_analytical(ray, si, xi, channel, True)
+        expected_t, layer_idx = _ref_distance_rgb(xi, channel)
+        expected_tr = _ref_tr_rgb(0.0, expected_t)
+        expected_pdf = expected_tr * _RGB_SIGMA_T[layer_idx]
+
+        assert dr.allclose(float(mei.t), float(expected_t), atol=1e-5)
+        assert dr.allclose(tr, expected_tr.tolist(), atol=1e-5)
+        assert dr.allclose(pdf, expected_pdf.tolist(), atol=1e-5)
+
+
+def test08_transmittance_eval_rgb(variant_scalar_rgb):
+    medium = _create_rgb_medium()
+    si = dr.zeros(mi.SurfaceInteraction3f)
+
+    # Three starting heights: full medium, top layer only, mid-layer start
+    for z0 in (0.0, 0.5, 0.25):
+        ray = mi.Ray3f(mi.Point3f(0.0, 0.0, z0), mi.Vector3f(0.0, 0.0, 1.0))
+        tr = medium.transmittance_eval_analytical(ray, si, True)
+        expected = _ref_tr_rgb(z0, 1.0)
+        assert dr.allclose(tr, expected.tolist(), atol=1e-5)

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -117,13 +117,13 @@ Medium<Float, Spectrum>::sample_interaction_real(const Ray3f &/*ray*/,
 }
 
 MI_VARIANT
-std::tuple<Float, Float, typename Medium<Float, Spectrum>::Mask>
-Medium<Float, Spectrum>::eval_transmittance_pdf_real(const Ray3f &/*ray*/, 
+Float
+Medium<Float, Spectrum>::eval_analytical_transmittance(const Ray3f &/*ray*/, 
                                     const SurfaceInteraction3f &/*si*/,
                                     UInt32 /*channel*/, Mask /*active*/) const {
     // PiecewiseVolPathIntegrator should only be used with piecewise medium
-    NotImplementedError("eval_transmittance_pdf_real");
-    return {0.f, 0.f, false};
+    NotImplementedError("eval_analytical_transmittance");
+    return 0.f;
 }
 // #RAY_CHANGE_END
 

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -106,14 +106,14 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
 
 // #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
 MI_VARIANT
-std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float, Float>
-Medium<Float, Spectrum>::sample_interaction_real(const Ray3f &/*ray*/, 
-                                            const SurfaceInteraction3f &/*si*/, Float /*sample*/,
+std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, 
+           typename Medium<Float, Spectrum>::UnpolarizedSpectrum,
+           typename Medium<Float, Spectrum>::UnpolarizedSpectrum>
+Medium<Float, Spectrum>::sample_interaction_analytical(const Ray3f &/*ray*/, 
+                                            const Interaction3f &/*it*/, Float /*sample*/,
                                             UInt32 /*channel*/, Mask /*active*/) const {
     // PiecewiseVolPathIntegrator should only be used with piecewise medium                                                
-    NotImplementedError("sample_interaction_real");
-    MediumInteraction3f mi = dr::zeros<MediumInteraction3f>(); 
-    return {mi,0.f,0.f};
+    NotImplementedError("sample_interaction_analytical");
 }
 
 MI_VARIANT

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -104,7 +104,7 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
     return { tr, pdf };
 }
 
-// #RAY_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
 MI_VARIANT
 std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, Float, Float>
 Medium<Float, Spectrum>::sample_interaction_real(const Ray3f &/*ray*/, 
@@ -117,15 +117,14 @@ Medium<Float, Spectrum>::sample_interaction_real(const Ray3f &/*ray*/,
 }
 
 MI_VARIANT
-Float
-Medium<Float, Spectrum>::eval_analytical_transmittance(const Ray3f &/*ray*/, 
-                                    const SurfaceInteraction3f &/*si*/,
-                                    UInt32 /*channel*/, Mask /*active*/) const {
+typename Medium<Float, Spectrum>::UnpolarizedSpectrum
+Medium<Float, Spectrum>::transmittance_eval_analytical(const Ray3f &/*ray*/, 
+                                    const Interaction3f &/*it*/,
+                                    Mask /*active*/) const {
     // PiecewiseVolPathIntegrator should only be used with piecewise medium
-    NotImplementedError("eval_analytical_transmittance");
-    return 0.f;
+    NotImplementedError("transmittance_eval_analytical");
 }
-// #RAY_CHANGE_END
+// #ERADIATE_CHANGE_END
 
 // #ERADIATE_CHANGE_BEGIN: Extremum structure accessor
 MI_VARIANT

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -94,10 +94,10 @@ template <typename Ptr, typename Cls> void bind_medium_generic(Cls &cls) {
                 return ptr->sample_interaction_real(ray, si, sample, channel, active); },
             "ray"_a, "si"_a, "sample"_a, "channel"_a, "active"_a,
             D(Medium, sample_interaction_real))
-        .def("eval_transmittance_pdf_real",
+        .def("eval_analytical_transmittance",
             [](Ptr ptr, const Ray3f &ray,  
                 const SurfaceInteraction3f &si, UInt32 channel, Mask active) {
-                return ptr->eval_transmittance_pdf_real(ray, si, channel, active); },
+                return ptr->eval_analytical_transmittance(ray, si, channel, active); },
             "ray"_a, "si"_a, "channel"_a, "active"_a,
             D(Medium, eval_transmittance_pdf_real))
        .def("get_scattering_coefficients",

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -89,17 +89,19 @@ template <typename Ptr, typename Cls> void bind_medium_generic(Cls &cls) {
                 return ptr->transmittance_eval_pdf(mi, si, active); },
             "mi"_a, "si"_a, "active"_a,
             D(Medium, transmittance_eval_pdf))
+// #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf 
         .def("sample_interaction_real",
             [](Ptr ptr, const Ray3f &ray, const SurfaceInteraction3f &si, Float sample, UInt32 channel, Mask active) {
                 return ptr->sample_interaction_real(ray, si, sample, channel, active); },
             "ray"_a, "si"_a, "sample"_a, "channel"_a, "active"_a,
             D(Medium, sample_interaction_real))
-        .def("eval_analytical_transmittance",
+        .def("transmittance_eval_analytical",
             [](Ptr ptr, const Ray3f &ray,  
-                const SurfaceInteraction3f &si, UInt32 channel, Mask active) {
-                return ptr->eval_analytical_transmittance(ray, si, channel, active); },
-            "ray"_a, "si"_a, "channel"_a, "active"_a,
+                const Interaction3f &it, Mask active) {
+                return ptr->transmittance_eval_analytical(ray, it, active); },
+            "ray"_a, "it"_a, "active"_a,
             D(Medium, eval_transmittance_pdf_real))
+// #ERADIATE_CHANGE_END
        .def("get_scattering_coefficients",
             [](Ptr ptr, const MediumInteraction3f &mi, Mask active = true) {
                 return ptr->get_scattering_coefficients(mi, active); },

--- a/src/render/python/medium_v.cpp
+++ b/src/render/python/medium_v.cpp
@@ -90,17 +90,17 @@ template <typename Ptr, typename Cls> void bind_medium_generic(Cls &cls) {
             "mi"_a, "si"_a, "active"_a,
             D(Medium, transmittance_eval_pdf))
 // #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf 
-        .def("sample_interaction_real",
-            [](Ptr ptr, const Ray3f &ray, const SurfaceInteraction3f &si, Float sample, UInt32 channel, Mask active) {
-                return ptr->sample_interaction_real(ray, si, sample, channel, active); },
-            "ray"_a, "si"_a, "sample"_a, "channel"_a, "active"_a,
-            D(Medium, sample_interaction_real))
+        .def("sample_interaction_analytical",
+            [](Ptr ptr, const Ray3f &ray, const Interaction3f &it, Float sample, UInt32 channel, Mask active) {
+                return ptr->sample_interaction_analytical(ray, it, sample, channel, active); },
+            "ray"_a, "it"_a, "sample"_a, "channel"_a, "active"_a,
+            D(Medium, sample_interaction_analytical))
         .def("transmittance_eval_analytical",
             [](Ptr ptr, const Ray3f &ray,  
                 const Interaction3f &it, Mask active) {
                 return ptr->transmittance_eval_analytical(ray, it, active); },
             "ray"_a, "it"_a, "active"_a,
-            D(Medium, eval_transmittance_pdf_real))
+            D(Medium, transmittance_eval_analytical))
 // #ERADIATE_CHANGE_END
        .def("get_scattering_coefficients",
             [](Ptr ptr, const MediumInteraction3f &mi, Mask active = true) {

--- a/tools/check_eradiate_fences.py
+++ b/tools/check_eradiate_fences.py
@@ -39,6 +39,9 @@ UPSTREAM_PREFIXES = ("src/", "include/")
 # Eradiate-specific subtrees that live inside the upstream directories above
 ERADIATE_PREFIXES = ("src/eradiate_plugins/", "include/eradiate/")
 
+# Generated files that should not be checked for fences
+GENERATED_FILES = ("include/mitsuba/python/docstr.h",)
+
 
 # ------------------------------------------------------------------------------
 #                               File classification
@@ -46,8 +49,10 @@ ERADIATE_PREFIXES = ("src/eradiate_plugins/", "include/eradiate/")
 
 
 def is_upstream(path: str) -> bool:
-    return any(path.startswith(p) for p in UPSTREAM_PREFIXES) and not any(
-        path.startswith(p) for p in ERADIATE_PREFIXES
+    return (
+        any(path.startswith(p) for p in UPSTREAM_PREFIXES)
+        and not any(path.startswith(p) for p in ERADIATE_PREFIXES)
+        and path not in GENERATED_FILES
     )
 
 


### PR DESCRIPTION
## Description

This PR aims at polishing the medium interface analytical functions that were added with the piecewise medium and make them compatible with variants that have more than one channel. It uses the opportunity to make the `piecewise` medium and integrator compatible with spectral extinction coefficients.

**Medium Interface:**
- Rename the analytical methods to reflect more closely their purpose.
- Modify the signature of `sample_interaction_analytical` to return a transmittace and pdf of type `UnpolarizedSpectrum`.
- Modify the signature of `eval_transmittance_analytical` to compute the Transmittance for all channels and therefore return an `UnpolarizedSpectrum`. The `channel` parameter was removed for the same reason.
- Both functions take an `Interaction` instead of a `SurfaceInteraction` to make them more general. 
- Docstrings were added for both functions.

**Piecewise Fix**
- It was found that the `piecewise_volpath` integrator did not compute the transmittance term for non-spectral media. This PR fixes that by moving the transmittance calculations outside of the `is_spectral`  check. 
- The `piecewise` medium was modified to match the new signatures described above.

## Testing

Unit tests were added for spectral transmittance and distance sampling of the piecewise medium. The eradiate test suite was also run.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)