### PR TITLE
[Enhancement] DDIS v2: use of separate DDIS phase function and surface DDIS.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         entry: tools/check_eradiate_fences.py
         language: script
         pass_filenames: false  # script calls git diff --cached itself
-        exclude: ^(src/eradiate_plugins|include/eradiate)/
+        exclude: ^(src/eradiate_plugins|include/eradiate|include/mitsuba/render/eradiate|include/eradiate/core/eradiate)/
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
     rev: v6.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ strive to document breaking API changes in the release notes below.
 
 ---
 
+## v0.6.0
+
+### New features
+
+- **`eoheterogeneous` medium**: A new heterogeneous that replicates and extends
+  the upstream `heterogeneous` medium. Introduces a seperate bounding box 
+  parametrization that allows the medium to have a different bounding box to
+  the underlying `sigma_t` volume bbox. In turns allows to exploit the wrap
+  mechanism of the volume and implement periodic boundaries.
+
+### Improvements
+
+- Improve the *DDIS* (Detector Directional Importance Sampling) variance 
+  reduction technique by generating DDIS phase functions, envelopes of the 
+  max phase function used in a medium. Implemented by `piecewise` and
+  `eoheterogeneous` media.
+
 ## v0.5.0 (9th June 2026)
 
 This release is the first to feature a full list of changes. It also contains

--- a/docs_eradiate/_docs_api/conf.py
+++ b/docs_eradiate/_docs_api/conf.py
@@ -93,6 +93,9 @@ api_doc_structure = {
         r"mitsuba\.ExtremumSegment([\w]*)",
         r"mitsuba\.ExtremumStructure([\w]*)",
     ],
+    "Phase": [
+        r"mitsuba\.PhaseFunction",
+    ],
 }
 
 # -- Docstring processing helpers -----------------------------------------

--- a/docs_eradiate/_docs_api/list_api.rst
+++ b/docs_eradiate/_docs_api/list_api.rst
@@ -15,3 +15,5 @@ Eradiate Mitsuba API
 
 .. autoclass:: mitsuba.Medium
 
+.. autoclass:: mitsuba.PhaseFunction
+

--- a/docs_eradiate/generated/eradiate_mitsuba_api.rst
+++ b/docs_eradiate/generated/eradiate_mitsuba_api.rst
@@ -29,8 +29,8 @@ Medium
 ------
 
 .. include:: /generated/extracted_rst_api.rst
-  :start-line: 192
-  :end-line: 375
+  :start-line: 197
+  :end-line: 381
 
 ------------
 
@@ -39,10 +39,19 @@ Extremum
 
 .. include:: /generated/extracted_rst_api.rst
   :start-line: 16
-  :end-line: 146
+  :end-line: 151
 
 ------------
 
 .. include:: /generated/extracted_rst_api.rst
-  :start-line: 147
-  :end-line: 191
+  :start-line: 152
+  :end-line: 196
+
+------------
+
+Phase
+-----
+
+.. include:: /generated/extracted_rst_api.rst
+  :start-line: 382
+  :end-line: 567

--- a/docs_eradiate/generated/extracted_rst_api.rst
+++ b/docs_eradiate/generated/extracted_rst_api.rst
@@ -1,6 +1,6 @@
 .. py:data:: mitsuba.ERD_MI_VERSION
     :type: str
-    :value: 0.4.3
+    :value: 0.5.0
 
 .. py:data:: mitsuba.ERD_MI_VERSION_MAJOR
     :type: int
@@ -8,11 +8,11 @@
 
 .. py:data:: mitsuba.ERD_MI_VERSION_MINOR
     :type: int
-    :value: 4
+    :value: 5
 
 .. py:data:: mitsuba.ERD_MI_VERSION_PATCH
     :type: int
-    :value: 3
+    :value: 0
 
 .. py:class:: mitsuba.ExtremumSegment
 
@@ -25,13 +25,7 @@
 
     .. py:method:: __init__()
 
-
-    .. py:method:: __init__(self, other)
-
-        Copy constructor
-
-        Parameter ``other`` (:py:obj:`mitsuba.ExtremumSegment`):
-            *no description available*
+        Default constructor — creates an invalid segment via reset()
 
     .. py:method:: __init__(self, mint, maxt, minorant, majorant)
 
@@ -54,7 +48,8 @@
 
     .. py:method:: __init__(self, mint, maxt, value)
 
-        Construct from entry/exit distances and a combined extremum vector.
+        Construct from entry/exit distances and separate minorant/majorant
+        values.
 
         Parameter ``mint`` (float):
             Segment entry distance
@@ -62,8 +57,18 @@
         Parameter ``maxt`` (float):
             Segment exit distance
 
-        Parameter ``value`` (:py:obj:`mitsuba.Vector2f`):
-            Extremum vector [minorant, majorant]
+        Parameter ``minorant``:
+            Lower extinction bound over the segment
+
+        Parameter ``majorant``:
+            Upper extinction bound over the segment
+
+    .. py:method:: __init__(self, arg)
+
+        Copy constructor
+
+        Parameter ``arg`` (:py:obj:`mitsuba.ExtremumSegment`):
+            *no description available*
 
     .. py:method:: mitsuba.ExtremumSegment.assign(self, arg)
 
@@ -317,9 +322,11 @@
             Mask to specify active lanes.
 
         Returns → tuple[:py:obj:`mitsuba.MediumInteraction3f`, :py:obj:`mitsuba.Color3f`, :py:obj:`mitsuba.Color3f`]:
-            This method returns a MediumInteraction. The MediumInteraction
-            will always be valid, except if the ray missed the Medium's
-            bounding box.
+            This method returns a tuple (MediumInteraction, Transmittance,
+            PDF). The MediumInteraction if an interaction was sampled within
+            the medium boudning box and before the bouding iteraction it. The
+            transmittance and PDF are both computed for all channels even if
+            the sampling operation is performed on one channel.
 
     .. py:method:: mitsuba.Medium.transmittance_eval_analytical(self, ray, it, active)
 
@@ -372,4 +379,189 @@
 
         Returns → bool:
             *no description available*
+
+.. py:class:: mitsuba.PhaseFunction
+
+    Base class: :py:obj:`mitsuba.Object`
+
+    Abstract phase function base-class.
+
+    This class provides an abstract interface to all Phase function
+    plugins in Mitsuba. It exposes functions for evaluating and sampling
+    the model.
+
+    .. py:method:: __init__(self, arg)
+
+        Parameter ``arg`` (:py:obj:`mitsuba.Properties`, /):
+            *no description available*
+
+
+    .. py:method:: mitsuba.PhaseFunction.accumulate_envelope(self, nodes, values)
+
+        Evaluate the phase function at the given cos_theta nodes and
+        accumulate the result into ``values`` by taking the elementwise
+        maximum.
+
+        For each node :math:`\mu_i` in ``nodes`` this method evaluates the
+        phase function value :math:`p(\mu_i)` and updates
+        :math:`\texttt{values}[i] \leftarrow \max(\texttt{values}[i],\,
+        p(\mu_i))`.
+
+        Delegating the comparison to the callee rather than the caller enables
+        natural recursion through composite phase functions (e.g.
+        BlendPhaseFunction, MultiPhaseFunction): a composite implementation
+        simply calls ``eval_max`` on each child with the same buffer, and each
+        child accumulates its contribution independently. The resulting buffer
+        holds the pointwise supremum over the entire phase-function tree
+        without the caller needing to know its structure.
+
+        \note cos_theta follows the physics convention (see get_nodes).
+
+        Parameter ``nodes`` (drjit.scalar.ArrayXf):
+            cos_theta values at which to evaluate the phase function, as
+            returned by get_nodes.
+
+        Parameter ``values`` (drjit.scalar.ArrayXf):
+            In/out buffer. Must have the same length as ``nodes`` and be zero-
+            initialised before the first comparison. On return, each entry
+            holds the maximum of its previous value and the phase function
+            evaluated at the corresponding node.
+
+        Returns → None:
+            *no description available*
+
+    .. py:method:: mitsuba.PhaseFunction.component_count(self, active=True)
+
+        Number of components this phase function is comprised of.
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → int:
+            *no description available*
+
+    .. py:method:: mitsuba.PhaseFunction.eval_pdf(self, ctx, mi, wo, active=True)
+
+        Evaluates the phase function model value and PDF
+
+        The function returns the value (which often equals the PDF) of the
+        phase function in the query direction.
+
+        Parameter ``ctx`` (:py:obj:`mitsuba.PhaseFunctionContext`):
+            A phase function sampling context, contains information about the
+            transport mode
+
+        Parameter ``mi`` (:py:obj:`mitsuba.MediumInteraction3f`):
+            A medium interaction data structure describing the underlying
+            medium position. The incident direction is obtained from the field
+            ``mi.wi``.
+
+        Parameter ``wo`` (:py:obj:`mitsuba.Vector3f`):
+            An outgoing direction to evaluate.
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → tuple[:py:obj:`mitsuba.Color3f`, float]:
+            The value and the sampling PDF of the phase function in direction
+            wo
+
+    .. py:method:: mitsuba.PhaseFunction.flags(self, index, active=True)
+
+        Overloaded function.
+
+        1. ``flags(self, index: int, active: bool = True) -> int``
+
+        Flags for a specific component of this phase function.
+
+        2. ``flags(self, active: bool = True) -> int``
+
+        Flags for this phase function.
+
+        Parameter ``index`` (int):
+            *no description available*
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → int:
+            *no description available*
+
+    .. py:method:: mitsuba.PhaseFunction.get_envelope_nodes()
+
+        Populate a set of cos_theta nodes suitable for representing this phase
+        function.
+
+        The nodes are used to build the piecewise-linear envelope required by
+        the DDIS importance sampling scheme. Subclasses may override this
+        method to supply irregularly spaced nodes that better resolve sharp
+        features (e.g. a strong forward-scattering peak). The default
+        implementation places ``m_node_count`` nodes uniformly in [-1, 1].
+
+        \note cos_theta follows the physics convention: a value of +1
+        corresponds to aligned (forward-scattering) incoming and outgoing
+        directions, and -1 corresponds to exact backscatter.
+
+        Returns → drjit.scalar.ArrayXf:
+            A sorted buffer of cos_theta values at which the phase function
+            should be evaluated.
+
+    .. py:property:: mitsuba.PhaseFunction.m_flags
+
+        Type of phase function (e.g. anisotropic)
+
+    .. py:method:: mitsuba.PhaseFunction.max_projected_area()
+
+        Return the maximum projected area of the microflake distribution
+
+        Returns → float:
+            *no description available*
+
+    .. py:method:: mitsuba.PhaseFunction.projected_area(self, mi, active=True)
+
+        Returns the microflake projected area
+
+        The function returns the projected area of the microflake distribution
+        defining the phase function. For non-microflake phase functions, e.g.
+        isotropic or Henyey-Greenstein, this should return a value of 1.
+
+        Parameter ``mi`` (:py:obj:`mitsuba.MediumInteraction3f`):
+            A medium interaction data structure describing the underlying
+            medium position. The incident direction is obtained from the field
+            ``mi.wi``.
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → float:
+            The projected area in direction ``mi.wi`` at position ``mi.p``
+
+    .. py:method:: mitsuba.PhaseFunction.sample(self, ctx, mi, sample1, sample2, active=True)
+
+        Importance sample the phase function model
+
+        The function returns a sampled direction.
+
+        Parameter ``ctx`` (:py:obj:`mitsuba.PhaseFunctionContext`):
+            A phase function sampling context, contains information about the
+            transport mode
+
+        Parameter ``mi`` (:py:obj:`mitsuba.MediumInteraction3f`):
+            A medium interaction data structure describing the underlying
+            medium position. The incident direction is obtained from the field
+            ``mi.wi``.
+
+        Parameter ``sample1`` (float):
+            A uniformly distributed sample on :math:`[0,1]`. It is used to
+            select the phase function component in multi-component models.
+
+        Parameter ``sample2`` (:py:obj:`mitsuba.Point2f`):
+            A uniformly distributed sample on :math:`[0,1]^2`. It is used to
+            generate the sampled direction.
+
+        Parameter ``active`` (bool):
+            Mask to specify active lanes.
+
+        Returns → tuple[:py:obj:`mitsuba.Vector3f`, :py:obj:`mitsuba.Color3f`, float]:
+            A sampled direction wo and its corresponding weight and PDF
 

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4944,12 +4944,12 @@ static const char *__doc_mitsuba_Medium_update_ddis_phase_function =
 R"doc(Rebuild any DDIS-related derived data when the phase function has
 changed.
 
-This method is called by the scene's parameters_changed() for every
+This method is called by the scene's `parameters_changed()` for every
 medium whose phase function is marked dirty. The default
 implementation is a no-op; subclasses that maintain a DDIS phase
 function override it.
 
-This is intentionally separate from parameters_changed() so that the
+This is intentionally separate from `parameters_changed()` so that the
 scene can drive all media to completion before clearing dirty flags,
 which is required when multiple media share the same phase function
 via a scene-level reference.)doc";
@@ -5975,16 +5975,7 @@ static const char *__doc_mitsuba_PhaseFunctionFlags_Microflake = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_PhaseFunction = R"doc(//! @})doc";
 
-static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc()doc";
-
-static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
-
-static const char *__doc_mitsuba_PhaseFunction_dirty =
-R"doc(Return whether this phase function's parameters have changed since the
-last call to set_dirty(false). Set by parameters_changed(), cleared by
-the scene after all dependent media have been updated.)doc";
-
-static const char *__doc_mitsuba_PhaseFunction_eval_max =
+static const char *__doc_mitsuba_PhaseFunction_accumulate_envelope =
 R"doc(Evaluate the phase function at the given cos_theta nodes and
 accumulate the result into ``values`` by taking the elementwise
 maximum.
@@ -6009,11 +6000,19 @@ Parameter ``nodes``:
     returned by get_nodes.
 
 Parameter ``values``:
-    In/out buffer. Must be either empty or have the same length as
-    ``nodes``; if empty it is resized and zero-initialised before the
-    first comparison. On return, each entry holds the maximum of its
-    previous value and the phase function evaluated at the
-    corresponding node.)doc";
+    In/out buffer. Must have the same length as ``nodes`` and be zero-
+    initialised before the first comparison. On return, each entry
+    holds the maximum of its previous value and the phase function
+    evaluated at the corresponding node.)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc()doc";
+
+static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_dirty =
+R"doc(Return whether this phase function's parameters have changed since the
+last call to set_dirty(false). Set by parameters_changed(), cleared by
+the scene after all dependent media have been updated.)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_eval_pdf =
 R"doc(Evaluates the phase function model value and PDF
@@ -6041,9 +6040,7 @@ static const char *__doc_mitsuba_PhaseFunction_flags = R"doc(Flags for this phas
 
 static const char *__doc_mitsuba_PhaseFunction_flags_2 = R"doc(Flags for a specific component of this phase function.)doc";
 
-static const char *__doc_mitsuba_PhaseFunction_get_flags = R"doc(Return type of phase function)doc";
-
-static const char *__doc_mitsuba_PhaseFunction_get_nodes =
+static const char *__doc_mitsuba_PhaseFunction_get_envelope_nodes =
 R"doc(Populate a set of cos_theta nodes suitable for representing this phase
 function.
 
@@ -6057,10 +6054,11 @@ implementation places ``m_node_count`` nodes uniformly in [-1, 1].
 corresponds to aligned (forward-scattering) incoming and outgoing
 directions, and -1 corresponds to exact backscatter.
 
-Parameter ``nodes``:
-    Output vector. Must be empty on input. On return it contains the
-    sorted cos_theta values at which the phase function should be
-    evaluated. The vector is resized by this call.)doc";
+Returns:
+    A sorted buffer of cos_theta values at which the phase function
+    should be evaluated.)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_get_flags = R"doc(Return type of phase function)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_m_components = R"doc(Flags for each component of this phase function.)doc";
 
@@ -7841,6 +7839,8 @@ static const char *__doc_mitsuba_Scene_m_silhouette_shapes_dr = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_m_thread_reordering = R"doc()doc";
 
+static const char *__doc_mitsuba_Scene_media = R"doc(Return the list of media)doc";
+
 static const char *__doc_mitsuba_Scene_parameters_changed = R"doc(Update internal state following a parameter update)doc";
 
 static const char *__doc_mitsuba_Scene_pdf_emitter =
@@ -8958,6 +8958,8 @@ mapping is bijective. The default implementation throws.)doc";
 
 static const char *__doc_mitsuba_Shape_exterior_medium = R"doc(Return the medium that lies on the exterior of this shape)doc";
 
+static const char *__doc_mitsuba_Shape_exterior_medium_2 = R"doc()doc";
+
 static const char *__doc_mitsuba_Shape_get_children_string = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_has_attribute =
@@ -8971,6 +8973,8 @@ static const char *__doc_mitsuba_Shape_has_flipped_normals = R"doc(Does this sha
 static const char *__doc_mitsuba_Shape_initialize = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_interior_medium = R"doc(Return the medium that lies on the interior of this shape)doc";
+
+static const char *__doc_mitsuba_Shape_interior_medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Shape_invert_silhouette_sample =
 R"doc(Map a silhouette segment to a point in boundary sample space
@@ -12322,7 +12326,12 @@ static const char *__doc_mitsuba_math_ulpdiff =
 R"doc(Compare the difference in ULPs between a reference value and another
 given floating point number)doc";
 
-static const char *__doc_mitsuba_merge_nodes = R"doc(Merge multiple lists of nodes into one. Remove duplicates.)doc";
+static const char *__doc_mitsuba_merge_envelope_nodes =
+R"doc(Merge multiple node buffers into one. Remove duplicates.
+
+The concatenation/sort/unique is performed on the host: JIT buffers
+are evaluated and copied to a temporary scalar array before being
+merged and loaded back into a single ``FloatStorage``.)doc";
 
 static const char *__doc_mitsuba_mueller_absorber =
 R"doc(Constructs the Mueller matrix of an ideal absorber

--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -4790,6 +4790,12 @@ static const char *__doc_mitsuba_Medium_Medium_2 = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_class_name = R"doc()doc";
 
+static const char *__doc_mitsuba_Medium_ddis_phase_function =
+R"doc(Return the ddis phase function of this medium. Can be null for medium
+that don't specify such phase function.)doc";
+
+static const char *__doc_mitsuba_Medium_ddis_threshold = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium_extremum_structure = R"doc(Returns the extremum structure for local extremum acceleration.)doc";
 
 static const char *__doc_mitsuba_Medium_get_majorant = R"doc(Returns the medium's majorant used for delta tracking)doc";
@@ -4808,6 +4814,10 @@ static const char *__doc_mitsuba_Medium_intersect_aabb = R"doc(Intersects a ray 
 
 static const char *__doc_mitsuba_Medium_is_homogeneous = R"doc(Returns whether this medium is homogeneous)doc";
 
+static const char *__doc_mitsuba_Medium_m_ddis_phase_function = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_m_ddis_threshold = R"doc()doc";
+
 static const char *__doc_mitsuba_Medium_m_extremum_structure = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_m_has_spectral_extinction = R"doc()doc";
@@ -4821,6 +4831,8 @@ static const char *__doc_mitsuba_Medium_m_sample_emitters = R"doc()doc";
 static const char *__doc_mitsuba_Medium_m_use_rrt = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_phase_function = R"doc(Return the phase function of this medium)doc";
+
+static const char *__doc_mitsuba_Medium_phase_function_2 = R"doc(Return the phase function of this medium, non const)doc";
 
 static const char *__doc_mitsuba_Medium_prepare_medium_traversal =
 R"doc(Intersects ray with the medium bbox and creates a medium interaction.
@@ -4880,9 +4892,11 @@ Parameter ``channel``:
     distance. This argument is only used when rendering in RGB modes.
 
 Returns:
-    This method returns a MediumInteraction. The MediumInteraction
-    will always be valid, except if the ray missed the Medium's
-    bounding box.)doc";
+    This method returns a tuple (MediumInteraction, Transmittance,
+    PDF). The MediumInteraction if an interaction was sampled within
+    the medium boudning box and before the bouding iteraction it. The
+    transmittance and PDF are both computed for all channels even if
+    the sampling operation is performed on one channel.)doc";
 
 static const char *__doc_mitsuba_Medium_to_string = R"doc(Return a human-readable representation of the Medium)doc";
 
@@ -4925,6 +4939,20 @@ static const char *__doc_mitsuba_Medium_traverse_1_cb_ro = R"doc()doc";
 static const char *__doc_mitsuba_Medium_traverse_1_cb_rw = R"doc()doc";
 
 static const char *__doc_mitsuba_Medium_type = R"doc()doc";
+
+static const char *__doc_mitsuba_Medium_update_ddis_phase_function =
+R"doc(Rebuild any DDIS-related derived data when the phase function has
+changed.
+
+This method is called by the scene's parameters_changed() for every
+medium whose phase function is marked dirty. The default
+implementation is a no-op; subclasses that maintain a DDIS phase
+function override it.
+
+This is intentionally separate from parameters_changed() so that the
+scene can drive all media to completion before clearing dirty flags,
+which is required when multiple media share the same phase function
+via a scene-level reference.)doc";
 
 static const char *__doc_mitsuba_Medium_use_emitter_sampling = R"doc(Returns whether this specific medium instance uses emitter sampling)doc";
 
@@ -5951,6 +5979,42 @@ static const char *__doc_mitsuba_PhaseFunction_class_name = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_component_count = R"doc(Number of components this phase function is comprised of.)doc";
 
+static const char *__doc_mitsuba_PhaseFunction_dirty =
+R"doc(Return whether this phase function's parameters have changed since the
+last call to set_dirty(false). Set by parameters_changed(), cleared by
+the scene after all dependent media have been updated.)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_eval_max =
+R"doc(Evaluate the phase function at the given cos_theta nodes and
+accumulate the result into ``values`` by taking the elementwise
+maximum.
+
+For each node :math:`\mu_i` in ``nodes`` this method evaluates the
+phase function value :math:`p(\mu_i)` and updates
+:math:`\texttt{values}[i] \leftarrow \max(\texttt{values}[i],\,
+p(\mu_i))`.
+
+Delegating the comparison to the callee rather than the caller enables
+natural recursion through composite phase functions (e.g.
+BlendPhaseFunction, MultiPhaseFunction): a composite implementation
+simply calls ``eval_max`` on each child with the same buffer, and each
+child accumulates its contribution independently. The resulting buffer
+holds the pointwise supremum over the entire phase-function tree
+without the caller needing to know its structure.
+
+\note cos_theta follows the physics convention (see get_nodes).
+
+Parameter ``nodes``:
+    cos_theta values at which to evaluate the phase function, as
+    returned by get_nodes.
+
+Parameter ``values``:
+    In/out buffer. Must be either empty or have the same length as
+    ``nodes``; if empty it is resized and zero-initialised before the
+    first comparison. On return, each entry holds the maximum of its
+    previous value and the phase function evaluated at the
+    corresponding node.)doc";
+
 static const char *__doc_mitsuba_PhaseFunction_eval_pdf =
 R"doc(Evaluates the phase function model value and PDF
 
@@ -5979,11 +6043,40 @@ static const char *__doc_mitsuba_PhaseFunction_flags_2 = R"doc(Flags for a speci
 
 static const char *__doc_mitsuba_PhaseFunction_get_flags = R"doc(Return type of phase function)doc";
 
+static const char *__doc_mitsuba_PhaseFunction_get_nodes =
+R"doc(Populate a set of cos_theta nodes suitable for representing this phase
+function.
+
+The nodes are used to build the piecewise-linear envelope required by
+the DDIS importance sampling scheme. Subclasses may override this
+method to supply irregularly spaced nodes that better resolve sharp
+features (e.g. a strong forward-scattering peak). The default
+implementation places ``m_node_count`` nodes uniformly in [-1, 1].
+
+\note cos_theta follows the physics convention: a value of +1
+corresponds to aligned (forward-scattering) incoming and outgoing
+directions, and -1 corresponds to exact backscatter.
+
+Parameter ``nodes``:
+    Output vector. Must be empty on input. On return it contains the
+    sorted cos_theta values at which the phase function should be
+    evaluated. The vector is resized by this call.)doc";
+
 static const char *__doc_mitsuba_PhaseFunction_m_components = R"doc(Flags for each component of this phase function.)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_m_dirty =
+R"doc(True if the phase function's parameters have changed since the last
+scene update)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_m_flags = R"doc(Type of phase function (e.g. anisotropic))doc";
 
+static const char *__doc_mitsuba_PhaseFunction_m_node_count =
+R"doc(Number of nodes to regularly discretize the cos theta dimension in
+eval_max)doc";
+
 static const char *__doc_mitsuba_PhaseFunction_max_projected_area = R"doc(Return the maximum projected area of the microflake distribution)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_parameters_changed = R"doc()doc";
 
 static const char *__doc_mitsuba_PhaseFunction_projected_area =
 R"doc(Returns the microflake projected area
@@ -6024,6 +6117,8 @@ Parameter ``sample2``:
 
 Returns:
     A sampled direction wo and its corresponding weight and PDF)doc";
+
+static const char *__doc_mitsuba_PhaseFunction_set_dirty = R"doc(Modify the phase function's dirty flag)doc";
 
 static const char *__doc_mitsuba_PhaseFunction_set_flags = R"doc(Set type of phase function)doc";
 
@@ -7723,6 +7818,8 @@ static const char *__doc_mitsuba_Scene_m_emitters_dr = R"doc()doc";
 static const char *__doc_mitsuba_Scene_m_environment = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_m_integrator = R"doc()doc";
+
+static const char *__doc_mitsuba_Scene_m_media = R"doc()doc";
 
 static const char *__doc_mitsuba_Scene_m_sensors = R"doc()doc";
 
@@ -12224,6 +12321,8 @@ Returns:
 static const char *__doc_mitsuba_math_ulpdiff =
 R"doc(Compare the difference in ULPs between a reference value and another
 given floating point number)doc";
+
+static const char *__doc_mitsuba_merge_nodes = R"doc(Merge multiple lists of nodes into one. Remove duplicates.)doc";
 
 static const char *__doc_mitsuba_mueller_absorber =
 R"doc(Constructs the Mueller matrix of an ideal absorber

--- a/include/mitsuba/render/eradiate/phase_utils.h
+++ b/include/mitsuba/render/eradiate/phase_utils.h
@@ -1,30 +1,42 @@
 #pragma once
 
 #include <mitsuba/core/fwd.h>
+#include <drjit/array.h>
 #include <algorithm>
 #include <vector>
 
 NAMESPACE_BEGIN(mitsuba)
-/**
-* Merge multiple lists of nodes into one. Remove duplicates.
-*/
-template <typename Float>
-std::vector<Float> merge_nodes(const std::vector<std::vector<Float>> &nodes) {
-    if (nodes.empty())
-        return {};
-    if (nodes.size() == 1)
-        return nodes[0];
 
-    std::vector<Float> merged_nodes;
-    for (const auto &n : nodes)
-        merged_nodes.insert(merged_nodes.end(), n.begin(), n.end());
-    std::sort(merged_nodes.begin(), merged_nodes.end());
+/**
+* Merge multiple node buffers into one. Remove duplicates.
+*
+* The concatenation/sort/unique is performed on the host: JIT buffers are
+* evaluated and copied to a temporary scalar array before being merged and
+* loaded back into a single \c FloatStorage.
+*/
+template <typename FloatStorage>
+FloatStorage merge_nodes(const std::vector<FloatStorage> &lists) {
+    using ScalarFloat = dr::scalar_t<FloatStorage>;
+
+    if (lists.empty())
+        return FloatStorage();
+    if (lists.size() == 1)
+        return lists[0];
+
+    std::vector<ScalarFloat> merged;
+    for (const auto &l : lists) {
+        size_t w   = dr::width(l);
+        size_t off = merged.size();
+        merged.resize(off + w);
+        dr::store(merged.data() + off, l);
+    }
+
+    std::sort(merged.begin(), merged.end());
     // std::unique moves indeterminate duplicates at the end of the range
     // which are erased by std::vector::erase.
-    merged_nodes.erase(std::unique(merged_nodes.begin(), merged_nodes.end()),
-                       merged_nodes.end());
+    merged.erase(std::unique(merged.begin(), merged.end()), merged.end());
 
-    return std::move(merged_nodes);
+    return dr::load<FloatStorage>(merged.data(), merged.size());
 }
 
 NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/eradiate/phase_utils.h
+++ b/include/mitsuba/render/eradiate/phase_utils.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(mitsuba)
 * loaded back into a single \c FloatStorage.
 */
 template <typename FloatStorage>
-FloatStorage merge_nodes(const std::vector<FloatStorage> &lists) {
+FloatStorage merge_envelope_nodes(const std::vector<FloatStorage> &lists) {
     using ScalarFloat = dr::scalar_t<FloatStorage>;
 
     if (lists.empty())

--- a/include/mitsuba/render/eradiate/phase_utils.h
+++ b/include/mitsuba/render/eradiate/phase_utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <mitsuba/core/fwd.h>
+#include <algorithm>
+#include <vector>
+
+NAMESPACE_BEGIN(mitsuba)
+/**
+* Merge multiple lists of nodes into one. Remove duplicates.
+*/
+template <typename Float>
+std::vector<Float> merge_nodes(const std::vector<std::vector<Float>> &nodes) {
+    if (nodes.empty())
+        return {};
+    if (nodes.size() == 1)
+        return nodes[0];
+
+    std::vector<Float> merged_nodes;
+    for (const auto &n : nodes)
+        merged_nodes.insert(merged_nodes.end(), n.begin(), n.end());
+    std::sort(merged_nodes.begin(), merged_nodes.end());
+    // std::unique moves indeterminate duplicates at the end of the range
+    // which are erased by std::vector::erase.
+    merged_nodes.erase(std::unique(merged_nodes.begin(), merged_nodes.end()),
+                       merged_nodes.end());
+
+    return std::move(merged_nodes);
+}
+
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -78,7 +78,7 @@ public:
                            const SurfaceInteraction3f &si,
                            Mask active) const;
 
-// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf
     /**
      * \brief Sample a free-flight distance in the medium analytically.
      *
@@ -95,31 +95,31 @@ public:
      * free-flight distance. This argument is only used when rendering in RGB
      * modes.
      *
-     * \return         This method returns a tuple 
+     * \return         This method returns a tuple
      *                 (MediumInteraction, Transmittance, PDF).
      *                 The MediumInteraction if an interaction was sampled within
-     *                 the medium boudning box and before the bouding iteraction 
+     *                 the medium boudning box and before the bouding iteraction
      *                 \ref it.
      *                 The transmittance and PDF are both computed for all channels
      *                 even if the sampling operation is performed on one channel.
-     *                 
+     *
      */
-    virtual 
-    std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum> 
+    virtual
+    std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum>
     sample_interaction_analytical(const Ray3f &ray, const Interaction3f &it,
                             Float sample, UInt32 channel, Mask active) const;
 
     /** \brief Compute the analytical transmittance along a ray to an interaction.
-     * 
+     *
      * \param ray      Ray, along which to compute the transmittance, use mint
      * \param si       Interaction that marks the end of the segment along which
      *                 to compute the transmittance.
-     * 
+     *
      * \return
      *      The transmittance along a ray
     */
     virtual UnpolarizedSpectrum
-    transmittance_eval_analytical(const Ray3f &ray, const Interaction3f &it, 
+    transmittance_eval_analytical(const Ray3f &ray, const Interaction3f &it,
                                   Mask active) const;
 // #ERADIATE_CHANGE_END
 
@@ -148,17 +148,17 @@ public:
 // #ERADIATE_CHANGE_BEGIN: Extremum Structure accessor and traversal helpers
     /**
      * \brief Intersects ray with the medium bbox and creates a medium interaction.
-     * 
+     *
      * \param ray   The ray that is used to test the medium bbox.
-     *       
+     *
      * \return
      *      A tuple (mei, mint, maxt): ``mei`` is a  ``MediumInteraction3f``
-     *      object initialized with the current ray and medium data. ``mint`` 
-     *      and ``maxt`` represent the minimum and maximum intersection 
+     *      object initialized with the current ray and medium data. ``mint``
+     *      and ``maxt`` represent the minimum and maximum intersection
      *      distances of the ray with the medium's bbox. In case there are no
      *      valid intersection, the range defaults to [0, +Inf].
      */
-    std::tuple<MediumInteraction3f, Float, Float> 
+    std::tuple<MediumInteraction3f, Float, Float>
     prepare_medium_traversal(const Ray3f& ray, Mask active) const;
 
     /// Returns the extremum structure for local extremum acceleration.
@@ -189,20 +189,32 @@ public:
         return m_ddis_threshold;
     }
 
+
     /**
      * \brief Rebuild any DDIS-related derived data when the phase function has
      * changed.
      *
-     * This method is called by the scene's parameters_changed() for every
+     * This method is called by the scene's `parameters_changed()` for every
      * medium whose phase function is marked dirty. The default implementation
      * is a no-op; subclasses that maintain a DDIS phase function override it.
      *
-     * This is intentionally separate from parameters_changed() so that the
+     * This is intentionally separate from `parameters_changed()` so that the
      * scene can drive all media to completion before clearing dirty flags,
      * which is required when multiple media share the same phase function via
      * a scene-level reference.
      */
-    virtual void update_ddis_phase_function() {}
+    virtual void update_ddis_phase_function();
+
+protected:
+    /**
+     * \brief Create the tabphase irregular plugin used as DDIS phase function.
+     *
+     * This method is an helper function for child classes.
+     */
+    ref<PhaseFunction> create_ddis_phase_function();
+
+public:
+
 // #ERADIATE_CHANGE_END
     void traverse(TraversalCallback *callback) override;
 
@@ -228,8 +240,8 @@ protected:
 // #ERADIATE_CHANGE_BEGIN: DDIS
     ref<PhaseFunction> m_ddis_phase_function = nullptr;
     ScalarFloat m_ddis_threshold = 0.f;
-    
-    MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure, 
+
+    MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure,
                            m_ddis_phase_function, m_ddis_threshold)
 // #ERADIATE_CHANGE_END
 };
@@ -250,12 +262,11 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
     DRJIT_CALL_METHOD(intersect_aabb)
     DRJIT_CALL_METHOD(sample_interaction)
     DRJIT_CALL_METHOD(transmittance_eval_pdf)
-// #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf 
+// #ERADIATE_CHANGE_BEGIN: Add function that calculates the transmittance and pdf
     DRJIT_CALL_METHOD(sample_interaction_analytical)
     DRJIT_CALL_METHOD(transmittance_eval_analytical)
 // #ERADIATE_CHANGE_END
     DRJIT_CALL_METHOD(get_scattering_coefficients)
-    
 // #ERADIATE_CHANGE_BEGIN: Extremum Support && Residual Ratio Tracking && DDIS
     DRJIT_CALL_GETTER(ddis_phase_function)
     DRJIT_CALL_GETTER(ddis_threshold)

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -127,6 +127,12 @@ public:
     MI_INLINE const PhaseFunction *phase_function() const {
         return m_phase_function.get();
     }
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    /// Return the phase function of this medium, non const
+    MI_INLINE PhaseFunction *phase_function() {
+        return m_phase_function.get();
+    }
+// #ERADIATE_CHANGE_END
 
     /// Returns whether this specific medium instance uses emitter sampling
     MI_INLINE bool use_emitter_sampling() const { return m_sample_emitters; }
@@ -170,6 +176,34 @@ public:
     }
 // #ERADIATE_CHANGE_END
 
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    /**
+     * \brief Return the ddis phase function of this medium. Can be null for
+     * medium that don't specify such phase function.
+     */
+    MI_INLINE const PhaseFunction *ddis_phase_function() const {
+        return m_ddis_phase_function.get();
+    }
+
+    MI_INLINE ScalarFloat ddis_threshold() const {
+        return m_ddis_threshold;
+    }
+
+    /**
+     * \brief Rebuild any DDIS-related derived data when the phase function has
+     * changed.
+     *
+     * This method is called by the scene's parameters_changed() for every
+     * medium whose phase function is marked dirty. The default implementation
+     * is a no-op; subclasses that maintain a DDIS phase function override it.
+     *
+     * This is intentionally separate from parameters_changed() so that the
+     * scene can drive all media to completion before clearing dirty flags,
+     * which is required when multiple media share the same phase function via
+     * a scene-level reference.
+     */
+    virtual void update_ddis_phase_function() {}
+// #ERADIATE_CHANGE_END
     void traverse(TraversalCallback *callback) override;
 
     /// Return a human-readable representation of the Medium
@@ -191,8 +225,13 @@ protected:
     bool m_use_rrt;
 // #ERADIATE_CHANGE_END
 
-    MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure)
-    // MI_DECLARE_TRAVERSE_CB(m_phase_function)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    ref<PhaseFunction> m_ddis_phase_function;
+    ScalarFloat m_ddis_threshold;
+    
+    MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure, 
+                           m_ddis_phase_function, m_ddis_threshold)
+// #ERADIATE_CHANGE_END
 };
 
 MI_EXTERN_CLASS(Medium)
@@ -217,9 +256,13 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::Medium)
 // #ERADIATE_CHANGE_END
     DRJIT_CALL_METHOD(get_scattering_coefficients)
     
+// #ERADIATE_CHANGE_BEGIN: Extremum Support && Residual Ratio Tracking && DDIS
+    DRJIT_CALL_GETTER(ddis_phase_function)
+    DRJIT_CALL_GETTER(ddis_threshold)
     DRJIT_CALL_GETTER(use_rrt)
     DRJIT_CALL_GETTER(extremum_structure)
     DRJIT_CALL_METHOD(prepare_medium_traversal)
+// #ERADIATE_CHANGE_END
 DRJIT_CALL_END()
 
 //! @}

--- a/include/mitsuba/render/medium.h
+++ b/include/mitsuba/render/medium.h
@@ -226,8 +226,8 @@ protected:
 // #ERADIATE_CHANGE_END
 
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    ref<PhaseFunction> m_ddis_phase_function;
-    ScalarFloat m_ddis_threshold;
+    ref<PhaseFunction> m_ddis_phase_function = nullptr;
+    ScalarFloat m_ddis_threshold = 0.f;
     
     MI_DECLARE_TRAVERSE_CB(m_phase_function, m_extremum_structure, 
                            m_ddis_phase_function, m_ddis_threshold)

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -207,9 +207,11 @@ public:
     /// Set type of phase function
     void set_flags(uint32_t flags) { m_flags = flags; }
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    /// Return whether this phase function's parameters have changed since the
-    /// last call to set_dirty(false). Set by parameters_changed(), cleared by
-    /// the scene after all dependent media have been updated.
+    /**
+     * Return whether this phase function's parameters have changed since the
+     * last call to set_dirty(false). Set by parameters_changed(), cleared by
+     * the scene after all dependent media have been updated.
+    */
     bool dirty() const { return m_dirty; }
 
     /// Modify the phase function's dirty flag
@@ -234,10 +236,10 @@ public:
      * \return A sorted buffer of cos_theta values at which the phase function
      *     should be evaluated.
      */
-    virtual FloatStorage get_nodes() const;
+    virtual FloatStorage get_envelope_nodes() const;
 
 
-     /**
+    /**
      * \brief Evaluate the phase function at the given cos_theta nodes and
      * accumulate the result into \c values by taking the elementwise maximum.
      *
@@ -264,7 +266,7 @@ public:
      *     holds the maximum of its previous value and the phase function
      *     evaluated at the corresponding node.
      */
-    virtual void eval_max(const FloatStorage &nodes, FloatStorage &values) const;
+    virtual void accumulate_envelope(const FloatStorage &nodes, FloatStorage &values) const;
 // #ERADIATE_CHANGE_END
     //! @}
     // -----------------------------------------------------------------------

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -107,6 +107,9 @@ class MI_EXPORT_LIB PhaseFunction : public JitObject<PhaseFunction<Float, Spectr
 public:
     MI_IMPORT_TYPES(PhaseFunctionContext);
 
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    using FloatStorage = mitsuba::DynamicBuffer<Float>;
+// #ERADIATE_CHANGE_END
     /**
      * \brief Importance sample the phase function model
      *
@@ -228,14 +231,13 @@ public:
      *     to aligned (forward-scattering) incoming and outgoing directions, and
      *     -1 corresponds to exact backscatter.
      *
-     * \param nodes
-     *     Output vector. On return it contains the cos_theta values at which
-     *     the phase function should be evaluated. The vector is resized by this
-     *     call.
+     * \return A sorted buffer of cos_theta values at which the phase function
+     *     should be evaluated.
      */
-    virtual void get_nodes(std::vector<ScalarFloat>& nodes) const;
+    virtual FloatStorage get_nodes() const;
 
-    /**
+
+     /**
      * \brief Evaluate the phase function at the given cos_theta nodes and
      * accumulate the result into \c values by taking the elementwise maximum.
      *
@@ -245,10 +247,10 @@ public:
      *
      * Delegating the comparison to the callee rather than the caller enables
      * natural recursion through composite phase functions (e.g.
-     * \ref BlendPhaseFunction, \ref MultiPhaseFunction): a composite 
-     * implementation simply calls \c eval_max on each child with the same 
-     * buffer, and each child accumulates its contribution independently. The 
-     * resulting buffer holds the pointwise supremum over the entire 
+     * \ref BlendPhaseFunction, \ref MultiPhaseFunction): a composite
+     * implementation simply calls \c eval_max on each child with the same
+     * buffer, and each child accumulates its contribution independently. The
+     * resulting buffer holds the pointwise supremum over the entire
      * phase-function tree without the caller needing to know its structure.
      *
      * \note cos_theta follows the physics convention (see \ref get_nodes).
@@ -257,13 +259,12 @@ public:
      *     cos_theta values at which to evaluate the phase function, as
      *     returned by \ref get_nodes.
      * \param values
-     *     In/out buffer. Must be either empty or have the same length as
-     *     \c nodes; if empty it is resized and zero-initialised before the
-     *     first comparison. On return, each entry holds the maximum of its
-     *     previous value and the phase function evaluated at the corresponding
-     *     node.
+     *     In/out buffer. Must have the same length as \c nodes and be
+     *     zero-initialised before the first comparison. On return, each entry
+     *     holds the maximum of its previous value and the phase function
+     *     evaluated at the corresponding node.
      */
-    virtual void eval_max(const std::vector<ScalarFloat>& nodes, std::vector<ScalarFloat>& values) const;
+    virtual void eval_max(const FloatStorage &nodes, FloatStorage &values) const;
 // #ERADIATE_CHANGE_END
     //! @}
     // -----------------------------------------------------------------------
@@ -319,8 +320,8 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::PhaseFunction)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(component_count)
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    DRJIT_CALL_METHOD(eval_max)
     DRJIT_CALL_METHOD(get_nodes)
+    DRJIT_CALL_METHOD(eval_max)
 // #ERADIATE_CHANGE_END
 DRJIT_CALL_END()
 

--- a/include/mitsuba/render/phase.h
+++ b/include/mitsuba/render/phase.h
@@ -203,7 +203,68 @@ public:
 
     /// Set type of phase function
     void set_flags(uint32_t flags) { m_flags = flags; }
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    /// Return whether this phase function's parameters have changed since the
+    /// last call to set_dirty(false). Set by parameters_changed(), cleared by
+    /// the scene after all dependent media have been updated.
+    bool dirty() const { return m_dirty; }
 
+    /// Modify the phase function's dirty flag
+    void set_dirty(bool dirty) { m_dirty = dirty; }
+
+    void parameters_changed(const std::vector<std::string> &keys = {}) override;
+
+    /**
+     * \brief Populate a set of cos_theta nodes suitable for representing this
+     * phase function.
+     *
+     * The nodes are used to build the piecewise-linear envelope required by
+     * the DDIS importance sampling scheme. Subclasses may override this method
+     * to supply irregularly spaced nodes that better resolve sharp features
+     * (e.g. a strong forward-scattering peak). The default implementation
+     * places \c m_node_count nodes uniformly in [-1, 1].
+     *
+     * \note cos_theta follows the physics convention: a value of +1 corresponds
+     *     to aligned (forward-scattering) incoming and outgoing directions, and
+     *     -1 corresponds to exact backscatter.
+     *
+     * \param nodes
+     *     Output vector. On return it contains the cos_theta values at which
+     *     the phase function should be evaluated. The vector is resized by this
+     *     call.
+     */
+    virtual void get_nodes(std::vector<ScalarFloat>& nodes) const;
+
+    /**
+     * \brief Evaluate the phase function at the given cos_theta nodes and
+     * accumulate the result into \c values by taking the elementwise maximum.
+     *
+     * For each node \f$\mu_i\f$ in \c nodes this method evaluates the phase
+     * function value \f$p(\mu_i)\f$ and updates
+     * \f$\texttt{values}[i] \leftarrow \max(\texttt{values}[i],\, p(\mu_i))\f$.
+     *
+     * Delegating the comparison to the callee rather than the caller enables
+     * natural recursion through composite phase functions (e.g.
+     * \ref BlendPhaseFunction, \ref MultiPhaseFunction): a composite 
+     * implementation simply calls \c eval_max on each child with the same 
+     * buffer, and each child accumulates its contribution independently. The 
+     * resulting buffer holds the pointwise supremum over the entire 
+     * phase-function tree without the caller needing to know its structure.
+     *
+     * \note cos_theta follows the physics convention (see \ref get_nodes).
+     *
+     * \param nodes
+     *     cos_theta values at which to evaluate the phase function, as
+     *     returned by \ref get_nodes.
+     * \param values
+     *     In/out buffer. Must be either empty or have the same length as
+     *     \c nodes; if empty it is resized and zero-initialised before the
+     *     first comparison. On return, each entry holds the maximum of its
+     *     previous value and the phase function evaluated at the corresponding
+     *     node.
+     */
+    virtual void eval_max(const std::vector<ScalarFloat>& nodes, std::vector<ScalarFloat>& values) const;
+// #ERADIATE_CHANGE_END
     //! @}
     // -----------------------------------------------------------------------
 
@@ -218,6 +279,12 @@ protected:
 
     /// Flags for each component of this phase function.
     std::vector<uint32_t> m_components;
+    // #ERADIATE_CHANGE_BEGIN: DDIS
+    /// Number of nodes to regularly discretize the cos theta dimension in \ref eval_max
+    size_t m_node_count;
+    /// True if the phase function's parameters have changed since the last scene update
+    bool m_dirty = false;
+    // #ERADIATE_CHANGE_END
 };
 
 MI_VARIANT
@@ -251,6 +318,10 @@ DRJIT_CALL_TEMPLATE_BEGIN(mitsuba::PhaseFunction)
     DRJIT_CALL_METHOD(max_projected_area)
     DRJIT_CALL_GETTER(flags)
     DRJIT_CALL_GETTER(component_count)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    DRJIT_CALL_METHOD(eval_max)
+    DRJIT_CALL_METHOD(get_nodes)
+// #ERADIATE_CHANGE_END
 DRJIT_CALL_END()
 
 //! @}

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -730,6 +730,10 @@ public:
 
     /// Return the list of sensors as a Dr.Jit array
     const DynamicBuffer<SensorPtr> &sensors_dr() const { return m_sensors_dr; }
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    /// Return the list of media
+    std::vector<ref<Medium>> &media() { return m_media; }
+// #ERADIATE_CHANGE_END
 
     //! @}
     // =============================================================

--- a/include/mitsuba/render/scene.h
+++ b/include/mitsuba/render/scene.h
@@ -6,6 +6,9 @@
 #include <mitsuba/render/fwd.h>
 #include <mitsuba/render/sensor.h>
 #include <mitsuba/render/shapegroup.h>
+// #ERADIATE_CHANGE_BEGIN: DDIS
+#include <mitsuba/render/phase.h>
+// #ERADIATE_CHANGE_END
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -36,9 +39,11 @@ NAMESPACE_BEGIN(mitsuba)
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB Scene final : public JitObject<Scene<Float, Spectrum>> {
 public:
+// #ERADIATE_CHANGE_BEGIN: DDIS
     MI_IMPORT_TYPES(BSDF, Emitter, EmitterPtr, SensorPtr, Film, Sampler, Shape,
                     ShapePtr, ShapeGroup, Sensor, Integrator, Medium, MediumPtr,
-                    Mesh)
+                    Mesh, PhaseFunction)
+// #ERADIATE_CHANGE_END
 
     /// Instantiate a scene from a \ref Properties object
     Scene(const Properties &props);
@@ -812,6 +817,9 @@ protected:
 
     std::vector<ref<Emitter>> m_emitters;
     DynamicBuffer<EmitterPtr> m_emitters_dr;
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+    std::vector<ref<Medium>> m_media;
+// #ERADIATE_CHANGE_END
 
     std::vector<ref<Shape>> m_shapes;
     DynamicBuffer<ShapePtr> m_shapes_dr;

--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -874,6 +874,12 @@ public:
 
     /// Return the medium that lies on the exterior of this shape
     const Medium *exterior_medium(Mask /*unused*/ = true) const { return m_exterior_medium.get(); }
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    // Add non const getters to add media in scene.cpp
+    Medium *interior_medium(Mask /*unused*/ = true) { return m_interior_medium.get(); }
+    
+    Medium *exterior_medium(Mask /*unused*/ = true) { return m_exterior_medium.get(); }
+// #ERADIATE_CHANGE_END
 
     /// Return the shape's BSDF
     const BSDF *bsdf(Mask /*unused*/ = true) const { return m_bsdf.get(); }

--- a/src/eradiate_plugins/integrators/eovolpath.cpp
+++ b/src/eradiate_plugins/integrators/eovolpath.cpp
@@ -49,7 +49,7 @@ EO Volumetric path tracer (:monosp:`eovolpath`)
    - |bool|
    - Hide directly visible emitters. (Default: no, i.e. |false|)
 
-This plugin provides a volumetric path tracer catered towards Earth Observation simualtions that can
+This plugin provides a volumetric path tracer catered towards Earth Observation simulations that can
 be used to compute approximate solutions of the radiative transfer equation. Its implementation
 makes use of multiple importance sampling to combine BSDF and phase function sampling with direct
 illumination sampling strategies. On surfaces, it behaves exactly like the standard path tracer.
@@ -61,15 +61,9 @@ has a :ref:`null <bsdf-null>` or :ref:`thin dielectric <bsdf-thindielectric>` BS
 to it (as compared to, say, a :ref:`dielectric <bsdf-dielectric>` or
 :ref:`roughdielectric <bsdf-roughdielectric>` BSDF).
 
-In addition, it implements the DDIS variance reduction method (Buras and Mayer, 2011) which reduces
-noise in the presence of strongly peaked phase functions. More variance reduction methods coming up
-soon!
-
-.. note:: This integrator does not implement good sampling strategies to render
-    participating media with a spectrally varying extinction coefficient. For these cases,
-    it is better to use the more advanced :ref:`volumetric path tracer with
-    spectral MIS <integrator-volpathmis>`, which will produce in a significantly less noisy
-    rendered image. Note however that it does not implement the EO features added in this integrator.
+In addition, it implements the DDIS variance reduction method
+:cite:p:`Buras2011EfficientUnbiasedVariance` which reduces noise in the presence of strongly peaked
+phase functions. More variance reduction methods coming up soon!
 
 .. warning:: This integrator does not support forward-mode differentiation.
 */
@@ -384,7 +378,7 @@ public:
 
                 PhaseFunctionContext phase_ctx(sampler);
                 auto phase = mei.medium->phase_function();
-                auto ddis_phase_function = mei.medium->ddis_phase_function();
+                auto ddis_phase = mei.medium->ddis_phase_function();
 
                 // --------------------- Emitter sampling ---------------------
                 Mask sample_emitters = mei.medium->use_emitter_sampling();
@@ -408,7 +402,7 @@ public:
 
                         Float ddis_phase_pdf;
                         std::tie(std::ignore, ddis_phase_pdf) =
-                            ddis_phase_function->eval_pdf(phase_ctx, ddis_mei, ds.d, perform_ddis);
+                            ddis_phase->eval_pdf(phase_ctx, ddis_mei, ds.d, perform_ddis);
 
                         // Compute mixture pdf accounting for DDIS probability
                         dr::masked(phase_pdf, perform_ddis) =
@@ -426,7 +420,7 @@ public:
                 Mask active_ddis = (eps < ddis_threshold) && act_medium_scatter && perform_ddis;
 
                 MediumInteraction3f sample_mei = dr::select(active_ddis, ddis_mei, mei);
-                auto sample_phase = dr::select(active_ddis, ddis_phase_function, phase);
+                auto sample_phase = dr::select(active_ddis, ddis_phase, phase);
 
                 // ddis off -> phase_weight: p(mu)/pdf(mu); phase_pdf: pdf(mu);
                 // ddis on  -> phase_weight: p(mu')/pdf(mu'); phase_pdf: pdf(mu');
@@ -439,7 +433,7 @@ public:
 
                 if (dr::any_or<true>(perform_ddis)) {
                     auto [natural_val, natural_pdf] = phase->eval_pdf(phase_ctx, mei, wo, perform_ddis);
-                    auto [ddis_val, ddis_pdf] = ddis_phase_function->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
+                    auto [ddis_val, ddis_pdf] = ddis_phase->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
 
                     dr::masked(phase_pdf, perform_ddis) =
                         ((1.f - ddis_threshold) * natural_pdf + ddis_threshold * ddis_pdf);
@@ -508,7 +502,7 @@ public:
                 MediumInteraction3f ddis_mei = dr::zeros<MediumInteraction3f>();
                 ddis_mei.p = si.p;
                 ddis_mei.time = si.time;
-                ddis_mei.wavelengths = ddis_mei.wavelengths;
+                ddis_mei.wavelengths = si.wavelengths;
                 ddis_mei.medium = medium;
                 PhaseFunctionContext phase_ctx(sampler);
 
@@ -538,7 +532,7 @@ public:
 
                 if (dr::any_or<true>(perform_ddis)) {
 
-                    auto ddis_phase_function = medium->ddis_phase_function();
+                    auto ddis_phase = medium->ddis_phase_function();
                     Spectrum natural_val = bsdf_val * bs.pdf;
                     Float natural_pdf = bs.pdf;
 
@@ -553,7 +547,7 @@ public:
                     // Sample from the ddis phase function
                     if (dr::any_or<true>(active_ddis)) {
                         auto [wo, phase_weight, phase_pdf] =
-                            ddis_phase_function->sample(phase_ctx, ddis_mei,
+                            ddis_phase->sample(phase_ctx, ddis_mei,
                                 sampler->next_1d(active_ddis),
                                 sampler->next_2d(active_ddis),
                                 active_ddis);
@@ -573,7 +567,7 @@ public:
 
                     Float ddis_pdf;
                     std::tie(std::ignore, ddis_pdf) =
-                        ddis_phase_function->eval_pdf(phase_ctx, ddis_mei,
+                        ddis_phase->eval_pdf(phase_ctx, ddis_mei,
                                                       si.to_world(bs.wo),
                                                       perform_ddis);
 

--- a/src/eradiate_plugins/integrators/eovolpath.cpp
+++ b/src/eradiate_plugins/integrators/eovolpath.cpp
@@ -25,60 +25,53 @@ EO Volumetric path tracer (:monosp:`eovolpath`)
 
  * - max_depth
    - |int|
-   - Specifies the longest path depth in the generated output image (where -1
-     corresponds to :math:`\infty`). A value of 1 will only render directly
-     visible light sources. 2 will lead to single-bounce (direct-only)
-     illumination, and so on. Default: -1
+   - Specifies the longest path depth in the generated output image (where -1 corresponds to
+     :math:`\infty`). A value of 1 will only render directly visible light sources. 2 will lead
+     to single-bounce (direct-only) illumination, and so on. (Default: -1)
 
  * - rr_depth
    - |int|
-   - Specifies the minimum path depth, after which the implementation will start
-     to use the *russian roulette* path termination criterion. Default: 5
+   - Specifies the minimum path depth, after which the implementation will start to use the
+     *russian roulette* path termination criterion. (Default: 5)
 
  * - rr_factor
    - |float|
-   - Specifies the maximum probability to keep a path when russian roulette is
-     evaluated. Default: 0.97
+   - Specifies the maximum probability to keep a path when russian roulette is evaluated.
+     (Default: 0.97)
 
- * - ddis_threshold
-   - |float|
-   - Specifies the probability to importance sample the phase using the emitter
-     as incident direction. Set to a negative value to disable. Default: 0.1
+ * - enable_ddis
+   - |bool|
+   - Activate the DDIS variance reduction method. The `ddis_threshold` used to determine the
+     probability of sampling usin the emitter direction is set in the media plugins.
+     (Default: false)
 
  * - hide_emitters
    - |bool|
-   - Hide directly visible emitters. Default: no, *i.e.* |False|
+   - Hide directly visible emitters. (Default: no, i.e. |false|)
 
-This plugin provides a volumetric path tracer catered towards Earth Observation
-simulations that can be used to compute approximate solutions of the radiative
-transfer equation. Its implementation makes use of multiple importance sampling
-to combine BSDF and phase function sampling with direct illumination sampling
-strategies. On surfaces, it behaves exactly like the standard path tracer.
+This plugin provides a volumetric path tracer catered towards Earth Observation simualtions that can
+be used to compute approximate solutions of the radiative transfer equation. Its implementation
+makes use of multiple importance sampling to combine BSDF and phase function sampling with direct
+illumination sampling strategies. On surfaces, it behaves exactly like the standard path tracer.
 
-This integrator has special support for index-matched transmission events
-(*i.e.* surface scattering events that do not change the direction of light).
-As a consequence, participating media enclosed by a stencil shape are rendered
-considerably more efficiently when this shape has a :ref:`null <bsdf-null>` or
-:ref:`thin dielectric <bsdf-thindielectric>` BSDF assigned to it (as compared
-to, say, a :ref:`dielectric <bsdf-dielectric>` or
+This integrator has special support for index-matched transmission events (i.e. surface scattering
+events that do not change the direction of light). As a consequence, participating media enclosed by
+a stencil shape are rendered considerably more efficiently when this shape
+has a :ref:`null <bsdf-null>` or :ref:`thin dielectric <bsdf-thindielectric>` BSDF assigned
+to it (as compared to, say, a :ref:`dielectric <bsdf-dielectric>` or
 :ref:`roughdielectric <bsdf-roughdielectric>` BSDF).
 
-In addition, it implements the DDIS variance reduction method
-:cite:p:`Buras2011EfficientUnbiasedVariance` which reduces noise in the presence
-of strongly peaked phase functions.
+In addition, it implements the DDIS variance reduction method (Buras and Mayer, 2011) which reduces
+noise in the presence of strongly peaked phase functions. More variance reduction methods coming up
+soon!
 
-.. note::
+.. note:: This integrator does not implement good sampling strategies to render
+    participating media with a spectrally varying extinction coefficient. For these cases,
+    it is better to use the more advanced :ref:`volumetric path tracer with
+    spectral MIS <integrator-volpathmis>`, which will produce in a significantly less noisy
+    rendered image. Note however that it does not implement the EO features added in this integrator.
 
-    This integrator does not implement good sampling strategies to render
-    participating media with a spectrally varying extinction coefficient. For
-    these cases, it is better to use the more advanced
-    :ref:`volumetric path tracer with spectral MIS <integrator-volpathmis>`,
-    which will produce in a significantly less noisy rendered image. Note however
-    that it does not implement the EO features added in this integrator.
-
-.. warning::
-
-    This integrator does not support forward-mode differentiation.
+.. warning:: This integrator does not support forward-mode differentiation.
 */
 template <typename Float, typename Spectrum>
 class EOVolumetricPathIntegrator : public MonteCarloIntegrator<Float, Spectrum> {
@@ -86,19 +79,17 @@ class EOVolumetricPathIntegrator : public MonteCarloIntegrator<Float, Spectrum> 
 public:
     MI_IMPORT_BASE(MonteCarloIntegrator, m_max_depth, m_rr_depth, m_hide_emitters)
     MI_IMPORT_TYPES(Scene, Sampler, Emitter, EmitterPtr, BSDF, BSDFPtr, Medium,
-                    MediumPtr, PhaseFunctionContext, ExtremumStructure)
+                    MediumPtr, PhaseFunction, PhaseFunctionContext, ExtremumStructure)
 
     using TrackingStateType = TrackingState<Float, Spectrum>;
 
     EOVolumetricPathIntegrator(const Properties &props) : Base(props) {
-        m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
         m_rr_factor = props.get<ScalarFloat>("rr_factor", 0.97f);
-
-        if (m_ddis_threshold > 1.f)
-            Throw("`ddis_threshold` is larger than 1.");
 
         if (m_rr_factor < 0.f || m_rr_factor > 1.f)
             Throw("`rr_factor` is outside range [0.,1.].");
+
+        m_enable_ddis = props.get<bool>("enable_ddis", false);
     }
 
     /// Create seed and offsets that can be used to generate a new PCG32 rng.
@@ -233,9 +224,14 @@ public:
             // we can perform a few optimizations to speed up rendering
             Mask is_spectral = active_medium;
             Mask not_spectral = false;
+            Float ddis_threshold = -1.f;
+
             if (dr::any_or<true>(active_medium)) {
                 is_spectral &= medium->has_spectral_extinction();
                 not_spectral = !is_spectral && active_medium;
+
+                dr::masked(ddis_threshold, active_medium && m_enable_ddis) =
+                    medium->ddis_threshold();
             }
 
             Float mint, maxt;
@@ -388,6 +384,7 @@ public:
 
                 PhaseFunctionContext phase_ctx(sampler);
                 auto phase = mei.medium->phase_function();
+                auto ddis_phase_function = mei.medium->ddis_phase_function();
 
                 // --------------------- Emitter sampling ---------------------
                 Mask sample_emitters = mei.medium->use_emitter_sampling();
@@ -397,7 +394,7 @@ public:
 
                 Mask active_e = act_medium_scatter && sample_emitters;
 
-                Mask perform_ddis = m_ddis_threshold > 0.f && active_e;
+                Mask perform_ddis = ddis_threshold > 0.f && active_e;
                 MediumInteraction3f ddis_mei = mei;
 
                 if (dr::any_or<true>(active_e)) {
@@ -411,11 +408,11 @@ public:
 
                         Float ddis_phase_pdf;
                         std::tie(std::ignore, ddis_phase_pdf) =
-                            phase->eval_pdf(phase_ctx, ddis_mei, ds.d, perform_ddis);
+                            ddis_phase_function->eval_pdf(phase_ctx, ddis_mei, ds.d, perform_ddis);
 
                         // Compute mixture pdf accounting for DDIS probability
                         dr::masked(phase_pdf, perform_ddis) =
-                            (1.f - m_ddis_threshold) * phase_pdf + m_ddis_threshold * ddis_phase_pdf;
+                            (1.f - ddis_threshold) * phase_pdf + ddis_threshold * ddis_phase_pdf;
                     }
 
                     dr::masked(result, active_e) += throughput * phase_val * emitted *
@@ -426,23 +423,26 @@ public:
                 dr::masked(phase, !act_medium_scatter) = nullptr;
 
                 Float eps = sampler->next_1d(active_medium);
-                Mask active_ddis = (eps < m_ddis_threshold) && act_medium_scatter && perform_ddis;
+                Mask active_ddis = (eps < ddis_threshold) && act_medium_scatter && perform_ddis;
+
                 MediumInteraction3f sample_mei = dr::select(active_ddis, ddis_mei, mei);
+                auto sample_phase = dr::select(active_ddis, ddis_phase_function, phase);
 
                 // ddis off -> phase_weight: p(mu)/pdf(mu); phase_pdf: pdf(mu);
                 // ddis on  -> phase_weight: p(mu')/pdf(mu'); phase_pdf: pdf(mu');
-                auto [wo, phase_weight, phase_pdf] = phase->sample(phase_ctx, sample_mei,
+                auto [wo, phase_weight, phase_pdf] = sample_phase->sample(phase_ctx, sample_mei,
                     sampler->next_1d(act_medium_scatter),
                     sampler->next_2d(act_medium_scatter),
                     act_medium_scatter);
+
                 act_medium_scatter &= phase_pdf > 0.f;
 
                 if (dr::any_or<true>(perform_ddis)) {
                     auto [natural_val, natural_pdf] = phase->eval_pdf(phase_ctx, mei, wo, perform_ddis);
-                    auto [ddis_val, ddis_pdf] = phase->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
+                    auto [ddis_val, ddis_pdf] = ddis_phase_function->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
 
                     dr::masked(phase_pdf, perform_ddis) =
-                        ((1.f - m_ddis_threshold) * natural_pdf + m_ddis_threshold * ddis_pdf);
+                        ((1.f - ddis_threshold) * natural_pdf + ddis_threshold * ddis_pdf);
                     dr::masked(phase_weight, perform_ddis) = natural_val / phase_pdf;
                 }
 
@@ -482,6 +482,7 @@ public:
                 EmitterPtr emitter = si.emitter(scene);
                 Mask active_e = active_surface && (emitter != nullptr) &&
                                 !((depth == 0u) && m_hide_emitters);
+
                 if (dr::any_or<true>(active_e)) {
                     Float emitter_pdf = 1.0f;
                     if (dr::any_or<true>(active_e && !count_direct)) {
@@ -502,9 +503,23 @@ public:
                 BSDFPtr bsdf  = si.bsdf(ray);
                 Mask active_e = active_surface && has_flag(bsdf->flags(), BSDFFlags::Smooth) && (depth + 1 < (uint32_t) m_max_depth);
 
+                // Initialize variables required for a DDIS
+                Mask perform_ddis = (medium != nullptr) && (ddis_threshold > 0.f) && active_e;
+                MediumInteraction3f ddis_mei = dr::zeros<MediumInteraction3f>();
+                ddis_mei.p = si.p;
+                ddis_mei.time = si.time;
+                ddis_mei.wavelengths = ddis_mei.wavelengths;
+                ddis_mei.medium = medium;
+                PhaseFunctionContext phase_ctx(sampler);
+
                 if (likely(dr::any_or<true>(active_e))) {
-                    // auto [emitted, ds] = sample_emitter(si, scene, sampler, medium, channel, active_e);
                     auto [emitted, ds] = sample_emitter(si, scene, sampler, medium, channel, active_e);
+
+                    if (dr::any_or<true>(perform_ddis)) {
+                        // Set ddis incoming direction towards emitter
+                        dr::masked(ddis_mei.wi, perform_ddis) = -ds.d;
+                        dr::masked(ddis_mei.sh_frame, perform_ddis) = Frame3f(-ds.d);
+                    }
 
                     // Query the BSDF for that emitter-sampled direction
                     Vector3f wo       = si.to_local(ds.d);
@@ -520,6 +535,53 @@ public:
                 // ----------------------- BSDF sampling ----------------------
                 auto [bs, bsdf_val] = bsdf->sample(ctx, si, sampler->next_1d(active_surface),
                                                    sampler->next_2d(active_surface), active_surface);
+
+                if (dr::any_or<true>(perform_ddis)) {
+
+                    auto ddis_phase_function = medium->ddis_phase_function();
+                    Spectrum natural_val = bsdf_val * bs.pdf;
+                    Float natural_pdf = bs.pdf;
+
+                    // DDIS is active if the emitter is in the same lobe as the ray,
+                    // and that the BSDF is neither Null or Delta.
+                    Float eps = sampler->next_1d(perform_ddis);
+                    Mask active_ddis = (eps < ddis_threshold) && perform_ddis;
+                    active_ddis &= dr::dot(-ray.d, -ddis_mei.wi) > 0.f;
+                    active_ddis &= !has_flag(bs.sampled_type, BSDFFlags::Null)
+                                && !has_flag(bs.sampled_type, BSDFFlags::Delta);
+
+                    // Sample from the ddis phase function
+                    if (dr::any_or<true>(active_ddis)) {
+                        auto [wo, phase_weight, phase_pdf] =
+                            ddis_phase_function->sample(phase_ctx, ddis_mei,
+                                sampler->next_1d(active_ddis),
+                                sampler->next_2d(active_ddis),
+                                active_ddis);
+
+                        dr::masked(bs.wo, active_ddis)  = si.to_local(wo);
+                        dr::masked(bs.eta, active_ddis) = 1.f;
+
+                        BSDFContext ddis_ctx;
+                        ddis_ctx.type_mask = +BSDFFlags::Reflection;
+
+                        // Update the bsdf value with the evalutation from the new outgoing direction
+                        auto [new_natural_val, new_natural_pdf] =
+                            bsdf->eval_pdf(ddis_ctx, si , bs.wo, active_ddis);
+                        dr::masked(natural_val, active_ddis) = new_natural_val;
+                        dr::masked(natural_pdf, active_ddis) = new_natural_pdf;
+                    }
+
+                    Float ddis_pdf;
+                    std::tie(std::ignore, ddis_pdf) =
+                        ddis_phase_function->eval_pdf(phase_ctx, ddis_mei,
+                                                      si.to_world(bs.wo),
+                                                      perform_ddis);
+
+                    dr::masked(bs.pdf, perform_ddis) =
+                        ((1.f - ddis_threshold) * natural_pdf + ddis_threshold * ddis_pdf);
+                    dr::masked(bsdf_val, perform_ddis) = natural_val / bs.pdf;
+                }
+
                 bsdf_val = si.to_world_mueller(bsdf_val, -bs.wo, si.wi);
 
                 dr::masked(throughput, active_surface) *= bsdf_val;
@@ -794,7 +856,8 @@ public:
     MI_DECLARE_CLASS(EOVolumetricPathIntegrator)
 private:
     ScalarFloat m_rr_factor;
-    ScalarFloat m_ddis_threshold;
+
+    bool m_enable_ddis;
 };
 
 MI_EXPORT_PLUGIN(EOVolumetricPathIntegrator)

--- a/src/eradiate_plugins/media/CMakeLists.txt
+++ b/src/eradiate_plugins/media/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(MI_PLUGIN_PREFIX "media")
 
 add_plugin(piecewise piecewise.cpp)
+add_plugin(eoheterogeneous eoheterogeneous.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -190,6 +190,8 @@ public:
                 PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
         }
 
+        m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
+
         if (m_ddis_threshold > 0.f) {
             // Create the DDIS phase function as a tabulated function of the
             // max function of the underlying phase function.

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -205,8 +205,9 @@ public:
 
             auto pmgr = PluginManager::instance();
             Properties props_ddis("tabphase_irregular");
-            props_ddis.set_any("nodes", nodes);
-            props_ddis.set_any("values", values);
+            size_t shape = nodes.size();
+            props_ddis.set_any("nodes", TensorXf(std::move(nodes), 1, &shape));
+            props_ddis.set_any("values", TensorXf(std::move(values), 1, &shape));
             m_ddis_phase_function =
                 static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
         }

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -1,0 +1,319 @@
+#include <mitsuba/core/frame.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/interaction.h>
+#include <mitsuba/render/medium.h>
+#include <mitsuba/render/phase.h>
+#include <mitsuba/render/sampler.h>
+#include <mitsuba/render/scene.h>
+#include <mitsuba/render/volume.h>
+#include <mitsuba/core/plugin.h>
+#include <mitsuba/render/eradiate/extremum.h>
+#include <sstream>
+#include <iomanip>
+
+NAMESPACE_BEGIN(mitsuba)
+
+
+/**!
+
+.. _medium-eoheterogeneous:
+
+EOHeterogeneous medium (:monosp:`eoheterogeneous`)
+-----------------------------------------------
+
+.. pluginparameters::
+
+ * - albedo
+   - |float|, |spectrum| or |volume|
+   - Single-scattering albedo of the medium (Default: 0.75).
+   - |exposed|, |differentiable|
+
+ * - sigma_t
+   - |float|, |spectrum| or |volume|
+   - Extinction coefficient in inverse scene units (Default: 1).
+   - |exposed|, |differentiable|
+
+ * - scale
+   - |float|
+   - Optional scale factor that will be applied to the extinction parameter.
+     It is provided for convenience when accommodating data based on different
+     units, or to simply tweak the density of the medium. (Default: 1)
+   - |exposed|
+
+ * - sample_emitters
+   - |bool|
+   - Flag to specify whether shadow rays should be cast from inside the volume (Default: |true|)
+     If the medium is enclosed in a :ref:`dielectric <bsdf-dielectric>` boundary,
+     shadow rays are ineffective and turning them off will significantly reduce
+     render time. This can reduce render time up to 50% when rendering objects
+     with subsurface scattering.
+
+ * - (Nested plugin)
+   - |phase|
+   - A nested phase function that describes the directional scattering properties of
+     the medium. When none is specified, the renderer will automatically use an instance of
+     isotropic.
+   - |exposed|, |differentiable|
+
+  * - ddis_threshold
+    - |float|
+   - Specifies the probability to importance sample the phase using the emitter as
+     incident direction. Set to a negative value to disable. (Default: 0.1)
+
+This plugin provides a flexible heterogeneous medium implementation, which acquires its data
+from nested volume instances. These can be constant, use a procedural function, or fetch data from
+disk, e.g. using a 3D grid.
+
+The medium is parametrized by the single scattering albedo and the extinction coefficient
+:math:`\sigma_t`. The extinction coefficient should be provided in inverse scene units.
+For instance, when a world-space distance of 1 unit corresponds to a meter, the
+extinction coefficient should have units of inverse meters. For convenience,
+the scale parameter can be used to correct the units. For instance, when the scene is in
+meters and the coefficients are in inverse millimeters, set scale to 1000.
+
+Both the albedo and the extinction coefficient can either be constant or textured,
+and both parameters are allowed to be spectrally varying.
+
+.. tabs::
+    .. code-tab:: xml
+        :name: lst-heterogeneous
+
+        <!-- Declare a heterogeneous participating medium named 'smoke' -->
+        <medium type="heterogeneous" id="smoke">
+            <!-- Acquire extinction values from an external data file -->
+            <volume name="sigma_t" type="gridvolume">
+                <string name="filename" value="frame_0150.vol"/>
+            </volume>
+
+            <!-- The albedo is constant and set to 0.9 -->
+            <float name="albedo" value="0.9"/>
+
+            <!-- Use an isotropic phase function -->
+            <phase type="isotropic"/>
+
+            <!-- Scale the density values as desired -->
+            <float name="scale" value="200"/>
+        </medium>
+
+        <!-- Attach the index-matched medium to a shape in the scene -->
+        <shape type="obj">
+            <!-- Load an OBJ file, which contains a mesh version
+                 of the axis-aligned box of the volume data file -->
+            <string name="filename" value="bounds.obj"/>
+
+            <!-- Reference the medium by ID -->
+            <ref name="interior" id="smoke"/>
+            <!-- If desired, this shape could also declare
+                a BSDF to create an index-mismatched
+                transition, e.g.
+                <bsdf type="dielectric"/>
+            -->
+        </shape>
+
+    .. code-tab:: python
+
+        # Declare a heterogeneous participating medium named 'smoke'
+        'smoke': {
+            'type': 'heterogeneous',
+
+            # Acquire extinction values from an external data file
+            'sigma_t': {
+                'type': 'gridvolume',
+                'filename': 'frame_0150.vol'
+            },
+
+            # The albedo is constant and set to 0.9
+            'albedo': 0.9,
+
+            # Use an isotropic phase function
+            'phase': {
+                'type': 'isotropic'
+            },
+
+            # Scale the density values as desired
+            'scale': 200
+        },
+
+        # Attach the index-matched medium to a shape in the scene
+        'shape': {
+            'type': 'obj',
+            # Load an OBJ file, which contains a mesh version
+            # of the axis-aligned box of the volume data file
+            'filename': 'bounds.obj',
+
+            # Reference the medium by ID
+            'interior': 'smoke',
+            # If desired, this shape could also declare
+            # a BSDF to create an index-mismatched
+            # transition, e.g.
+            # 'bsdf': {
+            #     'type': 'isotropic'
+            # },
+        }
+*/
+template <typename Float, typename Spectrum>
+class EOHeterogeneousMedium final : public Medium<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
+                    m_phase_function, m_extremum_structure,
+                    m_ddis_phase_function, m_ddis_threshold)
+    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure,
+                    ExtremumStructurePtr, PhaseFunction)
+
+    EOHeterogeneousMedium(const Properties &props) : Base(props) {
+        m_is_homogeneous = false;
+        m_albedo = props.get_volume<Volume>("albedo", 0.75f);
+        m_sigmat = props.get_volume<Volume>("sigma_t", 1.0f);
+
+        m_scale = props.get<ScalarFloat>("scale", 1.0f);
+        m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
+
+        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
+
+        for (auto &prop : props.objects()) {
+            if (auto *extremum = prop.try_get<ExtremumStructure>()) {
+                if (m_extremum_structure)
+                    Throw("Only a single extremum structure can be specified per medium");
+                m_extremum_structure = extremum;
+            }
+        }
+
+        if (!m_extremum_structure) {
+            // Create a default global extremum structure.
+            Properties props_extr("extremum_global");
+            props_extr.set("volume", (Object *) m_sigmat.get());
+            props_extr.set("scale", m_scale);
+            m_extremum_structure =
+                PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+        }
+
+        if (m_ddis_threshold > 0.f) {
+            // Create the DDIS phase function as a tabulated function of the
+            // max function of the underlying phase function.
+            std::vector<ScalarFloat> nodes, values;
+            m_phase_function->get_nodes(nodes);
+            m_phase_function->eval_max(nodes, values);
+
+            std::stringstream ss_nodes, ss_values;
+            ss_nodes << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
+            ss_values << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
+            for(size_t i = 0; i < nodes.size(); ++i) {
+                if(i != 0) {
+                    ss_nodes << ",";
+                    ss_values << ",";
+                }
+
+                ss_nodes << nodes[i];
+                ss_values << values[i];
+            }
+
+            auto pmgr = PluginManager::instance();
+            Properties props_ddis("tabphase_irregular");
+            props_ddis.set("nodes", ss_nodes.str());
+            props_ddis.set("values", ss_values.str());
+            m_ddis_phase_function = static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+        }
+    }
+
+    void traverse(TraversalCallback *cb) override {
+        cb->put("scale",   m_scale,  ParamFlags::NonDifferentiable);
+        cb->put("albedo",  m_albedo, ParamFlags::Differentiable);
+        cb->put("sigma_t", m_sigmat, ParamFlags::Differentiable);
+        if (m_ddis_phase_function != nullptr)
+            cb->put("ddis_phase_function", m_ddis_phase_function, ParamFlags::Differentiable);
+        Base::traverse(cb);
+    }
+
+    void update_ddis_phase_function() override {
+        // DDIS rebuild is driven exclusively by Scene::parameters_changed()
+        // via update_ddis_phase_function(), which ensures all media sharing a
+        // phase function via ref are updated before dirty flags are cleared.
+        if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
+            return;
+
+        std::vector<ScalarFloat> nodes, values;
+        m_phase_function->get_nodes(nodes);
+        m_phase_function->eval_max(nodes, values);
+
+        struct ValuesCallback : TraversalCallback {
+            DynamicBuffer<Float> *target = nullptr;
+            void put_value(std::string_view name, void *ptr, uint32_t,
+                           const std::type_info &) override {
+                if (name == "values")
+                    target = static_cast<DynamicBuffer<Float> *>(ptr);
+            }
+            void put_object(std::string_view, Object *, uint32_t) override {}
+        } cb;
+
+        m_ddis_phase_function->traverse(&cb);
+        if (cb.target) {
+            *cb.target = dr::load<DynamicBuffer<Float>>(values.data(), values.size());
+            m_ddis_phase_function->parameters_changed({});
+        }
+    }
+
+    void parameters_changed(const std::vector<std::string> &/*keys*/) override {
+        m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
+        m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
+    }
+
+    UnpolarizedSpectrum
+    get_majorant(const MediumInteraction3f & /* mi */,
+                 Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+        return m_max_density;
+    }
+
+    UnpolarizedSpectrum
+    get_minorant(const MediumInteraction3f & /* mi */,
+                 Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+        return m_min_density;
+    }
+
+    std::tuple<UnpolarizedSpectrum, UnpolarizedSpectrum, UnpolarizedSpectrum>
+    get_scattering_coefficients(const MediumInteraction3f &mi,
+                                Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::MediumEvaluate, active);
+
+        auto sigmat = m_scale * m_sigmat->eval(mi, active);
+        if (has_flag(m_phase_function->flags(), PhaseFunctionFlags::Microflake))
+            sigmat *= m_phase_function->projected_area(mi, active);
+
+        auto sigmas = sigmat * m_albedo->eval(mi, active);
+        auto sigman = m_max_density - sigmat;
+        return { sigmas, sigman, sigmat };
+    }
+
+    std::tuple<Mask, Float, Float>
+    intersect_aabb(const Ray3f &ray) const override {
+        return m_sigmat->bbox().ray_intersect(ray);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "HeterogeneousMedium[" << std::endl
+            << "  albedo  = " << string::indent(m_albedo) <<  "," << std::endl
+            << "  sigma_t = " << string::indent(m_sigmat) << "," << std::endl
+            << "  scale   = " << string::indent(m_scale) << "," << std::endl
+            << "  ddis_phase_function   = " << string::indent(m_ddis_phase_function) << "," << std::endl
+            << "  extremum = "<< string::indent(m_extremum_structure) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS(EOHeterogeneousMedium)
+private:
+    ref<Volume> m_sigmat, m_albedo;
+    ScalarFloat m_scale;
+    Float m_max_density;
+    Float m_min_density;
+
+    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)
+};
+
+MI_EXPORT_PLUGIN(EOHeterogeneousMedium)
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -10,8 +10,6 @@
 #include <mitsuba/render/volume.h>
 #include <mitsuba/core/plugin.h>
 #include <mitsuba/render/eradiate/extremum.h>
-#include <sstream>
-#include <iomanip>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -166,6 +164,7 @@ public:
                     m_ddis_phase_function, m_ddis_threshold)
     MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure,
                     ExtremumStructurePtr, PhaseFunction)
+    using FloatStorage = DynamicBuffer<Float>;
 
     EOHeterogeneousMedium(const Properties &props) : Base(props) {
         m_is_homogeneous = false;
@@ -200,28 +199,16 @@ public:
         if (m_ddis_threshold > 0.f) {
             // Create the DDIS phase function as a tabulated function of the
             // max function of the underlying phase function.
-            std::vector<ScalarFloat> nodes, values;
-            m_phase_function->get_nodes(nodes);
+            FloatStorage nodes  = m_phase_function->get_nodes();
+            FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
             m_phase_function->eval_max(nodes, values);
-
-            std::stringstream ss_nodes, ss_values;
-            ss_nodes << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
-            ss_values << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
-            for(size_t i = 0; i < nodes.size(); ++i) {
-                if(i != 0) {
-                    ss_nodes << ",";
-                    ss_values << ",";
-                }
-
-                ss_nodes << nodes[i];
-                ss_values << values[i];
-            }
 
             auto pmgr = PluginManager::instance();
             Properties props_ddis("tabphase_irregular");
-            props_ddis.set("nodes", ss_nodes.str());
-            props_ddis.set("values", ss_values.str());
-            m_ddis_phase_function = static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+            props_ddis.set_any("nodes", nodes);
+            props_ddis.set_any("values", values);
+            m_ddis_phase_function =
+                static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
         }
 
         // Optional user-provided bbox override
@@ -248,25 +235,32 @@ public:
         if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
             return;
 
-        std::vector<ScalarFloat> nodes, values;
-        m_phase_function->get_nodes(nodes);
+        FloatStorage nodes  = m_phase_function->get_nodes();
+        FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
         m_phase_function->eval_max(nodes, values);
 
         struct ValuesCallback : TraversalCallback {
-            DynamicBuffer<Float> *target = nullptr;
+            FloatStorage *target_nodes = nullptr;
+            FloatStorage *target_values = nullptr;
             void put_value(std::string_view name, void *ptr, uint32_t,
                            const std::type_info &) override {
+                if (name == "nodes")
+                    target_nodes = static_cast<FloatStorage *>(ptr);
                 if (name == "values")
-                    target = static_cast<DynamicBuffer<Float> *>(ptr);
+                    target_values = static_cast<FloatStorage *>(ptr);
             }
             void put_object(std::string_view, Object *, uint32_t) override {}
         } cb;
 
         m_ddis_phase_function->traverse(&cb);
-        if (cb.target) {
-            *cb.target = dr::load<DynamicBuffer<Float>>(values.data(), values.size());
+        if (cb.target_values)
+            *cb.target_values = values;
+
+        if (cb.target_nodes)
+            *cb.target_nodes = nodes;
+
+        if (cb.target_values || cb.target_nodes)
             m_ddis_phase_function->parameters_changed({});
-        }
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/) override {

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -18,8 +18,8 @@ NAMESPACE_BEGIN(mitsuba)
 
 .. _medium-eoheterogeneous:
 
-EOHeterogeneous medium (:monosp:`eoheterogeneous`)
------------------------------------------------
+Heterogeneous medium (Earth Observation) (:monosp:`eoheterogeneous`)
+--------------------------------------------------------------------
 
 .. pluginparameters::
 
@@ -58,16 +58,20 @@ EOHeterogeneous medium (:monosp:`eoheterogeneous`)
  * - ddis_threshold
    - |float|
    - Specifies the probability to importance sample the phase using the emitter as
-      incident direction. Set to a negative value to disable. (Default: 0.1)
+     incident direction. Set to a negative value to disable. (Default: 0.1)
 
  * - aabb_min, aabb_max
    - |point3f|
    - Optional override to the medium bounding box. Uses the bounding box of the
-     sigma_t volume by default.
+     `sigma_t` volume by default.
 
 This plugin provides a flexible heterogeneous medium implementation, which acquires its data
 from nested volume instances. These can be constant, use a procedural function, or fetch data from
 disk, e.g. using a 3D grid.
+
+This plugin is identical to the `heterogeneous` plugin but accepts additional parameters to set the
+medium's bounding box. It is possbile to set volumes that span a portion of the medium's bbox,
+and thus exploit wrapping mechanism, e.g. periodic boundaries, outside this portion.
 
 The medium is parametrized by the single scattering albedo and the extinction coefficient
 :math:`\sigma_t`. The extinction coefficient should be provided in inverse scene units.
@@ -78,90 +82,15 @@ meters and the coefficients are in inverse millimeters, set scale to 1000.
 
 Both the albedo and the extinction coefficient can either be constant or textured,
 and both parameters are allowed to be spectrally varying.
-
-.. tabs::
-    .. code-tab:: xml
-        :name: lst-heterogeneous
-
-        <!-- Declare a heterogeneous participating medium named 'smoke' -->
-        <medium type="heterogeneous" id="smoke">
-            <!-- Acquire extinction values from an external data file -->
-            <volume name="sigma_t" type="gridvolume">
-                <string name="filename" value="frame_0150.vol"/>
-            </volume>
-
-            <!-- The albedo is constant and set to 0.9 -->
-            <float name="albedo" value="0.9"/>
-
-            <!-- Use an isotropic phase function -->
-            <phase type="isotropic"/>
-
-            <!-- Scale the density values as desired -->
-            <float name="scale" value="200"/>
-        </medium>
-
-        <!-- Attach the index-matched medium to a shape in the scene -->
-        <shape type="obj">
-            <!-- Load an OBJ file, which contains a mesh version
-                 of the axis-aligned box of the volume data file -->
-            <string name="filename" value="bounds.obj"/>
-
-            <!-- Reference the medium by ID -->
-            <ref name="interior" id="smoke"/>
-            <!-- If desired, this shape could also declare
-                a BSDF to create an index-mismatched
-                transition, e.g.
-                <bsdf type="dielectric"/>
-            -->
-        </shape>
-
-    .. code-tab:: python
-
-        # Declare a heterogeneous participating medium named 'smoke'
-        'smoke': {
-            'type': 'heterogeneous',
-
-            # Acquire extinction values from an external data file
-            'sigma_t': {
-                'type': 'gridvolume',
-                'filename': 'frame_0150.vol'
-            },
-
-            # The albedo is constant and set to 0.9
-            'albedo': 0.9,
-
-            # Use an isotropic phase function
-            'phase': {
-                'type': 'isotropic'
-            },
-
-            # Scale the density values as desired
-            'scale': 200
-        },
-
-        # Attach the index-matched medium to a shape in the scene
-        'shape': {
-            'type': 'obj',
-            # Load an OBJ file, which contains a mesh version
-            # of the axis-aligned box of the volume data file
-            'filename': 'bounds.obj',
-
-            # Reference the medium by ID
-            'interior': 'smoke',
-            # If desired, this shape could also declare
-            # a BSDF to create an index-mismatched
-            # transition, e.g.
-            # 'bsdf': {
-            #     'type': 'isotropic'
-            # },
-        }
 */
 template <typename Float, typename Spectrum>
 class EOHeterogeneousMedium final : public Medium<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
                     m_phase_function, m_extremum_structure,
-                    m_ddis_phase_function, m_ddis_threshold)
+                    m_ddis_phase_function, m_ddis_threshold,
+                    create_ddis_phase_function
+                )
     MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure,
                     ExtremumStructurePtr, PhaseFunction)
     using FloatStorage = DynamicBuffer<Float>;
@@ -197,19 +126,7 @@ public:
         m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
 
         if (m_ddis_threshold > 0.f) {
-            // Create the DDIS phase function as a tabulated function of the
-            // max function of the underlying phase function.
-            FloatStorage nodes  = m_phase_function->get_nodes();
-            FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
-            m_phase_function->eval_max(nodes, values);
-
-            auto pmgr = PluginManager::instance();
-            Properties props_ddis("tabphase_irregular");
-            size_t shape = nodes.size();
-            props_ddis.set_any("nodes", TensorXf(std::move(nodes), 1, &shape));
-            props_ddis.set_any("values", TensorXf(std::move(values), 1, &shape));
-            m_ddis_phase_function =
-                static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+            m_ddis_phase_function = static_cast<PhaseFunction*>(create_ddis_phase_function());
         }
 
         // Optional user-provided bbox override
@@ -227,41 +144,6 @@ public:
         if (m_ddis_phase_function != nullptr)
             cb->put("ddis_phase_function", m_ddis_phase_function, ParamFlags::Differentiable);
         Base::traverse(cb);
-    }
-
-    void update_ddis_phase_function() override {
-        // DDIS rebuild is driven exclusively by Scene::parameters_changed()
-        // via update_ddis_phase_function(), which ensures all media sharing a
-        // phase function via ref are updated before dirty flags are cleared.
-        if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
-            return;
-
-        FloatStorage nodes  = m_phase_function->get_nodes();
-        FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
-        m_phase_function->eval_max(nodes, values);
-
-        struct ValuesCallback : TraversalCallback {
-            FloatStorage *target_nodes = nullptr;
-            FloatStorage *target_values = nullptr;
-            void put_value(std::string_view name, void *ptr, uint32_t,
-                           const std::type_info &) override {
-                if (name == "nodes")
-                    target_nodes = static_cast<FloatStorage *>(ptr);
-                if (name == "values")
-                    target_values = static_cast<FloatStorage *>(ptr);
-            }
-            void put_object(std::string_view, Object *, uint32_t) override {}
-        } cb;
-
-        m_ddis_phase_function->traverse(&cb);
-        if (cb.target_values)
-            *cb.target_values = values;
-
-        if (cb.target_nodes)
-            *cb.target_nodes = nodes;
-
-        if (cb.target_values || cb.target_nodes)
-            m_ddis_phase_function->parameters_changed({});
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/) override {
@@ -307,7 +189,7 @@ public:
 
     std::string to_string() const override {
         std::ostringstream oss;
-        oss << "HeterogeneousMedium[" << std::endl
+        oss << "EOHeterogeneousMedium[" << std::endl
             << "  albedo  = " << string::indent(m_albedo) <<  "," << std::endl
             << "  sigma_t = " << string::indent(m_sigmat) << "," << std::endl
             << "  scale   = " << string::indent(m_scale) << "," << std::endl
@@ -325,7 +207,7 @@ private:
     Float m_min_density;
     ScalarBoundingBox3f m_aabb;
 
-    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density, m_aabb)
+    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_scale, m_max_density, m_aabb)
 };
 
 MI_EXPORT_PLUGIN(EOHeterogeneousMedium)

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -57,10 +57,10 @@ EOHeterogeneous medium (:monosp:`eoheterogeneous`)
      isotropic.
    - |exposed|, |differentiable|
 
-  * - ddis_threshold
-    - |float|
+ * - ddis_threshold
+   - |float|
    - Specifies the probability to importance sample the phase using the emitter as
-     incident direction. Set to a negative value to disable. (Default: 0.1)
+      incident direction. Set to a negative value to disable. (Default: 0.1)
 
 This plugin provides a flexible heterogeneous medium implementation, which acquires its data
 from nested volume instances. These can be constant, use a procedural function, or fetch data from

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -62,6 +62,11 @@ EOHeterogeneous medium (:monosp:`eoheterogeneous`)
    - Specifies the probability to importance sample the phase using the emitter as
       incident direction. Set to a negative value to disable. (Default: 0.1)
 
+ * - aabb_min, aabb_max
+   - |point3f|
+   - Optional override to the medium bounding box. Uses the bounding box of the
+     sigma_t volume by default.
+
 This plugin provides a flexible heterogeneous medium implementation, which acquires its data
 from nested volume instances. These can be constant, use a procedural function, or fetch data from
 disk, e.g. using a 3D grid.
@@ -218,6 +223,13 @@ public:
             props_ddis.set("values", ss_values.str());
             m_ddis_phase_function = static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
         }
+
+        // Optional user-provided bbox override
+        if (props.has_property("aabb_min") && props.has_property("aabb_max")) {
+            ScalarPoint3f aabb_min = props.get<ScalarPoint3f>("aabb_min");
+            ScalarPoint3f aabb_max = props.get<ScalarPoint3f>("aabb_max");
+            m_aabb = ScalarBoundingBox3f(aabb_min, aabb_max);
+        }
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -292,6 +304,9 @@ public:
 
     std::tuple<Mask, Float, Float>
     intersect_aabb(const Ray3f &ray) const override {
+        if (m_aabb.valid()) {
+            return m_aabb.ray_intersect(ray);
+        }
         return m_sigmat->bbox().ray_intersect(ray);
     }
 
@@ -313,8 +328,9 @@ private:
     ScalarFloat m_scale;
     Float m_max_density;
     Float m_min_density;
+    ScalarBoundingBox3f m_aabb;
 
-    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density)
+    MI_TRAVERSE_CB(Base, m_sigmat, m_albedo, m_max_density, m_aabb)
 };
 
 MI_EXPORT_PLUGIN(EOHeterogeneousMedium)

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -203,8 +203,9 @@ public:
 
             auto pmgr = PluginManager::instance();
             Properties props_ddis("tabphase_irregular");
-            props_ddis.set_any("nodes", nodes);
-            props_ddis.set_any("values", values);
+            size_t shape = nodes.size();
+            props_ddis.set_any("nodes", TensorXf(std::move(nodes), 1, &shape));
+            props_ddis.set_any("values", TensorXf(std::move(values), 1, &shape));
             m_ddis_phase_function =
                 static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
         }

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -11,7 +11,6 @@
 #include <mitsuba/render/volume.h>
 #include <mitsuba/render/eradiate/extremum.h>
 #include <sstream>
-#include <iomanip>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -198,28 +197,16 @@ public:
         if (m_ddis_threshold > 0.f) {
             // Create the DDIS phase function as a tabulated function of the
             // max function of the underlying phase function.
-            std::vector<ScalarFloat> nodes, values;
-            m_phase_function->get_nodes(nodes);
+            FloatStorage nodes  = m_phase_function->get_nodes();
+            FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
             m_phase_function->eval_max(nodes, values);
-
-            std::stringstream ss_nodes, ss_values;
-            ss_nodes << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
-            ss_values << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
-            for(size_t i = 0; i < nodes.size(); ++i) {
-                if(i != 0) {
-                    ss_nodes << ",";
-                    ss_values << ",";
-                }
-
-                ss_nodes << nodes[i];
-                ss_values << values[i];
-            }
 
             auto pmgr = PluginManager::instance();
             Properties props_ddis("tabphase_irregular");
-            props_ddis.set("nodes", ss_nodes.str());
-            props_ddis.set("values", ss_values.str());
-            m_ddis_phase_function = static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+            props_ddis.set_any("nodes", nodes);
+            props_ddis.set_any("values", values);
+            m_ddis_phase_function =
+                static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
         }
     }
 
@@ -485,25 +472,32 @@ public:
         if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
             return;
 
-        std::vector<ScalarFloat> nodes, values;
-        m_phase_function->get_nodes(nodes);
+        FloatStorage nodes  = m_phase_function->get_nodes();
+        FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
         m_phase_function->eval_max(nodes, values);
 
         struct ValuesCallback : TraversalCallback {
-            DynamicBuffer<Float> *target = nullptr;
+            FloatStorage *target_nodes = nullptr;
+            FloatStorage *target_values = nullptr;
             void put_value(std::string_view name, void *ptr, uint32_t,
                            const std::type_info &) override {
+                if (name == "nodes")
+                    target_nodes = static_cast<FloatStorage *>(ptr);
                 if (name == "values")
-                    target = static_cast<DynamicBuffer<Float> *>(ptr);
+                    target_values = static_cast<FloatStorage *>(ptr);
             }
             void put_object(std::string_view, Object *, uint32_t) override {}
         } cb;
 
         m_ddis_phase_function->traverse(&cb);
-        if (cb.target) {
-            *cb.target = dr::load<DynamicBuffer<Float>>(values.data(), values.size());
+        if (cb.target_values)
+            *cb.target_values = values;
+
+        if (cb.target_nodes)
+            *cb.target_nodes = nodes;
+
+        if (cb.target_values || cb.target_nodes)
             m_ddis_phase_function->parameters_changed({});
-        }
     }
 
 

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -162,7 +162,8 @@ class PiecewiseMedium final : public Medium<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
                    m_phase_function, m_extremum_structure,
-                   m_ddis_phase_function, m_ddis_threshold)
+                   m_ddis_phase_function, m_ddis_threshold,
+                   create_ddis_phase_function)
     MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, PhaseFunction, ExtremumStructure)
 
     // Use 32 bit indices to keep track of indices to conserve memory
@@ -195,19 +196,7 @@ public:
         m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
 
         if (m_ddis_threshold > 0.f) {
-            // Create the DDIS phase function as a tabulated function of the
-            // max function of the underlying phase function.
-            FloatStorage nodes  = m_phase_function->get_nodes();
-            FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
-            m_phase_function->eval_max(nodes, values);
-
-            auto pmgr = PluginManager::instance();
-            Properties props_ddis("tabphase_irregular");
-            size_t shape = nodes.size();
-            props_ddis.set_any("nodes", TensorXf(std::move(nodes), 1, &shape));
-            props_ddis.set_any("values", TensorXf(std::move(values), 1, &shape));
-            m_ddis_phase_function =
-                static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+            m_ddis_phase_function = static_cast<PhaseFunction*>(create_ddis_phase_function());
         }
     }
 
@@ -465,42 +454,6 @@ public:
         Log(Info, "Medium Parameters changed!");
         precompute_optical_thickness();
     }
-
-    void update_ddis_phase_function() override {
-        // DDIS rebuild is driven exclusively by Scene::parameters_changed()
-        // via update_ddis_phase_function(), which ensures all media sharing a
-        // phase function via ref are updated before dirty flags are cleared.
-        if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
-            return;
-
-        FloatStorage nodes  = m_phase_function->get_nodes();
-        FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
-        m_phase_function->eval_max(nodes, values);
-
-        struct ValuesCallback : TraversalCallback {
-            FloatStorage *target_nodes = nullptr;
-            FloatStorage *target_values = nullptr;
-            void put_value(std::string_view name, void *ptr, uint32_t,
-                           const std::type_info &) override {
-                if (name == "nodes")
-                    target_nodes = static_cast<FloatStorage *>(ptr);
-                if (name == "values")
-                    target_values = static_cast<FloatStorage *>(ptr);
-            }
-            void put_object(std::string_view, Object *, uint32_t) override {}
-        } cb;
-
-        m_ddis_phase_function->traverse(&cb);
-        if (cb.target_values)
-            *cb.target_values = values;
-
-        if (cb.target_nodes)
-            *cb.target_nodes = nodes;
-
-        if (cb.target_values || cb.target_nodes)
-            m_ddis_phase_function->parameters_changed({});
-    }
-
 
     void precompute_optical_thickness() {
 

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -10,6 +10,8 @@
 #include <mitsuba/render/scene.h>
 #include <mitsuba/render/volume.h>
 #include <mitsuba/render/eradiate/extremum.h>
+#include <sstream>
+#include <iomanip>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -55,6 +57,11 @@ Piecewise medium (:monosp:`piecewise`)
      properties of the medium. When none is specified, the renderer will
      automatically use an instance of isotropic.
    - |exposed|, |differentiable|
+
+ * - ddis_threshold
+   - |float|
+   - Specifies the probability to importance sample the phase using the emitter as
+     incident direction. Set to a negative value to disable. (Default: 0.1)
 
 
 This plugin provides a 1D heterogeneous medium implementation (plane-parallel
@@ -155,8 +162,9 @@ template <typename Float, typename Spectrum>
 class PiecewiseMedium final : public Medium<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(Medium, m_is_homogeneous, m_has_spectral_extinction,
-                   m_phase_function, m_extremum_structure)
-    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, ExtremumStructure)
+                   m_phase_function, m_extremum_structure,
+                   m_ddis_phase_function, m_ddis_threshold)
+    MI_IMPORT_TYPES(Scene, Sampler, Texture, Volume, PhaseFunction, ExtremumStructure)
 
     // Use 32 bit indices to keep track of indices to conserve memory
     using ScalarIndex     = uint32_t;
@@ -184,6 +192,35 @@ public:
             PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
 
         precompute_optical_thickness();
+
+        m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
+
+        if (m_ddis_threshold > 0.f) {
+            // Create the DDIS phase function as a tabulated function of the
+            // max function of the underlying phase function.
+            std::vector<ScalarFloat> nodes, values;
+            m_phase_function->get_nodes(nodes);
+            m_phase_function->eval_max(nodes, values);
+
+            std::stringstream ss_nodes, ss_values;
+            ss_nodes << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
+            ss_values << std::setprecision(std::numeric_limits<ScalarFloat>::digits10);
+            for(size_t i = 0; i < nodes.size(); ++i) {
+                if(i != 0) {
+                    ss_nodes << ",";
+                    ss_values << ",";
+                }
+
+                ss_nodes << nodes[i];
+                ss_values << values[i];
+            }
+
+            auto pmgr = PluginManager::instance();
+            Properties props_ddis("tabphase_irregular");
+            props_ddis.set("nodes", ss_nodes.str());
+            props_ddis.set("values", ss_values.str());
+            m_ddis_phase_function = static_cast<PhaseFunction*>(pmgr->create_object<PhaseFunction>(props_ddis));
+        }
     }
 
     std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum>
@@ -429,6 +466,8 @@ public:
         cb->put("scale", m_scale, ParamFlags::NonDifferentiable);
         cb->put("albedo", m_albedo.get(), ParamFlags::Differentiable);
         cb->put("sigma_t", m_sigmat.get(), ParamFlags::Differentiable);
+        if (m_ddis_phase_function != nullptr)
+            cb->put("ddis_phase_function", m_ddis_phase_function, ParamFlags::Differentiable);
         Base::traverse(cb);
     }
 
@@ -438,6 +477,35 @@ public:
         Log(Info, "Medium Parameters changed!");
         precompute_optical_thickness();
     }
+
+    void update_ddis_phase_function() override {
+        // DDIS rebuild is driven exclusively by Scene::parameters_changed()
+        // via update_ddis_phase_function(), which ensures all media sharing a
+        // phase function via ref are updated before dirty flags are cleared.
+        if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
+            return;
+
+        std::vector<ScalarFloat> nodes, values;
+        m_phase_function->get_nodes(nodes);
+        m_phase_function->eval_max(nodes, values);
+
+        struct ValuesCallback : TraversalCallback {
+            DynamicBuffer<Float> *target = nullptr;
+            void put_value(std::string_view name, void *ptr, uint32_t,
+                           const std::type_info &) override {
+                if (name == "values")
+                    target = static_cast<DynamicBuffer<Float> *>(ptr);
+            }
+            void put_object(std::string_view, Object *, uint32_t) override {}
+        } cb;
+
+        m_ddis_phase_function->traverse(&cb);
+        if (cb.target) {
+            *cb.target = dr::load<DynamicBuffer<Float>>(values.data(), values.size());
+            m_ddis_phase_function->parameters_changed({});
+        }
+    }
+
 
     void precompute_optical_thickness() {
 

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -83,6 +83,9 @@ class MultiPhaseFunction final : public PhaseFunction<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
     MI_IMPORT_TYPES(PhaseFunctionContext, Volume)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    using typename Base::FloatStorage;
+// #ERADIATE_CHANGE_END
 
     MultiPhaseFunction(const Properties &props) : Base(props) {
         m_mis = props.get<bool>("use_mis", true);
@@ -266,20 +269,17 @@ public:
         return { val, pdf };
     }
 
-    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
-        std::vector<std::vector<ScalarFloat>> nested_nodes(m_nested_phases.size());
+    FloatStorage get_nodes() const override {
+        std::vector<FloatStorage> nested_nodes(m_nested_phases.size());
         for (size_t i = 0; i < m_nested_phases.size(); ++i)
-            m_nested_phases[i]->get_nodes(nested_nodes[i]);
-        auto result = merge_nodes<ScalarFloat>(nested_nodes);
-        nodes  = std::move(result);
+            nested_nodes[i] = m_nested_phases[i]->get_nodes();
+        return merge_nodes<FloatStorage>(nested_nodes);
     }
 
-    void eval_max(const std::vector<ScalarFloat> &nodes,
-                   std::vector<ScalarFloat> &values) const override {
+    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override {
         for (size_t i = 0; i < m_nested_phases.size(); ++i)
             m_nested_phases[i]->eval_max(nodes, values);
     }
-
 
     std::string to_string() const override {
         std::ostringstream oss;

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -269,16 +269,16 @@ public:
         return { val, pdf };
     }
 
-    FloatStorage get_nodes() const override {
+    FloatStorage get_envelope_nodes() const override {
         std::vector<FloatStorage> nested_nodes(m_nested_phases.size());
         for (size_t i = 0; i < m_nested_phases.size(); ++i)
-            nested_nodes[i] = m_nested_phases[i]->get_nodes();
-        return merge_nodes<FloatStorage>(nested_nodes);
+            nested_nodes[i] = m_nested_phases[i]->get_envelope_nodes();
+        return merge_envelope_nodes<FloatStorage>(nested_nodes);
     }
 
-    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override {
+    void accumulate_envelope(const FloatStorage &nodes, FloatStorage &values) const override {
         for (size_t i = 0; i < m_nested_phases.size(); ++i)
-            m_nested_phases[i]->eval_max(nodes, values);
+            m_nested_phases[i]->accumulate_envelope(nodes, values);
     }
 
     std::string to_string() const override {

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -3,6 +3,7 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/render/phase.h>
 #include <mitsuba/render/volume.h>
+#include <mitsuba/render/eradiate/phase_utils.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -24,10 +25,10 @@ Multi phase function (:monosp:`multiphase`)
  * - use_mis
    - |bool|
    - Enable Multiple Importance Sampling (MIS) for variance reduction. When enabled,
-     all phase functions are evaluated at each sampled direction to compute the 
-     mixture PDF and importance weight. This reduces variance when mixing very 
+     all phase functions are evaluated at each sampled direction to compute the
+     mixture PDF and importance weight. This reduces variance when mixing very
      different phase functions at the cost of additional computation. (Default: true)
-   - 
+   -
 
  * - (Nested plugin)
    - |phase|
@@ -51,7 +52,7 @@ multiple populations of scattering elements.
 
         <phase type="multiphase">
             <boolean name="use_mis" value="true"/>
-            
+
             <phase name="phase0" type="isotropic"/>
             <float name="weight0" value="1.0"/>
             <phase name="phase1" type="hg">
@@ -128,30 +129,30 @@ public:
 
         std::vector<Float> weight_values(m_nested_phases.size());
         Float weight_sum = 0.f;
-        
+
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
             weight_values[i] = eval_weight(mi, i, active);
             weight_sum += weight_values[i];
         }
-        
+
         Float inv_weight_sum = dr::rcp(weight_sum);
 
         if (unlikely(ctx.component != (uint32_t) -1)) {
             PhaseFunctionContext ctx2(ctx);
-            
+
             auto position = std::upper_bound(
                 m_nested_phases_index.begin(),
-                m_nested_phases_index.end(), 
+                m_nested_phases_index.end(),
                 ctx.component
             );
             size_t phase_index = std::distance(m_nested_phases_index.begin(), position) - 1;
-            
+
             ctx2.component = ctx.component - m_nested_phases_index[phase_index];
-            
+
             auto [wo, w, pdf] = m_nested_phases[phase_index]->sample(
                 ctx2, mi, sample1, sample2, active
             );
-            
+
             Float phase_weight = weight_values[phase_index] * inv_weight_sum;
             return { wo, w * phase_weight, pdf * phase_weight };
         }
@@ -159,16 +160,16 @@ public:
         Vector3f wo = dr::zeros<Vector3f>();
         Spectrum w = dr::zeros<Spectrum>();
         Float pdf = dr::zeros<Float>();
-        
+
         Float cdf_last = 0.f;
-        
+
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
             Float cdf_next = cdf_last + weight_values[i] * inv_weight_sum;
             Mask mask_i = active && sample1 >= cdf_last && sample1 < cdf_next;
-            
+
             if (dr::any_or<true>(mask_i)) {
                 Float sample1_adjusted = (sample1 - cdf_last) / (cdf_next - cdf_last);
-                
+
                 auto [wo_i, w_i, pdf_i] = m_nested_phases[i]->sample(
                     ctx, mi, sample1_adjusted, sample2, mask_i
                 );
@@ -179,30 +180,30 @@ public:
                 } else {
                     Spectrum phase_value_sum = w_i * pdf_i * weight_values[i];
                     Float pdf_mixture = pdf_i * weight_values[i];
-                    
+
                     for (size_t j = 0; j < m_nested_phases.size(); ++j) {
                         if (j == i) continue;
-                        
+
                         auto [val_j, pdf_j] = m_nested_phases[j]->eval_pdf(
                             ctx, mi, wo_i, mask_i
                         );
-                        
+
                         phase_value_sum += weight_values[j] * val_j;
                         pdf_mixture += weight_values[j] * pdf_j;
                     }
-                    
+
                     Spectrum w_mis = dr::select(
                         pdf_mixture > 1e-8f,
                         phase_value_sum / pdf_mixture,
                         Spectrum(0.f)
                     );
-                    
+
                     dr::masked(wo, mask_i) = wo_i;
                     dr::masked(w, mask_i) = w_mis;
                     dr::masked(pdf, mask_i) = pdf_mixture * inv_weight_sum;
                 }
             }
-            
+
             cdf_last = cdf_next;
         }
 
@@ -219,18 +220,18 @@ public:
                                         const MediumInteraction3f &mi,
                                         const Vector3f &wo,
                                         Mask active) const override {
-        
+
         MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
 
         std::vector<Float> weight_values;
         weight_values.reserve(m_nested_phases.size());
         Float weight_sum = 0.f;
-        
+
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
             weight_values.push_back(eval_weight(mi, i, active));
             weight_sum += weight_values.back();
         }
-        
+
         Float inv_weight_sum = dr::rcp(weight_sum);
 
         if (unlikely(ctx.component != (uint32_t) -1)) {
@@ -238,15 +239,15 @@ public:
 
             auto position = std::upper_bound(
                 m_nested_phases_index.begin(),
-                m_nested_phases_index.end(), 
+                m_nested_phases_index.end(),
                 ctx.component
             );
             size_t phase_index = std::distance(m_nested_phases_index.begin(), position) - 1;
-            
+
             ctx2.component = ctx.component - m_nested_phases_index[phase_index];
-            
+
             auto [val, pdf] = m_nested_phases[phase_index]->eval_pdf(ctx2, mi, wo, active);
-            
+
             Float phase_weight = weight_values[phase_index] * inv_weight_sum;
             return { val * phase_weight, pdf * phase_weight };
         }
@@ -256,14 +257,29 @@ public:
 
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
             auto [val_i, pdf_i] = m_nested_phases[i]->eval_pdf(ctx, mi, wo, active);
-            
+
             Float phase_weight = weight_values[i] * inv_weight_sum;
             val += val_i * phase_weight;
             pdf += pdf_i * phase_weight;
         }
-        
+
         return { val, pdf };
     }
+
+    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
+        std::vector<std::vector<ScalarFloat>> nested_nodes(m_nested_phases.size());
+        for (size_t i = 0; i < m_nested_phases.size(); ++i)
+            m_nested_phases[i]->get_nodes(nested_nodes[i]);
+        auto result = merge_nodes<ScalarFloat>(nested_nodes);
+        nodes  = std::move(result);
+    }
+
+    void eval_max(const std::vector<ScalarFloat> &nodes,
+                   std::vector<ScalarFloat> &values) const override {
+        for (size_t i = 0; i < m_nested_phases.size(); ++i)
+            m_nested_phases[i]->eval_max(nodes, values);
+    }
+
 
     std::string to_string() const override {
         std::ostringstream oss;

--- a/src/eradiate_plugins/phase/tabphase_irregular.cpp
+++ b/src/eradiate_plugins/phase/tabphase_irregular.cpp
@@ -3,6 +3,7 @@
 #include <mitsuba/core/warp.h>
 #include <mitsuba/render/phase.h>
 #include <mitsuba/render/eradiate/phase_utils.h>
+#include <drjit/tensor.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -48,22 +49,25 @@ public:
     using typename Base::FloatStorage;
 
     IrregularTabulatedPhaseFunction(const Properties &props) : Base(props) {
+        Log(Warn, "%f", int(props.type("nodes")));
+
         if (props.type("nodes") == Properties::Type::Any &&
             props.type("values") == Properties::Type::Any) {
-            const FloatStorage &nodes_buf  = props.get_any<FloatStorage>("nodes");
-            const FloatStorage &values_buf = props.get_any<FloatStorage>("values");
+            const TensorXf &nodes_buf  = props.get_any<TensorXf>("nodes");
+            const TensorXf &values_buf = props.get_any<TensorXf>("values");
 
             if (dr::width(nodes_buf) != dr::width(values_buf))
                 Throw("'nodes' and 'values' must have the same length");
 
             m_distr = IrregularContinuousDistribution<Float>(nodes_buf, values_buf);
 
-        } else if (props.type("values") == Properties::Type::Vector &&
-                   props.type("nodes") == Properties::Type::Vector) {
+        } else if (props.type("values") == Properties::Type::Color &&
+                   props.type("nodes") == Properties::Type::Color) {
 
+            // Handle Color type in llvm rg
             m_distr = IrregularContinuousDistribution<Float>(
-                props.get<ScalarVector3f>("nodes").data(),
-                props.get<ScalarVector3f>("values").data(),
+                props.get<ScalarColor3f>("nodes").data(),
+                props.get<ScalarColor3f>("values").data(),
                 3);
 
         } else if (props.type("values") == Properties::Type::String &&

--- a/src/eradiate_plugins/phase/tabphase_irregular.cpp
+++ b/src/eradiate_plugins/phase/tabphase_irregular.cpp
@@ -2,6 +2,7 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/warp.h>
 #include <mitsuba/render/phase.h>
+#include <mitsuba/render/eradiate/phase_utils.h>
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -103,8 +104,9 @@ public:
     }
 
     void
-    parameters_changed(const std::vector<std::string> & /*keys*/) override {
+    parameters_changed(const std::vector<std::string> & keys) override {
         m_distr.update();
+        Base::parameters_changed(keys);
     }
 
     std::tuple<Vector3f, Spectrum, Float>
@@ -155,6 +157,14 @@ public:
             << "  distr = " << string::indent(m_distr) << std::endl
             << "]";
         return oss.str();
+    }
+
+    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
+        const size_t n = m_distr.size();
+        nodes.resize(n);
+        for (size_t i = 0; i < n; ++i) {
+            nodes[i]  = dr::slice(m_distr.nodes(), i);
+        }
     }
 
     MI_DECLARE_CLASS(IrregularTabulatedPhaseFunction)

--- a/src/eradiate_plugins/phase/tabphase_irregular.cpp
+++ b/src/eradiate_plugins/phase/tabphase_irregular.cpp
@@ -16,16 +16,18 @@ Tabulated phase function (irregular angular grid) (:monosp:`tabphase_irregular`)
 .. pluginparameters::
 
  * - values
-   - |string|
-   - A comma-separated list of phase function values parameterized by the
-     cosine of the scattering angle. Must have the same length as ``nodes``.
+   - |string| or |tensor|
+   - Array of phase function values parameterized by the cosine of the
+     scattering angle. Must have the same length as ``nodes``. Accepts a
+     comma-separated list or 1D tensor.
    - |exposed|
 
  * - nodes
-   - |string|
-   - A comma-separated list of :math:`\cos \theta` specifying the grid on which
-     ``values`` are defined. Bounds must be [-1, 1] and values must be strictly
-     increasing. Must have the same length as ``values``.
+   - |string| or |tensor|
+   - Array of :math:`\cos \theta` specifying the grid on which ``values`` are
+     defined. Bounds must be [-1, 1] and values must be strictly increasing.
+     Must have the same length as ``values``. Accepts a comma-separated
+     list or 1D tensor.
    - |exposed|
 
 This plugin implements a generic phase function model for isotropic media
@@ -43,12 +45,33 @@ class IrregularTabulatedPhaseFunction final
 public:
     MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
     MI_IMPORT_TYPES(PhaseFunctionContext)
+    using typename Base::FloatStorage;
 
     IrregularTabulatedPhaseFunction(const Properties &props) : Base(props) {
-        std::vector<ScalarFloat> values;
-        std::vector<ScalarFloat> nodes;
+        if (props.type("nodes") == Properties::Type::Any &&
+            props.type("values") == Properties::Type::Any) {
+            const FloatStorage &nodes_buf  = props.get_any<FloatStorage>("nodes");
+            const FloatStorage &values_buf = props.get_any<FloatStorage>("values");
 
-        if (props.type("values") == Properties::Type::String) {
+            if (dr::width(nodes_buf) != dr::width(values_buf))
+                Throw("'nodes' and 'values' must have the same length");
+
+            m_distr = IrregularContinuousDistribution<Float>(nodes_buf, values_buf);
+
+        } else if (props.type("values") == Properties::Type::Vector &&
+                   props.type("nodes") == Properties::Type::Vector) {
+
+            m_distr = IrregularContinuousDistribution<Float>(
+                props.get<ScalarVector3f>("nodes").data(),
+                props.get<ScalarVector3f>("values").data(),
+                3);
+
+        } else if (props.type("values") == Properties::Type::String &&
+                   props.type("nodes") == Properties::Type::String) {
+
+            std::vector<ScalarFloat> values;
+            std::vector<ScalarFloat> nodes;
+
             std::vector<std::string> values_str =
                 string::tokenize(props.get<std::string>("values"), " ,");
             values.reserve(values_str.size());
@@ -60,11 +83,7 @@ public:
                     Throw("Could not parse floating point value '%s'", s);
                 }
             }
-        } else {
-            Throw("'values' must be a string");
-        }
 
-        if (props.type("nodes") == Properties::Type::String) {
             std::vector<std::string> nodes_str =
                 string::tokenize(props.get<std::string>("nodes"), " ,");
             nodes.reserve(nodes_str.size());
@@ -76,23 +95,22 @@ public:
                     Throw("Could not parse floating point value '%s'", s);
                 }
             }
-        } else {
-            Throw("'nodes' must be a string");
-        }
 
-        // Check that values and nodes have the same size
-        if (values.size() != nodes.size()) {
-            Throw("'nodes' and 'values' must have the same length");
-        }
+            // Check that values and nodes have the same size
+            if (values.size() != nodes.size()) {
+                Throw("'nodes' and 'values' must have the same length");
+            }
 
-        // Check that nodes cover the [-1, 1] segment
-        if (nodes[0] != -1.f || nodes[nodes.size() - 1] != 1.f) {
-            Throw("'nodes' bounds must be [-1, 1], got [%s, %s]", nodes[0],
-                  nodes[nodes.size() - 1]);
-        }
-
-        m_distr = IrregularContinuousDistribution<Float>(
+            m_distr = IrregularContinuousDistribution<Float>(
             nodes.data(), values.data(), values.size());
+        } else {
+            Throw("'values' and 'nodes' must either be of type ArrayXf or string");
+        }
+
+        // Check for node bounds.
+        if (dr::any(dr::min(m_distr.nodes()) != -1.f || dr::max(m_distr.nodes()) != 1.f))
+            Throw("'nodes' bounds must be [-1, 1], got [%s, %s]",
+                    dr::min(m_distr.nodes()), dr::max(m_distr.nodes()));
 
         m_flags = +PhaseFunctionFlags::Anisotropic;
         m_components.push_back(m_flags);
@@ -159,12 +177,8 @@ public:
         return oss.str();
     }
 
-    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
-        const size_t n = m_distr.size();
-        nodes.resize(n);
-        for (size_t i = 0; i < n; ++i) {
-            nodes[i]  = dr::slice(m_distr.nodes(), i);
-        }
+    FloatStorage get_nodes() const override {
+        return m_distr.nodes();
     }
 
     MI_DECLARE_CLASS(IrregularTabulatedPhaseFunction)

--- a/src/eradiate_plugins/phase/tabphase_irregular.cpp
+++ b/src/eradiate_plugins/phase/tabphase_irregular.cpp
@@ -49,7 +49,6 @@ public:
     using typename Base::FloatStorage;
 
     IrregularTabulatedPhaseFunction(const Properties &props) : Base(props) {
-        Log(Warn, "%f", int(props.type("nodes")));
 
         if (props.type("nodes") == Properties::Type::Any &&
             props.type("values") == Properties::Type::Any) {

--- a/src/eradiate_plugins/phase/tabphase_irregular.cpp
+++ b/src/eradiate_plugins/phase/tabphase_irregular.cpp
@@ -180,7 +180,7 @@ public:
         return oss.str();
     }
 
-    FloatStorage get_nodes() const override {
+    FloatStorage get_envelope_nodes() const override {
         return m_distr.nodes();
     }
 

--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -405,10 +405,11 @@ public:
     }
 
     void
-    parameters_changed(const std::vector<std::string> & /*keys*/) override {
+    parameters_changed(const std::vector<std::string> & keys) override {
         m_m11.update();
         m_mvec.nodes() = m_m11.nodes();
         m_mvec.update();
+        Base::parameters_changed(keys);
     }
 
     std::string to_string() const override {
@@ -417,6 +418,14 @@ public:
             << "  distr = " << string::indent(m_m11) << std::endl
             << "]";
         return oss.str();
+    }
+
+    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
+        const size_t n = m_m11.size();
+        nodes.resize(n);
+        for (size_t i = 0; i < n; ++i) {
+            nodes[i]  = dr::slice(m_m11.nodes(), i);
+        }
     }
 
     MI_DECLARE_CLASS(TabulatedPolarizedPhaseFunction)

--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -220,6 +220,7 @@ class TabulatedPolarizedPhaseFunction final
 public:
     MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
     MI_IMPORT_TYPES(PhaseFunctionContext)
+    using typename Base::FloatStorage;
 
     using VectorArray5 = std::array<std::vector<ScalarFloat>, 5>;
     using Vector5f = dr::Array<Float, 5>;
@@ -420,12 +421,8 @@ public:
         return oss.str();
     }
 
-    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
-        const size_t n = m_m11.size();
-        nodes.resize(n);
-        for (size_t i = 0; i < n; ++i) {
-            nodes[i]  = dr::slice(m_m11.nodes(), i);
-        }
+    FloatStorage get_nodes() const override {
+        return m_m11.nodes();
     }
 
     MI_DECLARE_CLASS(TabulatedPolarizedPhaseFunction)

--- a/src/eradiate_plugins/phase/tabphase_polarized.cpp
+++ b/src/eradiate_plugins/phase/tabphase_polarized.cpp
@@ -421,7 +421,7 @@ public:
         return oss.str();
     }
 
-    FloatStorage get_nodes() const override {
+    FloatStorage get_envelope_nodes() const override {
         return m_m11.nodes();
     }
 

--- a/src/eradiate_plugins/tests/phase/test_phase.py
+++ b/src/eradiate_plugins/tests/phase/test_phase.py
@@ -1,0 +1,154 @@
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def hg():
+    return mi.load_dict({"type": "hg", "g": 0.6})
+
+
+@pytest.fixture
+def tabphase_nodes():
+    return [-1.0, -0.3, 0.4, 1.0]
+
+
+@pytest.fixture
+def tabphase_irregular(tabphase_nodes):
+    values = [0.5, 0.8, 1.2, 1.5]
+    return mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": ",".join(map(str, values)),
+            "nodes": ",".join(map(str, tabphase_nodes)),
+        }
+    )
+
+
+def reference_eval_max(phase, nodes):
+    """Replicate the C++ ``PhaseFunction::eval_max`` evaluation for a single
+    (non-composite) phase function.
+
+    For each node ``mu`` (cos_theta in physics convention, +1 = forward
+    scattering), the envelope evaluates the phase value at the reconstructed
+    outgoing direction and accumulates the elementwise maximum into a
+    zero-initialised buffer. We mirror exactly the direction reconstruction
+    used in ``src/render/phase.cpp`` so the comparison is meaningful.
+    """
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.wi = mi.Vector3f(0, 0, 1)
+
+    nodes_np = np.array(nodes)
+    out = np.zeros(nodes_np.shape[0])
+    for i, mu in enumerate(nodes_np):
+        sin_theta = np.sqrt(max(0.0, 1.0 - mu * mu))
+        wo = mi.Vector3f(sin_theta, 0.0, -mu)
+        # value == pdf for the isotropic/hg/tabphase plugins exercised here
+        out[i] = phase.eval_pdf(ctx, mei, wo)[1]
+    return out
+
+
+def test_get_nodes_default(variant_scalar_rgb):
+    # A leaf phase function without irregular nodes falls back to the base
+    # implementation: 256 nodes spread uniformly over [-1, 1].
+    phase = mi.load_dict({"type": "isotropic"})
+    nodes = np.array(phase.get_nodes())
+
+    assert nodes.shape[0] == 256
+    # The grid is built in single precision; compare with an absolute tolerance.
+    assert np.allclose(nodes, np.linspace(-1, 1, 256), atol=1e-6)
+    # Strictly increasing, bounded by [-1, 1].
+    assert np.all(np.diff(nodes) > 0)
+
+
+def test_get_nodes_tabphase_irregular(
+    variant_scalar_rgb, tabphase_nodes, tabphase_irregular
+):
+    # tabphase_irregular overrides get_nodes() to expose its own grid.
+    assert np.allclose(np.array(tabphase_irregular.get_nodes()), tabphase_nodes)
+
+
+def test_get_nodes_blendphase_merged(
+    variant_scalar_rgb, tabphase_nodes, tabphase_irregular
+):
+    # A composite phase function merges (sorts + de-duplicates) the node grids
+    # of its children. We mix an irregular grid with the default uniform grid
+    # so the union contains nodes contributed by both children.
+
+    blend = mi.load_dict(
+        {
+            "type": "blendphase",
+            "weight": 0.5,
+            "phase_0": {"type": "isotropic"},
+            "phase_1": tabphase_irregular,
+        }
+    )
+
+    nodes = np.array(blend.get_nodes())
+    expected = np.unique(np.concatenate([np.linspace(-1, 1, 256), tabphase_nodes]))
+
+    # Single-precision grid: compare with an absolute tolerance.
+    assert np.allclose(nodes, expected, atol=1e-6)
+    # The shared endpoints (-1, 1) collapse: 256 uniform + 2 interior nodes.
+    assert nodes.shape[0] == 258
+    assert np.all(np.diff(nodes) > 0)
+
+
+def test_eval_max_single(variant_scalar_rgb, hg):
+    # The envelope of a single phase function is just the phase function
+    # evaluated at every node.
+    nodes = hg.get_nodes()
+    values = dr.zeros(type(nodes), dr.width(nodes))
+
+    hg.eval_max(nodes, values)
+    assert np.allclose(np.array(values), reference_eval_max(hg, nodes))
+
+
+def test_eval_max_blendphase(variant_scalar_rgb, hg):
+    # A composite envelope is the pointwise maximum over its (unweighted)
+    # children, regardless of the blend weight.
+    iso = mi.load_dict({"type": "isotropic"})
+    blend = mi.load_dict(
+        {"type": "blendphase", "weight": 0.3, "phase_0": iso, "phase_1": hg}
+    )
+
+    nodes = blend.get_nodes()
+    values = dr.zeros(type(nodes), dr.width(nodes))
+    blend.eval_max(nodes, values)
+
+    ref = np.maximum(
+        reference_eval_max(iso, nodes),
+        reference_eval_max(hg, nodes),
+    )
+    assert np.allclose(np.array(values), ref)
+
+
+def test_eval_max_multiphase(variant_scalar_rgb, hg, tabphase_irregular):
+    # Same envelope semantics for the N-component mixture.
+    iso = mi.load_dict({"type": "isotropic"})
+    multi = mi.load_dict(
+        {
+            "type": "multiphase",
+            "phase0": iso,
+            "weight0": 1.0,
+            "phase1": hg,
+            "weight1": 1.0,
+            "phase2": tabphase_irregular,
+            "weight2": 1.0,
+        }
+    )
+
+    nodes = multi.get_nodes()
+    values = dr.zeros(type(nodes), dr.width(nodes))
+    multi.eval_max(nodes, values)
+
+    ref = np.maximum.reduce(
+        [
+            reference_eval_max(iso, nodes),
+            reference_eval_max(hg, nodes),
+            reference_eval_max(tabphase_irregular, nodes),
+        ]
+    )
+    assert np.allclose(np.array(values), ref)

--- a/src/eradiate_plugins/tests/phase/test_phase.py
+++ b/src/eradiate_plugins/tests/phase/test_phase.py
@@ -26,14 +26,14 @@ def tabphase_irregular(tabphase_nodes):
     )
 
 
-def reference_eval_max(phase, nodes):
+def reference_accumulate_envelope(phase, nodes):
     """Replicate the C++ ``PhaseFunction::eval_max`` evaluation for a single
     (non-composite) phase function.
 
     For each node ``mu`` (cos_theta in physics convention, +1 = forward
     scattering), the envelope evaluates the phase value at the reconstructed
     outgoing direction and accumulates the elementwise maximum into a
-    zero-initialised buffer. We mirror exactly the direction reconstruction
+    zero-initialized buffer. We mirror exactly the direction reconstruction
     used in ``src/render/phase.cpp`` so the comparison is meaningful.
     """
     ctx = mi.PhaseFunctionContext(None)
@@ -45,7 +45,7 @@ def reference_eval_max(phase, nodes):
     for i, mu in enumerate(nodes_np):
         sin_theta = np.sqrt(max(0.0, 1.0 - mu * mu))
         wo = mi.Vector3f(sin_theta, 0.0, -mu)
-        # value == pdf for the isotropic/hg/tabphase plugins exercised here
+        # value == pdf for the isotropic/hg/tabphase plugins exercized here
         out[i] = phase.eval_pdf(ctx, mei, wo)[1]
     return out
 
@@ -54,7 +54,7 @@ def test_get_nodes_default(variant_scalar_rgb):
     # A leaf phase function without irregular nodes falls back to the base
     # implementation: 256 nodes spread uniformly over [-1, 1].
     phase = mi.load_dict({"type": "isotropic"})
-    nodes = np.array(phase.get_nodes())
+    nodes = np.array(phase.get_envelope_nodes())
 
     assert nodes.shape[0] == 256
     # The grid is built in single precision; compare with an absolute tolerance.
@@ -66,8 +66,10 @@ def test_get_nodes_default(variant_scalar_rgb):
 def test_get_nodes_tabphase_irregular(
     variant_scalar_rgb, tabphase_nodes, tabphase_irregular
 ):
-    # tabphase_irregular overrides get_nodes() to expose its own grid.
-    assert np.allclose(np.array(tabphase_irregular.get_nodes()), tabphase_nodes)
+    # tabphase_irregular overrides get_envelope_nodes() to expose its own grid.
+    assert np.allclose(
+        np.array(tabphase_irregular.get_envelope_nodes()), tabphase_nodes
+    )
 
 
 def test_get_nodes_blendphase_merged(
@@ -86,7 +88,7 @@ def test_get_nodes_blendphase_merged(
         }
     )
 
-    nodes = np.array(blend.get_nodes())
+    nodes = np.array(blend.get_envelope_nodes())
     expected = np.unique(np.concatenate([np.linspace(-1, 1, 256), tabphase_nodes]))
 
     # Single-precision grid: compare with an absolute tolerance.
@@ -99,11 +101,11 @@ def test_get_nodes_blendphase_merged(
 def test_eval_max_single(variant_scalar_rgb, hg):
     # The envelope of a single phase function is just the phase function
     # evaluated at every node.
-    nodes = hg.get_nodes()
+    nodes = hg.get_envelope_nodes()
     values = dr.zeros(type(nodes), dr.width(nodes))
 
-    hg.eval_max(nodes, values)
-    assert np.allclose(np.array(values), reference_eval_max(hg, nodes))
+    hg.accumulate_envelope(nodes, values)
+    assert np.allclose(np.array(values), reference_accumulate_envelope(hg, nodes))
 
 
 def test_eval_max_blendphase(variant_scalar_rgb, hg):
@@ -114,13 +116,13 @@ def test_eval_max_blendphase(variant_scalar_rgb, hg):
         {"type": "blendphase", "weight": 0.3, "phase_0": iso, "phase_1": hg}
     )
 
-    nodes = blend.get_nodes()
+    nodes = blend.get_envelope_nodes()
     values = dr.zeros(type(nodes), dr.width(nodes))
-    blend.eval_max(nodes, values)
+    blend.accumulate_envelope(nodes, values)
 
     ref = np.maximum(
-        reference_eval_max(iso, nodes),
-        reference_eval_max(hg, nodes),
+        reference_accumulate_envelope(iso, nodes),
+        reference_accumulate_envelope(hg, nodes),
     )
     assert np.allclose(np.array(values), ref)
 
@@ -140,15 +142,15 @@ def test_eval_max_multiphase(variant_scalar_rgb, hg, tabphase_irregular):
         }
     )
 
-    nodes = multi.get_nodes()
+    nodes = multi.get_envelope_nodes()
     values = dr.zeros(type(nodes), dr.width(nodes))
-    multi.eval_max(nodes, values)
+    multi.accumulate_envelope(nodes, values)
 
     ref = np.maximum.reduce(
         [
-            reference_eval_max(iso, nodes),
-            reference_eval_max(hg, nodes),
-            reference_eval_max(tabphase_irregular, nodes),
+            reference_accumulate_envelope(iso, nodes),
+            reference_accumulate_envelope(hg, nodes),
+            reference_accumulate_envelope(tabphase_irregular, nodes),
         ]
     )
     assert np.allclose(np.array(values), ref)

--- a/src/eradiate_plugins/tests/phase/test_tabphase_irregular.py
+++ b/src/eradiate_plugins/tests/phase/test_tabphase_irregular.py
@@ -15,7 +15,7 @@ def test_create(variant_scalar_rgb):
     assert p is not None
 
 
-def test_create_tensor(variants_vec_backends_once_rgb):
+def test_create_tensor(variant_scalar_mono, variants_vec_backends_once_rgb):
     # 'values' and 'nodes' supplied as 1D Dr.Jit arrays (tensor input)
     p = mi.load_dict(
         {
@@ -27,7 +27,7 @@ def test_create_tensor(variants_vec_backends_once_rgb):
     assert p is not None
 
 
-def test_create_tensor_3(variants_vec_backends_once_rgb):
+def test_create_tensor_3(variant_scalar_mono, variants_vec_backends_once_rgb):
     # 'values' and 'nodes' supplied as 1D Dr.Jit arrays of size 3,
     # interpreted as vectors.
     p = mi.load_dict(

--- a/src/eradiate_plugins/tests/phase/test_tabphase_irregular.py
+++ b/src/eradiate_plugins/tests/phase/test_tabphase_irregular.py
@@ -15,6 +15,67 @@ def test_create(variant_scalar_rgb):
     assert p is not None
 
 
+def test_create_tensor(variants_vec_backends_once_rgb):
+    # 'values' and 'nodes' supplied as 1D Dr.Jit arrays (tensor input)
+    p = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": mi.TensorXf([0.5, 0.8, 1.2, 1.5]),
+            "nodes": mi.TensorXf([-1.0, -0.3, 0.4, 1.0]),
+        }
+    )
+    assert p is not None
+
+
+def test_create_tensor_3(variants_vec_backends_once_rgb):
+    # 'values' and 'nodes' supplied as 1D Dr.Jit arrays of size 3,
+    # interpreted as vectors.
+    p = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": mi.TensorXf([0.5, 0.8, 1.5]),
+            "nodes": mi.TensorXf([-1.0, -0.3, 1.0]),
+        }
+    )
+    assert p is not None
+
+
+def test_tensor_matches_string(variants_vec_backends_once_rgb):
+    # The tensor and string construction paths must produce identical plugins.
+    values = [0.5, 0.8, 1.2, 1.5]
+    nodes = [-1.0, -0.3, 0.4, 1.0]
+
+    p_tensor = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": mi.TensorXf(values),
+            "nodes": mi.TensorXf(nodes),
+        }
+    )
+    p_string = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": ",".join(map(str, values)),
+            "nodes": ",".join(map(str, nodes)),
+        }
+    )
+
+    # Compare stored values and nodes
+    params_t = mi.traverse(p_tensor)
+    params_s = mi.traverse(p_string)
+    assert dr.allclose(params_t["values"], params_s["values"])
+    assert dr.allclose(params_t["nodes"], params_s["nodes"])
+
+    # Compare the evaluated phase function
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.wi = mi.Vector3f(0, 0, -1)
+    for wo in [mi.Vector3f(0, 0, 1), mi.Vector3f(1, 0, 0), mi.Vector3f(0, 0, -1)]:
+        assert dr.allclose(
+            p_tensor.eval_pdf(ctx, mei, wo)[1], p_string.eval_pdf(ctx, mei, wo)[1]
+        )
+
+
 def test_eval_pdf(variant_scalar_rgb):
     """
     Compare eval() output with a reference implementation written in Python.
@@ -41,7 +102,7 @@ def test_eval_pdf(variant_scalar_rgb):
         cos_theta = np.array([np.dot(a, b) for a, b in zip(wi, wo)])
         return 0.5 / np.pi * np.interp(-cos_theta, ref_x, ref_y) / ref_integral
 
-    wi = np.array([[0, 0, -1.]])
+    wi = np.array([[0, 0, -1.0]])
     thetas = np.linspace(0, np.pi / 2, 16)
     phis = np.linspace(0, np.pi, 16)
     wos = np.array(

--- a/src/phase/blendphase.cpp
+++ b/src/phase/blendphase.cpp
@@ -1,6 +1,9 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/render/phase.h>
 #include <mitsuba/render/volume.h>
+// #ERADIATE_CHANGE_BEGIN: DDIS
+#include <mitsuba/render/eradiate/phase_utils.h>
+// #ERADIATE_CHANGE_END
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -193,6 +196,21 @@ public:
         return oss.str();
     }
 
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
+        std::vector<ScalarFloat> nodes0, nodes1;
+        m_nested_phase[0]->get_nodes(nodes0);
+        m_nested_phase[1]->get_nodes(nodes1);
+        auto result = merge_nodes<ScalarFloat>({nodes0, nodes1});
+        nodes  = std::move(result);
+    }
+
+    void eval_max(const std::vector<ScalarFloat> &nodes,
+                  std::vector<ScalarFloat> &values) const override {
+        m_nested_phase[0]->eval_max(nodes, values);
+        m_nested_phase[1]->eval_max(nodes, values);
+    }
+// #ERADIATE_CHANGE_END
     MI_DECLARE_CLASS(BlendPhaseFunction)
 protected:
     ref<Volume> m_weight;

--- a/src/phase/blendphase.cpp
+++ b/src/phase/blendphase.cpp
@@ -69,6 +69,9 @@ class BlendPhaseFunction final : public PhaseFunction<Float, Spectrum> {
 public:
     MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
     MI_IMPORT_TYPES(PhaseFunctionContext, Volume)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    using typename Base::FloatStorage;
+// #ERADIATE_CHANGE_END
 
     BlendPhaseFunction(const Properties &props) : Base(props) {
         int phase_index = 0;
@@ -197,16 +200,12 @@ public:
     }
 
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    void get_nodes(std::vector<ScalarFloat> &nodes) const override {
-        std::vector<ScalarFloat> nodes0, nodes1;
-        m_nested_phase[0]->get_nodes(nodes0);
-        m_nested_phase[1]->get_nodes(nodes1);
-        auto result = merge_nodes<ScalarFloat>({nodes0, nodes1});
-        nodes  = std::move(result);
+    FloatStorage get_nodes() const override {
+        return merge_nodes<FloatStorage>({ m_nested_phase[0]->get_nodes(),
+                                           m_nested_phase[1]->get_nodes() });
     }
 
-    void eval_max(const std::vector<ScalarFloat> &nodes,
-                  std::vector<ScalarFloat> &values) const override {
+    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override {
         m_nested_phase[0]->eval_max(nodes, values);
         m_nested_phase[1]->eval_max(nodes, values);
     }

--- a/src/phase/blendphase.cpp
+++ b/src/phase/blendphase.cpp
@@ -200,14 +200,14 @@ public:
     }
 
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    FloatStorage get_nodes() const override {
-        return merge_nodes<FloatStorage>({ m_nested_phase[0]->get_nodes(),
-                                           m_nested_phase[1]->get_nodes() });
+    FloatStorage get_envelope_nodes() const override {
+        return merge_envelope_nodes<FloatStorage>({ m_nested_phase[0]->get_envelope_nodes(),
+                                           m_nested_phase[1]->get_envelope_nodes() });
     }
 
-    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override {
-        m_nested_phase[0]->eval_max(nodes, values);
-        m_nested_phase[1]->eval_max(nodes, values);
+    void accumulate_envelope(const FloatStorage &nodes, FloatStorage &values) const override {
+        m_nested_phase[0]->accumulate_envelope(nodes, values);
+        m_nested_phase[1]->accumulate_envelope(nodes, values);
     }
 // #ERADIATE_CHANGE_END
     MI_DECLARE_CLASS(BlendPhaseFunction)

--- a/src/phase/tabphase.cpp
+++ b/src/phase/tabphase.cpp
@@ -2,6 +2,9 @@
 #include <mitsuba/core/properties.h>
 #include <mitsuba/core/warp.h>
 #include <mitsuba/render/phase.h>
+// #ERADIATE_CHANGE_BEGIN: DDIS
+#include <mitsuba/render/eradiate/phase_utils.h>
+// #ERADIATE_CHANGE_END
 
 NAMESPACE_BEGIN(mitsuba)
 
@@ -38,7 +41,9 @@ function of the cosine of the scattering angle.
 template <typename Float, typename Spectrum>
 class TabulatedPhaseFunction final : public PhaseFunction<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    MI_IMPORT_BASE(PhaseFunction, m_flags, m_components, m_node_count)
+// #ERADIATE_CHANGE_END
     MI_IMPORT_TYPES(PhaseFunctionContext)
 
     TabulatedPhaseFunction(const Properties &props) : Base(props) {
@@ -64,15 +69,21 @@ public:
 
         m_flags = +PhaseFunctionFlags::Anisotropic;
         m_components.push_back(m_flags);
+// #ERADIATE_CHANGE_BEGIN: DDIS
+        m_node_count = m_distr.size();
+// #ERADIATE_CHANGE_END
     }
 
     void traverse(TraversalCallback *cb) override {
         cb->put("values", m_distr.pdf(), ParamFlags::Differentiable | ParamFlags::Discontinuous);
     }
 
-    void parameters_changed(const std::vector<std::string> & /*keys*/) override {
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    void parameters_changed(const std::vector<std::string> & keys) override {
         m_distr.update();
+        Base::parameters_changed(keys);
     }
+// #ERADIATE_CHANGE_END
 
     std::tuple<Vector3f, Spectrum, Float> sample(const PhaseFunctionContext & /* ctx */,
                                                  const MediumInteraction3f &mi,

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -104,21 +104,21 @@ Medium<Float, Spectrum>::transmittance_eval_pdf(const MediumInteraction3f &mi,
     return { tr, pdf };
 }
 
-// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf  
+// #ERADIATE_CHANGE_BEGIN, NM 05/06/2024 : add function that calculates the transmittance and pdf
 MI_VARIANT
-std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f, 
+std::tuple<typename Medium<Float, Spectrum>::MediumInteraction3f,
            typename Medium<Float, Spectrum>::UnpolarizedSpectrum,
            typename Medium<Float, Spectrum>::UnpolarizedSpectrum>
-Medium<Float, Spectrum>::sample_interaction_analytical(const Ray3f &/*ray*/, 
+Medium<Float, Spectrum>::sample_interaction_analytical(const Ray3f &/*ray*/,
                                             const Interaction3f &/*it*/, Float /*sample*/,
                                             UInt32 /*channel*/, Mask /*active*/) const {
-    // PiecewiseVolPathIntegrator should only be used with piecewise medium                                                
+    // PiecewiseVolPathIntegrator should only be used with piecewise medium
     NotImplementedError("sample_interaction_analytical");
 }
 
 MI_VARIANT
 typename Medium<Float, Spectrum>::UnpolarizedSpectrum
-Medium<Float, Spectrum>::transmittance_eval_analytical(const Ray3f &/*ray*/, 
+Medium<Float, Spectrum>::transmittance_eval_analytical(const Ray3f &/*ray*/,
                                     const Interaction3f &/*it*/,
                                     Mask /*active*/) const {
     // PiecewiseVolPathIntegrator should only be used with piecewise medium
@@ -153,6 +153,69 @@ Medium<Float, Spectrum>::prepare_medium_traversal(const Ray3f& ray, Mask active)
 }
 // #ERADIATE_CHANGE_END
 
+// #ERADIATE_CHANGE_BEGIN: DDIS
+MI_VARIANT
+ref<typename Medium<Float, Spectrum>::PhaseFunction>
+Medium<Float, Spectrum>::create_ddis_phase_function() {
+    using FloatStorage = DynamicBuffer<Float>;
+
+    // Create the DDIS phase function as a tabulated function of the
+    // max function of the underlying phase function.
+    auto phase = phase_function();
+    FloatStorage nodes  = phase->get_envelope_nodes();
+    FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
+    m_phase_function->accumulate_envelope(nodes, values);
+
+    auto pmgr = PluginManager::instance();
+    Properties props_ddis("tabphase_irregular");
+    size_t shape = nodes.size();
+    props_ddis.set_any("nodes", TensorXf(std::move(nodes), 1, &shape));
+    props_ddis.set_any("values", TensorXf(std::move(values), 1, &shape));
+    return pmgr->create_object<PhaseFunction>(props_ddis);
+}
+
+MI_VARIANT
+void Medium<Float, Spectrum>::update_ddis_phase_function() {
+    using FloatStorage = DynamicBuffer<Float>;
+
+    // DDIS rebuild is driven exclusively by Scene::parameters_changed()
+    // via update_ddis_phase_function(), which ensures all media sharing a
+    // phase function via ref are updated before dirty flags are cleared.
+    if (m_ddis_threshold <= 0.f || m_ddis_phase_function == nullptr)
+        return;
+
+    FloatStorage nodes  = m_phase_function->get_envelope_nodes();
+    FloatStorage values = dr::zeros<FloatStorage>(dr::width(nodes));
+    m_phase_function->accumulate_envelope(nodes, values);
+
+    struct ValuesCallback : TraversalCallback {
+        FloatStorage *target_nodes = nullptr;
+        FloatStorage *target_values = nullptr;
+        void put_value(std::string_view name, void *ptr, uint32_t,
+                        const std::type_info &) override {
+            if (name == "nodes")
+                target_nodes = static_cast<FloatStorage *>(ptr);
+            if (name == "values")
+                target_values = static_cast<FloatStorage *>(ptr);
+        }
+        void put_object(std::string_view, Object *, uint32_t) override {}
+    } cb;
+
+    m_ddis_phase_function->traverse(&cb);
+
+    Assert(cb.taget_values && cb.target_nodes);
+
+    if (cb.target_values)
+        *cb.target_values = values;
+
+    if (cb.target_nodes)
+        *cb.target_nodes = nodes;
+
+    if (cb.target_values || cb.target_nodes)
+        m_ddis_phase_function->parameters_changed({});
+}
+
+// #ERADIATE_CHANGE_END
 MI_IMPLEMENT_TRAVERSE_CB(Medium, Object)
 MI_INSTANTIATE_CLASS(Medium)
 NAMESPACE_END(mitsuba)

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -35,6 +35,9 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props)
     }
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
+// #ERADIATE_CHANGE_END
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() { }

--- a/src/render/medium.cpp
+++ b/src/render/medium.cpp
@@ -35,9 +35,6 @@ MI_VARIANT Medium<Float, Spectrum>::Medium(const Properties &props)
     }
 
     m_sample_emitters = props.get<bool>("sample_emitters", true);
-// #ERADIATE_CHANGE_BEGIN: DDIS
-    m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
-// #ERADIATE_CHANGE_END
 }
 
 MI_VARIANT Medium<Float, Spectrum>::~Medium() { }

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -12,13 +12,13 @@ MI_VARIANT PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props
 }   
 
 MI_VARIANT typename PhaseFunction<Float, Spectrum>::FloatStorage
-PhaseFunction<Float, Spectrum>::get_nodes() const {
+PhaseFunction<Float, Spectrum>::get_envelope_nodes() const {
     FloatStorage i = dr::arange<FloatStorage>(m_node_count);
     return -1.f + 2.f * i / ScalarFloat(m_node_count - 1);
 }
 
 MI_VARIANT void
-PhaseFunction<Float, Spectrum>::eval_max(const FloatStorage &nodes,
+PhaseFunction<Float, Spectrum>::accumulate_envelope(const FloatStorage &nodes,
                                          FloatStorage &values) const {
     PhaseFunctionContext ctx(nullptr);
     size_t n               = dr::width(nodes);

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -9,37 +9,37 @@ MI_VARIANT PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props
     : JitObject<PhaseFunction>(props.id()), 
       m_flags(+PhaseFunctionFlags::Empty),
       m_node_count(256) {
-}
- 
-MI_VARIANT void PhaseFunction<Float, Spectrum>::get_nodes(
-    std::vector<ScalarFloat> &nodes) const {
-    
-    nodes.resize(m_node_count);
+}   
 
-    for (size_t i = 0; i < m_node_count; ++i) {
-        nodes[i] = -1.f + 2.f * ScalarFloat(i) / ScalarFloat(m_node_count - 1);
-    }
+MI_VARIANT typename PhaseFunction<Float, Spectrum>::FloatStorage
+PhaseFunction<Float, Spectrum>::get_nodes() const {
+    FloatStorage i = dr::arange<FloatStorage>(m_node_count);
+    return -1.f + 2.f * i / ScalarFloat(m_node_count - 1);
 }
 
-MI_VARIANT void PhaseFunction<Float, Spectrum>::eval_max(
-    const std::vector<ScalarFloat> &nodes, 
-    std::vector<ScalarFloat> &values) const {
-
-    MI_IMPORT_TYPES(PhaseFunctionContext)
-    
-    size_t n = nodes.size();
-    values.resize(n);
-
-    MediumInteraction3f mi = dr::zeros<MediumInteraction3f>();
-    mi.wi                  = Vector3f(0.f, 0.f, 1.f);
+MI_VARIANT void
+PhaseFunction<Float, Spectrum>::eval_max(const FloatStorage &nodes,
+                                         FloatStorage &values) const {
     PhaseFunctionContext ctx(nullptr);
+    size_t n               = dr::width(nodes);
+    MediumInteraction3f mi = dr::zeros<MediumInteraction3f>(n);
+    mi.wi                  = Vector3f(0.f, 0.f, 1.f);
 
-    for (size_t i = 0; i < n; ++i) {
-        ScalarFloat mu        = nodes[i];
-        ScalarFloat sin_theta = dr::sqrt(dr::maximum(ScalarFloat(0), 1.f - mu * mu));
+    if constexpr (dr::is_jit_v<Float>) {
+        Float mu        = nodes;
+        Float sin_theta = dr::sqrt(dr::maximum(Float(0), 1.f - mu * mu));
         Vector3f wo(sin_theta, 0.f, -mu);
         auto [val, pdf] = eval_pdf(ctx, mi, wo);
-        values[i]       = dr::maximum(values[i], (ScalarFloat) dr::slice(unpolarized_spectrum(val)[0]));
+        values          = dr::maximum(values, unpolarized_spectrum(val)[0]);
+
+    } else {
+        for (size_t i = 0; i < n; ++i) {
+            ScalarFloat mu        = nodes[i];
+            ScalarFloat sin_theta = dr::sqrt(dr::maximum(ScalarFloat(0), 1.f - mu * mu));
+            Vector3f wo(sin_theta, 0.f, -mu);
+            auto [val, pdf] = eval_pdf(ctx, mi, wo);
+            values[i]       = dr::maximum(values[i], (ScalarFloat) unpolarized_spectrum(val)[0]);
+        }
     }
 }
 // #ERADIATE_CHANGE_END

--- a/src/render/phase.cpp
+++ b/src/render/phase.cpp
@@ -4,9 +4,51 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
+// #ERADIATE_CHANGE_BEGIN: DDIS
 MI_VARIANT PhaseFunction<Float, Spectrum>::PhaseFunction(const Properties &props)
-    : JitObject<PhaseFunction>(props.id()), m_flags(+PhaseFunctionFlags::Empty) {
+    : JitObject<PhaseFunction>(props.id()), 
+      m_flags(+PhaseFunctionFlags::Empty),
+      m_node_count(256) {
+}
+ 
+MI_VARIANT void PhaseFunction<Float, Spectrum>::get_nodes(
+    std::vector<ScalarFloat> &nodes) const {
+    
+    nodes.resize(m_node_count);
+
+    for (size_t i = 0; i < m_node_count; ++i) {
+        nodes[i] = -1.f + 2.f * ScalarFloat(i) / ScalarFloat(m_node_count - 1);
+    }
 }
 
+MI_VARIANT void PhaseFunction<Float, Spectrum>::eval_max(
+    const std::vector<ScalarFloat> &nodes, 
+    std::vector<ScalarFloat> &values) const {
+
+    MI_IMPORT_TYPES(PhaseFunctionContext)
+    
+    size_t n = nodes.size();
+    values.resize(n);
+
+    MediumInteraction3f mi = dr::zeros<MediumInteraction3f>();
+    mi.wi                  = Vector3f(0.f, 0.f, 1.f);
+    PhaseFunctionContext ctx(nullptr);
+
+    for (size_t i = 0; i < n; ++i) {
+        ScalarFloat mu        = nodes[i];
+        ScalarFloat sin_theta = dr::sqrt(dr::maximum(ScalarFloat(0), 1.f - mu * mu));
+        Vector3f wo(sin_theta, 0.f, -mu);
+        auto [val, pdf] = eval_pdf(ctx, mi, wo);
+        values[i]       = dr::maximum(values[i], (ScalarFloat) dr::slice(unpolarized_spectrum(val)[0]));
+    }
+}
+// #ERADIATE_CHANGE_END
+
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty flag
+MI_VARIANT void PhaseFunction<Float, Spectrum>::parameters_changed(
+        const std::vector<std::string> &/*keys*/) {
+    m_dirty = true;
+}
+// #ERADIATE_CHANGE_END
 MI_INSTANTIATE_CLASS(PhaseFunction)
 NAMESPACE_END(mitsuba)

--- a/src/render/python/phase_v.cpp
+++ b/src/render/python/phase_v.cpp
@@ -39,12 +39,12 @@ public:
         NB_OVERRIDE_PURE(eval_pdf, ctx, mi, wo, active);
     }
 // #ERADIATE_CHANGE_BEGIN: DDIS
-    FloatStorage get_nodes() const override{
-        NB_OVERRIDE(get_nodes);
+    FloatStorage get_envelope_nodes() const override{
+        NB_OVERRIDE(get_envelope_nodes);
     };
 
-    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override{
-        NB_OVERRIDE(eval_max, nodes, values);
+    void accumulate_envelope(const FloatStorage &nodes, FloatStorage &values) const override{
+        NB_OVERRIDE(accumulate_envelope, nodes, values);
     };
 // #ERADIATE_CHANGE_END
 
@@ -106,19 +106,19 @@ template <typename Ptr, typename Cls> void bind_phase_generic(Cls &cls) {
             "active"_a = true, D(PhaseFunction, component_count));
 // #ERADIATE_CHANGE_BEGIN: DDIS
 
-    // get_nodes/eval_max operate on a single phase function and exchange node
+    // get_envelope_nodes/accumulate_envelope operate on a single phase function and exchange node
     // buffers; The out-parameter cannot be bound on a vectorized array of phase
     // function pointers.
     if constexpr (std::is_pointer_v<Ptr>) {
-        cls.def("get_nodes",
-                [](Ptr ptr) { return ptr->get_nodes(); },
-                D(PhaseFunction, get_nodes))
-           .def("eval_max",
+        cls.def("get_envelope_nodes",
+                [](Ptr ptr) { return ptr->get_envelope_nodes(); },
+                D(PhaseFunction, get_envelope_nodes))
+           .def("accumulate_envelope",
                 [](Ptr ptr, const FloatStorage &nodes, FloatStorage &values) {
                     if (dr::width(nodes) != dr::width(values))
-                        Throw("eval_max, nodes and values must have the same length");
-                    ptr->eval_max(nodes, values);
-                }, "nodes"_a, "values"_a, D(PhaseFunction, eval_max));
+                        Throw("accumulate_envelope, nodes and values must have the same length");
+                    ptr->accumulate_envelope(nodes, values);
+                }, "nodes"_a, "values"_a, D(PhaseFunction, accumulate_envelope));
     }
 // #ERADIATE_CHANGE_END
 }

--- a/src/render/python/phase_v.cpp
+++ b/src/render/python/phase_v.cpp
@@ -15,7 +15,11 @@
 MI_VARIANT class PyPhaseFunction : public PhaseFunction<Float, Spectrum> {
 public:
     MI_IMPORT_TYPES(PhaseFunction, PhaseFunctionContext)
-    NB_TRAMPOLINE(PhaseFunction, 7);
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    NB_TRAMPOLINE(PhaseFunction, 9);
+
+    using FloatStorage = DynamicBuffer<Float>;
+// #ERADIATE_CHANGE_END
 
     PyPhaseFunction(const Properties &props) : PhaseFunction(props) {}
 
@@ -34,6 +38,15 @@ public:
         using Return = std::pair<Spectrum, Float>;
         NB_OVERRIDE_PURE(eval_pdf, ctx, mi, wo, active);
     }
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    FloatStorage get_nodes() const override{
+        NB_OVERRIDE(get_nodes);
+    };
+
+    void eval_max(const FloatStorage &nodes, FloatStorage &values) const override{
+        NB_OVERRIDE(eval_max, nodes, values);
+    };
+// #ERADIATE_CHANGE_END
 
     Float projected_area(const MediumInteraction3f &mi, Mask active) const override {
         NB_OVERRIDE(projected_area, mi, active);
@@ -63,7 +76,10 @@ public:
 
 template <typename Ptr, typename Cls> void bind_phase_generic(Cls &cls) {
     MI_PY_IMPORT_TYPES(PhaseFunctionContext)
+// #ERADIATE_CHANGE_BEGIN: DDIS
+    using FloatStorage = DynamicBuffer<Float>;
 
+// #ERADIATE_CHANGE_END
     cls.def("sample",
             [](Ptr ptr, const PhaseFunctionContext &ctx,
                const MediumInteraction3f &mi, const Float &s1, const Point2f &s2,
@@ -88,6 +104,23 @@ template <typename Ptr, typename Cls> void bind_phase_generic(Cls &cls) {
             "active"_a = true, D(PhaseFunction, flags))
        .def("component_count", [](Ptr ptr, Mask active) { return ptr->component_count(active); },
             "active"_a = true, D(PhaseFunction, component_count));
+// #ERADIATE_CHANGE_BEGIN: DDIS
+
+    // get_nodes/eval_max operate on a single phase function and exchange node
+    // buffers; The out-parameter cannot be bound on a vectorized array of phase
+    // function pointers.
+    if constexpr (std::is_pointer_v<Ptr>) {
+        cls.def("get_nodes",
+                [](Ptr ptr) { return ptr->get_nodes(); },
+                D(PhaseFunction, get_nodes))
+           .def("eval_max",
+                [](Ptr ptr, const FloatStorage &nodes, FloatStorage &values) {
+                    if (dr::width(nodes) != dr::width(values))
+                        Throw("eval_max, nodes and values must have the same length");
+                    ptr->eval_max(nodes, values);
+                }, "nodes"_a, "values"_a, D(PhaseFunction, eval_max));
+    }
+// #ERADIATE_CHANGE_END
 }
 
 MI_PY_EXPORT(PhaseFunction) {

--- a/src/render/python/scene_v.cpp
+++ b/src/render/python/scene_v.cpp
@@ -130,6 +130,9 @@ MI_PY_EXPORT(Scene) {
              },
              D(Scene, shapes))
         .def("shapes_dr", &Scene::shapes_dr, D(Scene, shapes_dr))
+// #ERADIATE_CHANGE_BEGIN: DDIS
+        .def("media", nb::overload_cast<>(&Scene::media), D(Scene, emitters))
+// #ERADIATE_CHANGE_END
         .def("silhouette_shapes",
              [](const Scene &scene) {
                  nb::list result;

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -53,6 +53,12 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
             }
             if (mesh)
                 mesh->set_scene(this);
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+            if (shape->interior_medium())
+                m_media.push_back(shape->interior_medium());
+            if (shape->exterior_medium())
+                m_media.push_back(shape->exterior_medium());
+// #ERADIATE_CHANGE_END
         } else if (emitter) {
             // Surface emitters will be added to the list when attached to a shape
             if (!has_flag(emitter->flags(), EmitterFlags::Surface))
@@ -72,10 +78,15 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
 // #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
         } else if (medium) {
             m_media.push_back(medium);
-// #ERADIATE_CHANGE_END
         }
     }
 
+    // remove duplicate media introduced by gathering both top level and shapes.
+    std::sort(m_media.begin(), m_media.end());
+    auto last = std::unique(m_media.begin(), m_media.end());
+    m_media.erase(last, m_media.end());
+
+// #ERADIATE_CHANGE_END
     // Create sensors' shapes (environment sensors)
     for (Sensor *sensor: m_sensors)
         sensor->set_scene(this);

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -30,6 +30,9 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
         Emitter *emitter       = dynamic_cast<Emitter *>(v.get());
         Sensor *sensor         = dynamic_cast<Sensor *>(v.get());
         Integrator *integrator = dynamic_cast<Integrator *>(v.get());
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+        Medium *medium         = dynamic_cast<Medium *>(v.get());
+// #ERADIATE_CHANGE_END
 
         if (Scene *scene = dynamic_cast<Scene *>(v.get())) {
             // Skip nested scenes in children list
@@ -66,6 +69,10 @@ MI_VARIANT Scene<Float, Spectrum>::Scene(const Properties &props)
             if (m_integrator)
                 Throw("Only one integrator can be specified per scene.");
             m_integrator = integrator;
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+        } else if (medium) {
+            m_media.push_back(medium);
+// #ERADIATE_CHANGE_END
         }
     }
 
@@ -184,6 +191,9 @@ MI_VARIANT Scene<Float, Spectrum>::~Scene() {
     m_shapes.clear();
     m_shapegroups.clear();
     m_sensors.clear();
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+    m_media.clear();
+// #ERADIATE_CHANGE_END
     m_children.clear();
     m_integrator = nullptr;
     m_environment = nullptr;
@@ -569,6 +579,18 @@ MI_VARIANT void Scene<Float, Spectrum>::parameters_changed(const std::vector<std
             break;
         }
     }
+// #ERADIATE_CHANGE_BEGIN: DDIS phase dirty tracking
+    // Update the DDIS phase function for all media whose phase function has
+    // been marked dirty. All media are updated before any dirty flag is
+    // cleared so that media sharing the same phase function via a scene-level
+    // ref all get rebuilt.
+    for (auto &m : m_media)
+        if (m->phase_function() && m->phase_function()->dirty())
+            m->update_ddis_phase_function();
+    for (auto &m : m_media)
+        if (m->phase_function())
+            m->phase_function()->set_dirty(false);
+// #ERADIATE_CHANGE_END
 }
 
 MI_VARIANT std::string Scene<Float, Spectrum>::to_string() const {

--- a/tools/check_eradiate_fences.py
+++ b/tools/check_eradiate_fences.py
@@ -36,8 +36,14 @@ RE_END = re.compile(r"ERADIATE_CHANGE_END")
 # Directories containing upstream Mitsuba code (relative to repo root)
 UPSTREAM_PREFIXES = ("src/", "include/")
 
-# Eradiate-specific subtrees that live inside the upstream directories above
-ERADIATE_PREFIXES = ("src/eradiate_plugins/", "include/eradiate/")
+# Eradiate-specific subtrees that live inside the upstream directories above.
+# Any path with an "eradiate" or "eradiate_plugins" directory component is
+# treated as Eradiate-specific code and therefore exempt from fences.
+ERADIATE_DIRS = ("eradiate", "eradiate_plugins")
+
+
+def _is_eradiate_path(path: str) -> bool:
+    return any(part in ERADIATE_DIRS for part in path.split("/"))
 
 # Generated files that should not be checked for fences
 GENERATED_FILES = ("include/mitsuba/python/docstr.h",)
@@ -51,7 +57,7 @@ GENERATED_FILES = ("include/mitsuba/python/docstr.h",)
 def is_upstream(path: str) -> bool:
     return (
         any(path.startswith(p) for p in UPSTREAM_PREFIXES)
-        and not any(path.startswith(p) for p in ERADIATE_PREFIXES)
+        and not _is_eradiate_path(path)
         and path not in GENERATED_FILES
     )
 


### PR DESCRIPTION
## Description

Hello, this PR brings enhancements to the implementation of DDIS in `eovolpath`:
* Use of a `ddis_phase_function` as described in the VROOM paper: a phase function that returns the envelope 
value of all existing phase functions in the medium.
* A `phase_utils` header to merge phase angle envelope nodes and utility functions in `PhaseFunction` to retrieve the max phase value over a phase tree.
* The aforementioned `ddis_phase_function` and `ddis_threshold` are now part of the medium. Corresponding getters were added to access those parameters. 
* A new `EOHeterogeneous` was added that is a copy of heterogeneous (similar to `EOVolPath`). As a first change, it generates its own tabulated DDIS phase function from the phase function it holds. It also accepts `aabb_min` and `aabb_max` as bbox parameters. This allows for medium bboxs to be larger than their underlying volumes, and to make use of the volume's wrapping mechanism.
* DDIS sampling scheme over surface interactions.
* Modify `tabphase_irregular` so that it accepts tensors as input parameters for its nodes and values.
* Addition of `PhaseFunction` to the API documentation.

To ensure that the `ddis_phase_function` is updated whenever one of the phase functions of the medium is updated, we introduced intrusive changes to the phase function API and the scene implementation. The latter now keeps track of the media held at scene level, and updates the ddis phase function whenever their phase is dirty.  I am honestly not convinced of this approach, but cannot think of a more reliable way of updating it.

Note that this breaks the interface whereby `ddis_threshold` was passed in the integrator. DDIS is now enabled by setting `enable_ddis` in `eovolpath` and is by default turned off (defaults will be reviewed with further VROOM improvements).

## Testing

Preliminary tests were done over various scenes: cloud layer, polarized ocean, canopy.
Unit tests were added for the `eval_max` and get_nodes` functions.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)