### PR TITLE
[Feature] Add prediction Based Splitting and N-tuple Local Estimate to `eovolpath`.

### DIFF
--- a/src/eradiate_plugins/integrators/eovolpath.cpp
+++ b/src/eradiate_plugins/integrators/eovolpath.cpp
@@ -14,6 +14,28 @@
 
 NAMESPACE_BEGIN(mitsuba)
 
+/**
+ * \brief This list of flags is used to differentiate the type of paths that
+ * are present in the stack.
+ */
+enum class PathTypeFlag : uint32_t {
+    /// Default when standard path tracing with no variance reduction method.
+    Standard    = 0x0000,
+
+    /// NLE: natural path from which Clones are spawned.
+    Mother      = 0x0001,
+
+    /// NLE: path cloned from a mother path.
+    Clone       = 0x0002,
+
+    /// Path that underwent a splitting operation.
+    Split       = 0x0004,
+
+    /// Set of path types that constitute the NLE variance reduction method
+    NLE         = Mother | Clone,
+};
+MI_DECLARE_ENUM_OPERATORS(PathTypeFlag)
+
 /**!
 
 .. _integrator-eovolpath:
@@ -39,11 +61,71 @@ EO Volumetric path tracer (:monosp:`eovolpath`)
    - Specifies the maximum probability to keep a path when russian roulette is evaluated.
      (Default: 0.97)
 
- * - enable_ddis
+ * - ddis_enable
    - |bool|
    - Activate the DDIS variance reduction method. The ``ddis_threshold`` used to determine the
      probability of sampling using the emitter direction is set in the media plugins.
      (Default: false)
+
+ * - ddis_enable_surface
+   - |bool|
+   - Activate ddis for surfaces when ``ddis_enable`` is true. (Default: |true|).
+
+ * - pbs_enable
+   - |bool|
+   - Enable prediction-based path splitting (PBS). At each volumetric event,
+     the predicted contribution of the ddis scattered direction is used to determine whether
+     to split the path into multiple independent copies or to perform russian rouletter.
+     Each split path has a proportionally reduced weight. Requires ``ddis_enable=true``.
+     (Default: |false|)
+
+ * - pbs_min_split_threshold
+   - |float|
+   - Minimum prediction weight required to trigger a split. Only paths whose predicted weight
+     exceeds this value are split. Must be greater than 1 for splitting to produce more than one
+     copy. (Default: 3.0)
+
+ * - pbs_max_split_count
+   - |int|
+   - Maximum number of path copies created at a single splitting event. The actual count is
+     ``min(pbs_max_split_count, floor(w_spl))``, where ``w_spl`` is the split prediction weight.
+     (Default: 50)
+
+ * - pbs_crit_rr_threshold
+   - |float|
+   - Weight threshold below which Russian Roulette is applied to split paths. Split paths whose
+     current prediction weight falls below this value are stochastically terminated to limit the
+     cost of low-weight copies. (Default: 0.33)
+
+ * - pbs_min_rr_threshold
+   - |float|
+   - Minimum survival probability for split-path Russian Roulette. The survival probability is
+     ``max(w_spl, pbs_min_rr_threshold)``, which ensures the kill probability never exceeds
+     ``1 - pbs_min_rr_threshold`` and that surviving paths are not reweighted above their pre-split
+     weight. (Default: 0.2)
+
+ * - nle_enable
+   - |bool|
+   - Enable the N-tuple Local Estimate (NLE) variance reduction method. Each primary ray is traced as
+     a *mother* path. At regular intervals along the mother's trajectory, a *clone* path is forked
+     and traced independently to perform additional next-event estimation. Requires ``ddis_enable=true``.
+     (Default: |false|)
+
+ * - nle_first_clone_depth
+   - |int|
+   - Scatter depth at which the mother path creates its first clone. Clone creation then recurs
+     every ``nle_nee_per_clone`` scatters thereafter. (Default: 5)
+
+ * - nle_max_clone_depth
+   - |int|
+   - Maximum number of scattering events a clone is allowed to trace before it is terminated.
+     Controls the amount of next-event estimation work performed per clone. (Default: 12)
+
+ * - nle_nee_per_clone
+   - |int|
+   - Interval, in scattering events, between successive clone creation events along the mother
+     path. A new clone is spawned every ``nle_nee_per_clone`` scatters starting from
+     ``nle_first_clone_depth``. (Default: 11)
 
  * - hide_emitters
    - |bool|
@@ -61,9 +143,10 @@ has a :ref:`null <bsdf-null>` or :ref:`thin dielectric <bsdf-thindielectric>` BS
 to it (as compared to, say, a :ref:`dielectric <bsdf-dielectric>` or
 :ref:`roughdielectric <bsdf-roughdielectric>` BSDF).
 
-In addition, it implements the DDIS variance reduction method
-:cite:p:`Buras2011EfficientUnbiasedVariance` which reduces noise in the presence of strongly peaked
-phase functions. More variance reduction methods coming up soon!
+In addition, it implements the VROOM variance reduction methods
+:cite:p:`Buras2011EfficientUnbiasedVariance` which reduce noise in the presence of strongly peaked
+phase functions. Note that VROOM makes some strong assumptions: there must be a single directional
+emitter and the sampler must be independent.
 
 .. warning:: This integrator does not support forward-mode differentiation.
 */
@@ -77,13 +160,90 @@ public:
 
     using TrackingStateType = TrackingState<Float, Spectrum>;
 
+private:
+
+    struct PathState {
+        Mask active;
+        UInt32 depth;
+        Ray3f ray;
+        Spectrum throughput;
+        MediumPtr medium;
+        Float eta;
+        Interaction3f last_scatter_event;
+        Float last_scatter_direction_pdf;
+        Mask specular_chain;
+        Mask valid_ray;
+        Float split_weight_rr;
+        UInt32 path_flag;
+        UInt32 local_depth;
+
+        DRJIT_STRUCT(PathState, active, depth, ray, throughput, \
+            medium, eta, last_scatter_event, last_scatter_direction_pdf, \
+            specular_chain, valid_ray, split_weight_rr, \
+            path_flag, local_depth)
+    };
+
+    static constexpr size_t LS_STACK_SIZE = 4;
+
+    using PathStack = dr::Array<PathState, LS_STACK_SIZE>;
+    using CountStack = dr::Array<UInt32, LS_STACK_SIZE>;
+
+    struct LoopState {
+        PathState current;
+        Spectrum result;
+        PathStack stack;
+        CountStack counts;
+        Int32 stack_counter;  // -1 means empty (no saved state)
+        Sampler* sampler;
+        Mask active;
+
+        DRJIT_STRUCT(LoopState, current, result, stack, counts, stack_counter, sampler, active)
+    };
+
+public:
+
     EOVolumetricPathIntegrator(const Properties &props) : Base(props) {
         m_rr_factor = props.get<ScalarFloat>("rr_factor", 0.97f);
 
         if (m_rr_factor < 0.f || m_rr_factor > 1.f)
             Throw("`rr_factor` is outside range [0.,1.].");
 
-        m_enable_ddis = props.get<bool>("enable_ddis", false);
+        m_ddis_enable = props.get<bool>("ddis_enable", false);
+        m_ddis_enable_surface = props.get<bool>("ddis_enable_surface", true);
+
+        // Prediction Based Splitting (PBS) Properties
+        m_pbs_enable           = props.get<bool>("pbs_enable", false);
+        m_pbs_max_split_count       = props.get<ScalarUInt32>("pbs_max_split_count", 50);
+        m_pbs_min_split_threshold   = props.get<ScalarFloat>("pbs_min_split_threshold", 3.f);
+        m_pbs_crit_rr_threshold     = props.get<ScalarFloat>("pbs_crit_rr_threshold", 0.33f);
+        m_pbs_min_rr_threshold      = props.get<ScalarFloat>("pbs_min_rr_threshold", 0.2f);
+
+        if (m_pbs_enable && !m_ddis_enable)
+            Throw("`pbs_enable=True` requires `ddis_enable=True`");
+
+        if (m_pbs_enable && (m_pbs_crit_rr_threshold <  0.f || m_pbs_crit_rr_threshold >= 1.f))
+            Throw("`pbs_crit_rr_threshold` must be between 0 and 1.");
+
+        if (m_pbs_enable && (m_pbs_min_rr_threshold <  0.f || m_pbs_min_rr_threshold >= 1.f))
+            Throw("`pbs_min_rr_threshold` must be between 0 and 1.");
+
+        if (m_pbs_enable && (m_pbs_min_split_threshold < 1.f))
+            Throw("`pbs_min_split_threshold` must be greater than 1.");
+
+        // N-tuple Local Estimate (NLE) Properties
+        m_nle_enable         = props.get<bool>("nle_enable", false);
+        m_nle_first_clone_depth  = props.get<ScalarUInt32>("nle_first_clone_depth", 5);
+        m_nle_max_clone_depth    = props.get<ScalarUInt32>("nle_max_clone_depth", 12);
+        m_nle_nee_per_clone      = props.get<ScalarUInt32>("nle_nee_per_clone", 11);
+
+        if (m_nle_enable && !m_ddis_enable)
+            Throw("`nle_enable=True` requires `ddis_enable=True`");
+
+        if (m_nle_enable && (m_nle_max_clone_depth <= 1 || m_nle_nee_per_clone <= 1))
+            Throw("`nle_max_clone_depth` and `nle_nee_per_clone` must be larger than one");
+
+        if (m_nle_enable && m_nle_max_clone_depth < m_nle_nee_per_clone )
+            Throw("`nle_max_clone_depth` must be larger or equal to `nle_nee_per_clone`.");
     }
 
     /// Create seed and offsets that can be used to generate a new PCG32 rng.
@@ -96,6 +256,83 @@ public:
         seed   = sample_tea_64(s0, s1);
         offset = sample_tea_64(s1, s0);
         return {seed, offset};
+    }
+
+    // === Stack helpers ===
+
+    void write(Int32 index, LoopState &ls, const PathState &ps,
+               UInt32 count, Mask active = true) const {
+        if constexpr (!dr::is_jit_v<Float>) {
+            if (active) {
+                ls.stack[index]  = ps;
+                ls.counts[index] = count;
+            }
+        } else {
+            for (size_t i = 0; i < LS_STACK_SIZE; ++i) {
+                Mask cond = (Int32(i) == index) && active;
+                dr::masked(ls.stack[i],  cond) = ps;
+                dr::masked(ls.counts[i], cond) = count;
+            }
+        }
+    }
+
+    void update_current(Int32 index, LoopState &ls, Mask active = true) const {
+        if constexpr (!dr::is_jit_v<Float>) {
+            dr::masked(ls.current, active) = ls.stack[int(index)];
+        } else {
+            for (size_t i = 0; i < LS_STACK_SIZE; ++i)
+                ls.current = dr::select((Int32(i) == index) && active, ls.stack[i], ls.current);
+        }
+    }
+
+    // === Splitting interface ===
+
+    /// Push ps onto the stack at stack_counter+1.
+    /// Returns the mask of lanes that successfully pushed (stack was not full).
+    Mask push(LoopState &ls, const PathState &ps, UInt32 count, Mask active) const {
+        Mask can_push = active && (ls.stack_counter < Int32(LS_STACK_SIZE) - 1);
+        Int32 new_sc = ls.stack_counter + 1;
+        write(new_sc, ls, ps, count, can_push);
+        dr::masked(ls.stack_counter, can_push) += 1;
+        return can_push;
+    }
+
+    /// Decrement count at the current top and pop if exhausted. Cascade through
+    /// the stack if the count is equal to zero.
+    /// Returns true for lanes whose stack is now empty (stack_counter < 0).
+    Mask pop(LoopState &ls, Mask active) const {
+        if constexpr (!dr::is_jit_v<Float>) {
+            if (active) {
+                for (int i = int(ls.stack_counter); i >= 0; --i) {
+                    ls.counts[i]--;
+                    if (ls.counts[i] > 0) break;
+                    ls.stack_counter--;
+                }
+            }
+        } else {
+            for (int i = int(LS_STACK_SIZE) - 1; i >= 0; --i) {
+                Mask is_top = active && (Int32(i) == ls.stack_counter);
+                dr::masked(ls.counts[i], is_top) -= 1;
+                dr::masked(ls.stack_counter, is_top && (ls.counts[i] == 0)) -= 1;
+            }
+        }
+        return active && (ls.stack_counter < Int32(0));
+    }
+
+    void terminate_ray(LoopState &ls) const {
+        Mask terminated = ls.active && !ls.current.active;
+        Mask empty = pop(ls, terminated);
+        ls.active &= !empty;
+
+        // Clip to 0 so update_current never receives a -1 index (UB in debug).
+        dr::masked(ls.stack_counter, empty) = Int32(0);
+
+        // In scalar mode stack_counter may still be -1 for fully-drained stacks;
+        // the clipping above handles it, but the early return is a cheap guard.
+        if (dr::none_or<false>(ls.active))
+            return;
+
+        update_current(ls.stack_counter, ls, terminated && ls.active);
     }
 
     std::pair<Spectrum, Mask> sample(const Scene *scene,
@@ -117,9 +354,8 @@ public:
 
         Spectrum throughput(1.f), result(0.f);
         MediumPtr medium = initial_medium;
-        MediumInteraction3f mei = dr::zeros<MediumInteraction3f>();
         Mask specular_chain = active && !m_hide_emitters;
-        UInt32 depth = 0;
+        UInt32 depth = 0, local_depth = 0;
 
         UInt32 channel = 0;
         if (is_rgb_v<Spectrum>) {
@@ -127,82 +363,113 @@ public:
             channel = (UInt32) dr::minimum(sampler->next_1d(active) * n_channels, n_channels - 1);
         }
 
-        SurfaceInteraction3f si = dr::zeros<SurfaceInteraction3f>();
         Interaction3f last_scatter_event = dr::zeros<Interaction3f>();
         Float last_scatter_direction_pdf = 1.f;
+
+        // VROOM variables
+        UInt32 path_flag =
+            dr::select(m_nle_enable, +PathTypeFlag::Mother, +PathTypeFlag::Standard);
+        Float split_weight_rr = 1.f;
 
         /* Set up a Dr.Jit loop (optimizes away to a normal loop in scalar mode,
            generates wavefront or megakernel renderer based on configuration).
            Register everything that changes as part of the loop here */
-        struct LoopState {
-            Mask active;
-            UInt32 depth;
-            Ray3f ray;
-            Spectrum throughput;
-            Spectrum result;
-            SurfaceInteraction3f si;
-            MediumInteraction3f mei;
-            MediumPtr medium;
-            Float eta;
-            Interaction3f last_scatter_event;
-            Float last_scatter_direction_pdf;
-            Mask specular_chain;
-            Mask valid_ray;
-            Sampler* sampler;
-
-            DRJIT_STRUCT(LoopState, active, depth, ray, throughput, result, \
-                si, mei, medium, eta, last_scatter_event, \
-                last_scatter_direction_pdf, \
-                specular_chain, valid_ray, sampler)
-        } ls = {
+        PathState ps = {
             active,
             depth,
             ray,
             throughput,
-            result,
-            si,
-            mei,
             medium,
             eta,
             last_scatter_event,
             last_scatter_direction_pdf,
             specular_chain,
             valid_ray,
-            sampler
+            split_weight_rr,
+            path_flag,
+            local_depth
         };
 
+        PathStack stack;
+        CountStack counts;
+        Int32 stack_counter = Int32(-1);
+
+        LoopState ls {
+            ps,
+            result,
+            stack,
+            counts,
+            stack_counter,
+            sampler,
+            active
+        };
+
+        // Base sentinel: push the initial path state with count 1 so that
+        // pop() cascades through it and deactivates the lane when done.
+        push(ls, ps, UInt32(1), active);
+
         dr::tie(ls) = dr::while_loop(dr::make_tuple(ls),
-            [](const LoopState& ls) { return ls.active; },
+            [](const LoopState& ls) { return ls.active; }, // LoopState active flag
             [this, scene, channel](LoopState& ls) {
 
-            Mask& active = ls.active;
-            UInt32& depth = ls.depth;
-            Ray3f& ray = ls.ray;
-            Spectrum& throughput = ls.throughput;
+            Mask& active = ls.current.active; // PathState active flag
+            UInt32& depth = ls.current.depth;
+            Ray3f& ray = ls.current.ray;
+            Spectrum& throughput = ls.current.throughput;
             Spectrum& result = ls.result;
-            SurfaceInteraction3f& si = ls.si;
-            MediumInteraction3f& mei = ls.mei;
-            MediumPtr& medium = ls.medium;
-            Float& eta = ls.eta;
-            Interaction3f& last_scatter_event = ls.last_scatter_event;
-            Float& last_scatter_direction_pdf = ls.last_scatter_direction_pdf;
-            Mask& specular_chain = ls.specular_chain;
-            Mask& valid_ray = ls.valid_ray;
+            MediumPtr& medium = ls.current.medium;
+            Float& eta = ls.current.eta;
+            Interaction3f& last_scatter_event = ls.current.last_scatter_event;
+            Float& last_scatter_direction_pdf = ls.current.last_scatter_direction_pdf;
+            Mask& specular_chain = ls.current.specular_chain;
+            Mask& valid_ray = ls.current.valid_ray;
             Sampler* sampler = ls.sampler;
+            Float& split_weight_rr = ls.current.split_weight_rr;
+            UInt32& path_flag    = ls.current.path_flag;
+            UInt32& local_depth  = ls.current.local_depth;
+
+            MediumInteraction3f mei;
+            SurfaceInteraction3f si;
+
+            Mask is_mother = has_flag(path_flag, PathTypeFlag::Mother);
+            Mask is_clone = has_flag(path_flag, PathTypeFlag::Clone);
 
             // ----------------- Handle termination of paths ------------------
-            // Russian roulette: try to keep path weights equal to one, while accounting for the
+            active &= dr::any(unpolarized_spectrum(throughput) != 0.f);
+
+            Float q = 1.f;
+            Mask perform_rr = false;
+
+            // Standard Russian roulette:
+            // Try to keep path weights equal to one, while accounting for the
             // solid angle compression at refractive index boundaries. Stop with at least some
             // probability to avoid getting stuck (e.g. due to total internal reflection)
-            active &= dr::any(unpolarized_spectrum(throughput) != 0.f);
-            Float q = dr::minimum(dr::max(unpolarized_spectrum(throughput)) * dr::square(eta), m_rr_factor);
-            Mask perform_rr = (depth > (uint32_t) m_rr_depth);
+            dr::masked(q, !m_pbs_enable) =
+                dr::minimum(dr::max(unpolarized_spectrum(throughput)) * dr::square(eta), m_rr_factor);
+            dr::masked(perform_rr, !m_pbs_enable) =
+                (depth > (uint32_t) m_rr_depth);
+
+            // PBS Russian Roulette:
+            // Eliminate path that are predicted to have a small contribution.
+            // Mask do_pbs_rr = m_pbs_enable && (is_clone || has_flag(path_flag, PathTypeFlag::Split));
+            Mask do_pbs_rr = m_pbs_enable; // always apply
+            // Comparison to the current throughut to avoid values larger than one.
+            dr::masked(q, do_pbs_rr) =
+                dr::minimum(dr::maximum(dr::maximum(split_weight_rr, m_pbs_min_rr_threshold),
+                                        dr::max(unpolarized_spectrum(throughput))),
+                            1.f);
+            dr::masked(perform_rr, do_pbs_rr) =
+                (split_weight_rr < m_pbs_crit_rr_threshold);
+
+            // apply russian roulette
             active &= sampler->next_1d(active) < q || !perform_rr;
             dr::masked(throughput, perform_rr) *= dr::rcp(dr::detach(q));
 
             active &= depth < (uint32_t) m_max_depth;
-            if (dr::none_or<false>(active))
+            if (dr::none_or<false>(active)) {
+                terminate_ray(ls);
                 return;
+            }
 
             // ----------------------- Sampling the RTE -----------------------
             Mask active_medium  = active && (medium != nullptr);
@@ -219,12 +486,13 @@ public:
             Mask is_spectral = active_medium;
             Mask not_spectral = false;
             Float ddis_threshold = -1.f;
+            split_weight_rr = 1.f;
 
             if (dr::any_or<true>(active_medium)) {
                 is_spectral &= medium->has_spectral_extinction();
                 not_spectral = !is_spectral && active_medium;
 
-                dr::masked(ddis_threshold, active_medium && m_enable_ddis) =
+                dr::masked(ddis_threshold, active_medium && m_ddis_enable) =
                     medium->ddis_threshold();
             }
 
@@ -367,18 +635,28 @@ public:
 
                 act_medium_scatter = !escaped_medium && active_medium;
                 dr::masked(depth, act_medium_scatter) += 1;
+                dr::masked(local_depth, act_medium_scatter) += 1;
                 dr::masked(last_scatter_event, act_medium_scatter) = mei;
             }
 
             // Dont estimate lighting if we exceeded number of bounces
             active &= depth < (uint32_t) m_max_depth;
+            active &= !(has_flag(path_flag, PathTypeFlag::Clone)
+                        && local_depth > (uint32_t)m_nle_max_clone_depth);
             act_medium_scatter &= active;
-
             if (dr::any_or<true>(act_medium_scatter)) {
 
                 PhaseFunctionContext phase_ctx(sampler);
                 auto phase = mei.medium->phase_function();
                 auto ddis_phase = mei.medium->ddis_phase_function();
+
+                // --------------------- NLE setup ---------------------
+                Mask nle_enable = act_medium_scatter && m_nle_enable;
+
+                // Clone creation: mother at/past nle_first_clone_depth, spaced by nle_nee_per_clone
+                Mask create_clone = active && is_mother
+                    && depth >= (uint32_t)m_nle_first_clone_depth
+                    && ((depth - (uint32_t)m_nle_first_clone_depth) % (uint32_t)m_nle_nee_per_clone == 0);
 
                 // --------------------- Emitter sampling ---------------------
                 Mask sample_emitters = mei.medium->use_emitter_sampling();
@@ -387,58 +665,118 @@ public:
                 specular_chain |= act_medium_scatter && !sample_emitters;
 
                 Mask active_e = act_medium_scatter && sample_emitters;
-
                 Mask perform_ddis = ddis_threshold > 0.f && active_e;
+                Mask active_nee = active_e;
+
+                if (dr::any_or<true>(nle_enable)) {
+                    // DDIS: restrict to create_clone or existing clone when NLE is on
+                    dr::masked(perform_ddis, nle_enable) &=
+                        (depth <= (uint32_t)m_nle_first_clone_depth) || (create_clone || is_clone);
+
+                    // NEE gating:
+                    //  Mother: before nle_first_clone_depth only
+                    //  First clone (creation_depth == nle_first_clone_depth): always NEE
+                    //  Subsequent clones: last nle_nee_per_clone scatters only
+                    // local_depth is already incremented → 1-indexed at NEE time
+                    dr::masked(active_nee, nle_enable) &=
+                        (depth <= (uint32_t)m_nle_first_clone_depth)
+                        || (is_clone
+                        && ( (depth - local_depth) == (uint32_t) m_nle_first_clone_depth
+                           || local_depth > (uint32_t) (m_nle_max_clone_depth - m_nle_nee_per_clone)));
+                }
+
                 MediumInteraction3f ddis_mei = mei;
 
                 if (dr::any_or<true>(active_e)) {
-                    auto [emitted, ds] = sample_emitter(mei, scene, sampler, medium, channel, active_e);
-                    auto [phase_val, phase_pdf] = phase->eval_pdf(phase_ctx, mei, ds.d, active_e);
+                    // Externalize direction sampling so ds.d is available for DDIS setup
+                    auto [ds, emitter_val] = scene->sample_emitter_direction(
+                        mei, sampler->next_2d(active_e), false, active_e);
+                    dr::masked(emitter_val, ds.pdf == 0.f) = 0.f;
 
                     if (dr::any_or<true>(perform_ddis)) {
-                        // Set ddis incoming direction towards emitter
-                        dr::masked(ddis_mei.wi, perform_ddis) = -ds.d;
+                        // DDIS incoming direction towards emitter
+                        dr::masked(ddis_mei.wi,       perform_ddis) = -ds.d;
                         dr::masked(ddis_mei.sh_frame, perform_ddis) = Frame3f(-ds.d);
-
-                        Float ddis_phase_pdf;
-                        std::tie(std::ignore, ddis_phase_pdf) =
-                            ddis_phase->eval_pdf(phase_ctx, ddis_mei, ds.d, perform_ddis);
-
-                        // Compute mixture pdf accounting for DDIS probability
-                        dr::masked(phase_pdf, perform_ddis) =
-                            (1.f - ddis_threshold) * phase_pdf + ddis_threshold * ddis_phase_pdf;
                     }
 
-                    dr::masked(result, active_e) += throughput * phase_val * emitted *
-                                                    mis_weight(ds.pdf, dr::select(ds.delta, 0.f, phase_pdf));
+                    if (dr::any_or<true>(active_nee)) {
+
+                        auto [phase_val, phase_pdf] = phase->eval_pdf(phase_ctx, mei, ds.d, active_nee);
+
+                        // With DDIS, we make the assumption that the illumination is collimated
+                        // and thus direction pdf is 0. in the MIS weight.
+
+                        auto [emitted, ds_out] = sample_emitter(
+                            ds, emitter_val, mei, scene, sampler, medium, channel, active_nee);
+                        dr::masked(result, active_nee) += throughput * phase_val * emitted *
+                            mis_weight(ds.pdf, dr::select(ds.delta, 0.f, phase_pdf));
+                    }
                 }
 
                 // ------------------ Phase function sampling -----------------
                 dr::masked(phase, !act_medium_scatter) = nullptr;
 
-                Float eps = sampler->next_1d(active_medium);
-                Mask active_ddis = (eps < ddis_threshold) && act_medium_scatter && perform_ddis;
+                auto [wo, phase_weight, phase_pdf] = phase->sample(phase_ctx, mei,
+                        sampler->next_1d(act_medium_scatter),
+                        sampler->next_2d(act_medium_scatter),
+                        act_medium_scatter);
 
-                MediumInteraction3f sample_mei = dr::select(active_ddis, ddis_mei, mei);
-                auto sample_phase = dr::select(active_ddis, ddis_phase, phase);
+                // --------------------- NLE clone creation --------------------
+                if (dr::any_or<true>(create_clone)) {
+                    PathState mps = ls.current;
+                    mps.ray                         = mei.spawn_ray(wo);
+                    mps.throughput                  *= phase_weight;
+                    mps.last_scatter_direction_pdf  = phase_pdf;
+                    // Requires a count of two to account for the continuing clone.
+                    write(Int32(0), ls, mps, 2, create_clone);
 
-                // ddis off -> phase_weight: p(mu)/pdf(mu); phase_pdf: pdf(mu);
-                // ddis on  -> phase_weight: p(mu')/pdf(mu'); phase_pdf: pdf(mu');
-                auto [wo, phase_weight, phase_pdf] = sample_phase->sample(phase_ctx, sample_mei,
-                    sampler->next_1d(act_medium_scatter),
-                    sampler->next_2d(act_medium_scatter),
-                    act_medium_scatter);
+                    dr::masked(path_flag,   create_clone) = +PathTypeFlag::Clone;
+                    dr::masked(local_depth, create_clone) = UInt32(0);
 
-                act_medium_scatter &= phase_pdf > 0.f;
+                    is_mother = !create_clone;
+                    is_clone = create_clone;
+                }
 
+                // ------------------------ DDIS -------------------------------
                 if (dr::any_or<true>(perform_ddis)) {
-                    auto [natural_val, natural_pdf] = phase->eval_pdf(phase_ctx, mei, wo, perform_ddis);
-                    auto [ddis_val, ddis_pdf] = ddis_phase->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
+                    Spectrum natural_val = phase_weight * phase_pdf;
+                    Float natural_pdf = phase_pdf;
+
+                    Float eps = sampler->next_1d(active_medium);
+                    Mask active_ddis = (eps < ddis_threshold) && act_medium_scatter && perform_ddis;
+
+                    if(dr::any_or<true>(active_ddis)) {
+                        auto [ddis_wo, ddis_weight, ddis_pdf] =
+                            ddis_phase->sample(phase_ctx, ddis_mei,
+                            sampler->next_1d(active_ddis),
+                            sampler->next_2d(active_ddis),
+                            active_ddis);
+
+                        dr::masked(wo, active_ddis) = ddis_wo;
+
+                        auto [new_natural_val, new_natural_pdf] =
+                            phase->eval_pdf(phase_ctx, mei, wo, active_ddis);
+                        dr::masked(natural_val, active_ddis) = new_natural_val;
+                        dr::masked(natural_pdf, active_ddis) = new_natural_pdf;
+                    }
+
+                    auto [ddis_val, ddis_pdf] =
+                        ddis_phase->eval_pdf(phase_ctx, ddis_mei, wo, perform_ddis);
 
                     dr::masked(phase_pdf, perform_ddis) =
                         ((1.f - ddis_threshold) * natural_pdf + ddis_threshold * ddis_pdf);
                     dr::masked(phase_weight, perform_ddis) = natural_val / phase_pdf;
+
+                    // split_weight computed for all perform_ddis lanes; pbs_enable gates PBS below
+                    dr::masked(split_weight_rr, perform_ddis) =
+                        dr::max(unpolarized_spectrum(ddis_val * throughput));
+                    dr::masked(split_weight_rr, perform_ddis) *=
+                        dr::select(depth <= 7, 1.5f, 1.f+0.1/Float(depth));
                 }
+
+                act_medium_scatter &= phase_pdf > 0.f;
+
+                // ----------------------- Update Path -------------------------
 
                 Ray3f new_ray  = mei.spawn_ray(wo);
                 dr::masked(ray, act_medium_scatter) = new_ray;
@@ -453,15 +791,15 @@ public:
 
             if (dr::any_or<true>(active_surface)) {
                 // ---------------------- Hide area emitters ----------------------
-                if (m_hide_emitters && dr::any_or<true>(ls.depth == 0u)) {
+                if (m_hide_emitters && dr::any_or<true>(depth == 0u)) {
                     // Are we on the first segment and did we hit an area emitter?
                     // If so, skip all area emitters along this ray
                     Mask skip_emitters = si.is_valid() &&
                                          (si.shape->emitter() != nullptr) &&
-                                         (ls.depth == 0);
+                                         (depth == 0);
 
                     if (dr::any_or<true>(skip_emitters)) {
-                        Ray3f ray = si.spawn_ray(ls.ray.d);
+                        Ray3f ray = si.spawn_ray(ray.d);
                         PreliminaryIntersection3f pi =
                             Base::skip_area_emitters(scene, ray, true, skip_emitters);
                         SurfaceInteraction3f si_after_skip =
@@ -491,14 +829,44 @@ public:
                 }
             }
             active_surface &= si.is_valid();
+            active &= !(has_flag(path_flag, PathTypeFlag::Clone)
+                        && (local_depth + 1)> (uint32_t)m_nle_max_clone_depth);
+            active_surface &= active;
+
             if (dr::any_or<true>(active_surface)) {
+
+                // --------------------- NLE setup (surface) ---------------------
+                Mask nle_enable = active_surface && m_nle_enable;
+
+
+                // Tentative clone creation (non_null_bsdf not yet known)
+                Mask create_clone = nle_enable
+                    && is_mother
+                    && (depth + 1) >= (uint32_t)m_nle_first_clone_depth
+                    && ((depth + 1 - (uint32_t)m_nle_first_clone_depth) % (uint32_t)m_nle_nee_per_clone == 0);
+
                 // --------------------- Emitter sampling ---------------------
                 BSDFContext ctx;
                 BSDFPtr bsdf  = si.bsdf(ray);
-                Mask active_e = active_surface && has_flag(bsdf->flags(), BSDFFlags::Smooth) && (depth + 1 < (uint32_t) m_max_depth);
 
-                // Initialize variables required for a DDIS
-                Mask perform_ddis = (medium != nullptr) && (ddis_threshold > 0.f) && active_e;
+                Mask active_e = active_surface && has_flag(bsdf->flags(), BSDFFlags::Smooth) && (depth + 1 < (uint32_t) m_max_depth);
+                Mask perform_ddis = m_ddis_enable_surface
+                                    && (medium != nullptr)
+                                    && (ddis_threshold > 0.f)
+                                    && active_e;
+                Mask active_nee = active_e;
+
+                if (dr::any_or<true>(nle_enable)) {
+                    dr::masked(perform_ddis, nle_enable) &=
+                        ((depth+1) <= (uint32_t)m_nle_first_clone_depth) || (create_clone || is_clone);
+
+                    dr::masked(active_nee, nle_enable) &=
+                        ((depth + 1) <= (uint32_t)m_nle_first_clone_depth)
+                        || (is_clone
+                            && ( (depth - local_depth) == (uint32_t) m_nle_first_clone_depth
+                            || (local_depth + 1) > (uint32_t) (m_nle_max_clone_depth - m_nle_nee_per_clone)));
+                }
+
                 MediumInteraction3f ddis_mei = dr::zeros<MediumInteraction3f>();
                 ddis_mei.p = si.p;
                 ddis_mei.time = si.time;
@@ -507,7 +875,9 @@ public:
                 PhaseFunctionContext phase_ctx(sampler);
 
                 if (likely(dr::any_or<true>(active_e))) {
-                    auto [emitted, ds] = sample_emitter(si, scene, sampler, medium, channel, active_e);
+                    auto [ds, emitter_val] = scene->sample_emitter_direction(
+                        si, sampler->next_2d(active_e), false, active_e);
+                    dr::masked(emitter_val, ds.pdf == 0.f) = 0.f;
 
                     if (dr::any_or<true>(perform_ddis)) {
                         // Set ddis incoming direction towards emitter
@@ -523,13 +893,56 @@ public:
                     // Determine probability of having sampled that same
                     // direction using BSDF sampling.
                     Float bsdf_pdf = bsdf->pdf(ctx, si, wo, active_e);
-                    result[active_e] += throughput * bsdf_val * mis_weight(ds.pdf, dr::select(ds.delta, 0.f, bsdf_pdf)) * emitted;
+
+                    if (dr::any_or<true>(active_nee)) {
+                        auto [emitted, ds_out] = sample_emitter(
+                            ds, emitter_val, si, scene, sampler, medium, channel, active_nee);
+                        dr::masked(result, active_nee) += throughput * bsdf_val *
+                            mis_weight(ds.pdf, dr::select(ds.delta, 0.f, bsdf_pdf)) * emitted;
+                    }
                 }
 
                 // ----------------------- BSDF sampling ----------------------
                 auto [bs, bsdf_val] = bsdf->sample(ctx, si, sampler->next_1d(active_surface),
                                                    sampler->next_2d(active_surface), active_surface);
 
+                Mask non_null_bsdf = active_surface && !has_flag(bs.sampled_type, BSDFFlags::Null);
+
+                // Finalize clone creation condition
+                create_clone &= non_null_bsdf;
+
+                // --------------------- NLE clone creation --------------------
+                if (dr::any_or<true>(create_clone)) {
+                    Spectrum bsdf_val_world =
+                        si.to_world_mueller(bsdf_val, -bs.wo, si.wi);
+
+                    PathState mps = ls.current;
+                    mps.ray                         = si.spawn_ray(si.to_world(bs.wo));
+                    mps.throughput                  *= bsdf_val_world;
+                    mps.eta                         *= bs.eta;
+                    mps.last_scatter_direction_pdf  = bs.pdf;
+
+                    // create_clone already ensures that this is a non Null BSDF
+                    mps.depth               += 1;
+                    mps.last_scatter_event  = si;
+                    mps.valid_ray           = true;
+
+                    mps.specular_chain = specular_chain || has_flag(bs.sampled_type, BSDFFlags::Delta);
+                    mps.specular_chain &= !(active_surface && has_flag(bs.sampled_type, BSDFFlags::Smooth));
+
+                    Mask has_medium_trans = create_clone && active_surface && si.is_medium_transition();
+                    dr::masked(mps.medium, has_medium_trans) = si.target_medium(si.spawn_ray(si.to_world(bs.wo)).d);
+
+                    write(Int32(0), ls, mps, UInt32(2), create_clone);
+
+                    dr::masked(path_flag,      create_clone) = (uint32_t)PathTypeFlag::Clone;
+                    dr::masked(local_depth,    create_clone) = UInt32(0);
+
+                    is_mother = !create_clone;
+                    is_clone = create_clone;
+                }
+
+                // ------------------------- DDIS ------------------------------
                 if (dr::any_or<true>(perform_ddis)) {
 
                     auto ddis_phase = medium->ddis_phase_function();
@@ -565,8 +978,7 @@ public:
                         dr::masked(natural_pdf, active_ddis) = new_natural_pdf;
                     }
 
-                    Float ddis_pdf;
-                    std::tie(std::ignore, ddis_pdf) =
+                    auto [ddis_val, ddis_pdf] =
                         ddis_phase->eval_pdf(phase_ctx, ddis_mei,
                                                       si.to_world(bs.wo),
                                                       perform_ddis);
@@ -574,6 +986,11 @@ public:
                     dr::masked(bs.pdf, perform_ddis) =
                         ((1.f - ddis_threshold) * natural_pdf + ddis_threshold * ddis_pdf);
                     dr::masked(bsdf_val, perform_ddis) = natural_val / bs.pdf;
+
+                    dr::masked(split_weight_rr, perform_ddis) =
+                        dr::max(unpolarized_spectrum(ddis_val * throughput));
+                    dr::masked(split_weight_rr, perform_ddis) *=
+                        dr::select(depth <= 7, 1.5f, 1.f+0.1/Float(depth));
                 }
 
                 bsdf_val = si.to_world_mueller(bsdf_val, -bs.wo, si.wi);
@@ -584,8 +1001,8 @@ public:
                 Ray3f bsdf_ray                  = si.spawn_ray(si.to_world(bs.wo));
                 dr::masked(ray, active_surface) = bsdf_ray;
 
-                Mask non_null_bsdf = active_surface && !has_flag(bs.sampled_type, BSDFFlags::Null);
                 dr::masked(depth, non_null_bsdf) += 1;
+                dr::masked(local_depth, non_null_bsdf) += 1;
 
                 // update the last scatter PDF event if we encountered a non-null scatter event
                 dr::masked(last_scatter_event, non_null_bsdf) = si;
@@ -598,22 +1015,39 @@ public:
                 Mask has_medium_trans                = active_surface && si.is_medium_transition();
                 dr::masked(medium, has_medium_trans) = si.target_medium(ray.d);
             }
+
+            // --------------- Prediction Based Splitting ------------------
+            Mask pbs_enable = (active_surface || active_medium) && m_pbs_enable
+                              && ((is_mother && depth < m_nle_first_clone_depth) || !is_mother);
+            Mask split = pbs_enable && split_weight_rr > m_pbs_min_split_threshold;
+            split &= ls.stack_counter < Int32(LS_STACK_SIZE) - 1;
+
+            if (dr::any_or<true>(split)) {
+                UInt32 split_count = dr::minimum(m_pbs_max_split_count, UInt32(split_weight_rr));
+                dr::masked(throughput, split) /= Float(split_count);
+                dr::masked(path_flag, split) |= +PathTypeFlag::Split;
+                push(ls, ls.current, split_count, split);
+            }
+
             active &= (active_surface | active_medium);
+            if (dr::any_or<true>(!active)) {
+                terminate_ray(ls);
+            }
         },
         "Volpath integrator");
 
-        return { ls.result, ls.valid_ray };
+        return { ls.result, ls.current.valid_ray };
     }
 
-    /// Samples an emitter in the scene and evaluates its attenuated contribution
+    /// Inner overload: ds and emitter_val pre-sampled; does shadow/transmittance traversal only.
     template <typename Interaction>
     std::tuple<Spectrum, DirectionSample3f>
-    sample_emitter(const Interaction &ref_interaction, const Scene *scene,
+    sample_emitter(DirectionSample3f ds, Spectrum emitter_val,
+                   const Interaction &ref_interaction, const Scene *scene,
                    Sampler *sampler, MediumPtr medium,
                    UInt32 channel, Mask active) const {
         Spectrum transmittance(1.0f);
 
-        auto [ds, emitter_val] = scene->sample_emitter_direction(ref_interaction, sampler->next_2d(active), false, active);
         dr::masked(emitter_val, ds.pdf == 0.f) = 0.f;
         active &= (ds.pdf != 0.f);
 
@@ -689,8 +1123,6 @@ public:
             if (dr::any_or<true>(active_medium)) {
                 // Prepare extremum traversal
                 auto extremum = medium->extremum_structure();
-                // auto [mei, mint, maxt] =
-                //     medium->prepare_medium_traversal(ray, active_medium);
 
                 Float sample1 = sampler->next_1d();
                 Float sample2 = sampler->next_1d();
@@ -829,6 +1261,19 @@ public:
         return { ls.transmittance * emitter_val, dir_sample };
     }
 
+    /// Outer overload: samples the emitter direction then calls the inner overload.
+    template <typename Interaction>
+    std::tuple<Spectrum, DirectionSample3f>
+    sample_emitter(const Interaction &ref_interaction, const Scene *scene,
+                   Sampler *sampler, MediumPtr medium,
+                   UInt32 channel, Mask active) const {
+        Spectrum transmittance(1.0f);
+
+        auto [ds, emitter_val] = scene->sample_emitter_direction(ref_interaction, sampler->next_2d(active), false, active);
+        return sample_emitter(ds, emitter_val, ref_interaction, scene, sampler, medium, channel, active);
+    }
+
+
     //! @}
     // =============================================================
 
@@ -851,7 +1296,19 @@ public:
 private:
     ScalarFloat m_rr_factor;
 
-    bool m_enable_ddis;
+    bool m_ddis_enable;
+    bool m_ddis_enable_surface;
+
+    bool m_pbs_enable;
+    ScalarUInt32 m_pbs_max_split_count;
+    ScalarFloat m_pbs_min_split_threshold;
+    ScalarFloat m_pbs_crit_rr_threshold;
+    ScalarFloat m_pbs_min_rr_threshold;
+
+    bool m_nle_enable;
+    ScalarUInt32 m_nle_first_clone_depth;
+    ScalarUInt32 m_nle_max_clone_depth;
+    ScalarUInt32 m_nle_nee_per_clone;
 };
 
 MI_EXPORT_PLUGIN(EOVolumetricPathIntegrator)


### PR DESCRIPTION
## Description

Hello, 
This PR closely follows the DDIS change to propose an implementation of the remaining variance reduction methods from the VROOM paper (Buras and Mayer, 2011). 

What's new:
- Prediction Based Splitting (PBS): allows to split paths given a prediction weight (based on DDIS). This reduces the impact of fireflies for given trajectories. It also uses the same weight to apply Russian Roulette on split and cloned path (see next point).
- N-tuple Local Estimate: Tracks a "mother" path that does not apply DDIS. This path gets periodically cloned into "clone" paths that apply DDIS and Splitting. This allows to reduce variance for scenes with large AOTs.

Design Points:
- The design makes its best effort to allow DDIS, PBS, and NLE to be used independently and with any other methods.
- A stack approach was used to deal with splitting and cloning of paths. This involves a path stack and a counts stack. The latter represents the number of times the path has to be used. Note that this approach is not very suited to llvm approaches as all elements of the stack have to traversed for any push or pop operation.
- A path type flag was introduced to better track and manipulate the type of path we are in.

Parameter Tuning: 
The resulting variance and fireflies are very sensitive to parameter tuning. The defaults were chosen following the parameters provided in the original paper, but might benefit from further tuning.

## Testing

Testing has so far been limited to an homogeneous cloud layer. Further tests are required.
On this note, a bespoke render test suite for eovolpath and its various settings would be extremely valuable.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for  `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)