### PR TITLE
[Enhancement] Periodic extremum grid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ strive to document breaking API changes in the release notes below.
 - Implement prediction-based splitting (PBS) and N-tuple local estimate (NLE)
   variance reduction methods, completing work on VROOM method support in the
   `eovolpath` integrator.
+- Add an experimental implementation for periodic boundaries of extremum grid
+  structures.
 
 ## v0.5.0 (9th June 2026)
 

--- a/src/eradiate_plugins/extremum/extremum_grid.cpp
+++ b/src/eradiate_plugins/extremum/extremum_grid.cpp
@@ -35,6 +35,15 @@ Extremum grid structure (:monosp:`extremum_grid`)
      the underlying volume. Set to [0,0,0] to trigger an adaptive resolution
      routine. Default: [1,1,1]
 
+ * - wrap_mode
+   - |string|
+   - **EXPERIMENTAL** Specifies how to handle extremum queries and traversal
+     outside its data definition. Values should be one of :monosp:`clamp`,
+     :monosp:`repeat`, :monosp:`mirror`. Should match the underlying volume to
+     ensure consistent extremum representation. Note that this is experimental
+     until proper periodic boundary conditions are defined for media.
+     Default: :monosp:`clamp`
+
 This plugin creates a regular grid structure storing local extremum values for
 efficient delta tracking in heterogeneous media. The grid is constructed
 by querying the extinction volume's extrema over each grid cell.
@@ -42,6 +51,10 @@ by querying the extinction volume's extrema over each grid cell.
 At runtime, DDA (Digital Differential Analyzer) traversal through the grid provides
 tight-fitting local extrema, dramatically reducing null collisions in media with
 high spatial variance (*e.g.* clouds, fog).
+
+Note that the current implementation expects :monosp:`to_world` and
+:monosp:`scale` to match that of its volume and media to ensure correct extremum
+bounds and periodic behaviours.;
 */
 
 template <typename Float, typename Spectrum>
@@ -75,6 +88,17 @@ public:
         m_to_local = props.get<ScalarAffineTransform4f>("to_world", ScalarAffineTransform4f()).inverse();
         m_scale = props.get<ScalarFloat>("scale", 1.0f);
 
+        std::string_view wrap_mode_str = props.get<std::string_view>("wrap_mode", "clamp");
+        if (wrap_mode_str == "repeat")
+            m_wrap_mode = dr::WrapMode::Repeat;
+        else if (wrap_mode_str == "mirror")
+            m_wrap_mode = dr::WrapMode::Mirror;
+        else if (wrap_mode_str == "clamp")
+            m_wrap_mode = dr::WrapMode::Clamp;
+        else
+            Throw("Invalid wrap_mode \"%s\", must be one of: \"repeat\", "
+                  "\"mirror\", or \"clamp\"!", wrap_mode_str);
+
         // Resolution Parameters
         m_resolution = props.get<ScalarVector3i>("resolution", ScalarVector3i(1,1,1));
 
@@ -84,12 +108,19 @@ public:
             m_resolution = find_resolution(m_volume);
         }
 
+        for (size_t i = 0; i < 3; ++i)
+            m_inv_resolution[i] = dr::divisor<int32_t>((int32_t) m_resolution[i]);
+
+
         build_grid(m_volume.get(), m_resolution);
     }
 
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
         if (m_adaptive) {
             m_resolution = find_resolution(m_volume.get());
+
+            for (size_t i = 0; i < 3; ++i)
+                m_inv_resolution[i] = dr::divisor<int32_t>((int32_t) m_resolution[i]);
         }
         build_grid(m_volume.get(), m_resolution);
     }
@@ -118,11 +149,10 @@ public:
     std::tuple<Float, Float> eval_1(const Interaction3f &it,
                                     Mask active) const override {
         Point3f po = m_to_local * it.p;
-        // Effectively acts as a clamp wrapping policy
-        Vector3i pi =
-            dr::clip(Vector3i(po * m_resolution), 0, m_resolution - 1);
-        UInt32 idx = dr::fmadd(dr::fmadd(pi.z(), m_resolution.y(), pi.y()),
-                               m_resolution.x(), pi.x());
+        Vector3i piw = wrap(dr::floor2int<Vector3i>(po * m_resolution));
+
+        UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
+                               m_resolution.x(), piw.x());
         Vector2f extremum = dr::gather<Vector2f>(m_extremum_grid, idx, active);
         return { extremum.x(), extremum.y() };
     }
@@ -134,10 +164,27 @@ public:
     }
 
     std::string to_string() const override {
+        std::string wrap_str;
+        switch (m_wrap_mode)
+        {
+        case dr::WrapMode::Clamp:
+            wrap_str = "Clamp";
+            break;
+        case dr::WrapMode::Repeat:
+            wrap_str = "Repeat";
+            break;
+        case dr::WrapMode::Mirror:
+            wrap_str = "Mirror";
+            break;
+        default:
+            break;
+        }
+
         std::ostringstream oss;
         oss << "ExtremumGrid[" << std::endl
             << "  resolution = " << m_resolution << "," << std::endl
             << "  bbox = " << m_bbox << "," << std::endl
+            << "  wrap_mode = " << wrap_str << "," << std::endl
             << "]";
         return oss.str();
     }
@@ -244,6 +291,9 @@ private:
 
             result[i] = left_cost <= right_cost ? left : right;
         }
+
+        // safety net, result should never be outside those bounds.
+        result = dr::clip(result, 1, m_resolution - 1);
         return result;
     }
 
@@ -386,29 +436,10 @@ private:
         auto inf_t     = local_ray.d == 0.f;
         auto d_pos     = local_ray.d >= 0.f;
 
-        // Per-axis intersection of the ray with the grid bounds
-        Vector3f t_min_v  = -local_ray.o * rcp_d;
-        Vector3f t_max_v  = (res - local_ray.o) * rcp_d;
-        Vector3f t_min_v2 = dr::minimum(t_min_v, t_max_v);
-        Vector3f t_max_v2 = dr::maximum(t_min_v, t_max_v);
+        Float t_min = mint;
+        Float t_max = maxt;
 
-        // Disable extent computation for dims where the ray direction is zero
-        dr::masked(t_max_v2, inf_t) = dr::Infinity<Float>;
-        dr::masked(t_min_v2, inf_t) = -dr::Infinity<Float>;
-
-        // Reduce constraints to a single ray interval
-        Float t_min = dr::maximum(dr::max(t_min_v2), mint);
-        Float t_max = dr::minimum(dr::min(t_max_v2), maxt);
-        mint        = t_min;
-        maxt        = t_max;
-
-        // Only run the DDA algorithm if the interval is nonempty
-        active &= (t_max > t_min) & dr::isfinite(t_max);
-
-        // Deactivate rays that have zero direction along any axis
-        // and whose origin along that axis is outside the grid bounds
-        active &=
-            dr::all(!inf_t || ((0.f <= local_ray.o) && (local_ray.o <= res)));
+        active &= t_max > t_min && dr::isfinite(t_max);
 
         // Advance the ray to the start of the interval
         local_ray.o = dr::fmadd(local_ray.d, t_min, local_ray.o);
@@ -419,8 +450,13 @@ private:
         Vector3i step      = dr::select(d_pos, 1, -1);
         Vector3f abs_rcp_d = abs(rcp_d);
 
+        // #NOFIX: Possibly overflow in case the number of cells in the domain
+        // is larger than the range of int32. This check prevents this from
+        // happening, future iterations will probably change the way periodic bounds
+        // will be implemented.
+
         // Integer grid coordinates
-        Vector3i pi = dr::clip(Vector3i(local_ray.o), 0, m_resolution - 1);
+        Vector3i pi = dr::floor2int<Vector3i>(local_ray.o);
 
         // Fractional entry position
         Vector3f p0 = local_ray.o - Vector3f(pi);
@@ -470,8 +506,9 @@ private:
 
             // Note: not multiplying the index by 2 because we gather using
             // Vector2f.
-            UInt32 idx = dr::fmadd(dr::fmadd(pi.z(), m_resolution.y(), pi.y()),
-                                   m_resolution.x(), pi.x());
+            Vector3i piw = wrap(pi);
+            UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
+                                   m_resolution.x(), piw.x());
 
             const Vector2f extremum    = dr::gather<Vector2f>(m_extremum_grid, idx);
 
@@ -490,15 +527,39 @@ private:
             dr::masked(pi, mask && advance) += step;
             dr::masked(t_rem, advance) -= dt;
 
-            active &= dr::all((pi >= 0)
-                      && (pi < m_resolution))
-                      && (t_rem > 0.f);
+            active &= t_rem > 0.f;
         },
         "DDA Traversal");
 
         return ls.state;
     };
 
+    /**
+     * \brief Applies the configured texture wrapping mode to an integer
+     * position
+     */
+    Vector3i wrap(const Vector3i &pos) const {
+        if (m_wrap_mode == dr::WrapMode::Clamp) {
+            return dr::clip(pos, 0, m_resolution - 1);
+        } else {
+            Vector3i value_shift_neg = dr::select(pos < 0, pos + 1, pos);
+
+            Vector3i div;
+            for (size_t i = 0; i < 3; ++i)
+                div[i] = m_inv_resolution[i](value_shift_neg[i]);
+
+            Vector3i mod = pos - div * m_resolution;
+            mod[mod < 0] += Vector3i(m_resolution);
+
+            if (m_wrap_mode == dr::WrapMode::Mirror)
+                // Starting at 0, flip the texture every other repetition
+                // (flip when: even number of repetitions in negative direction,
+                // or odd number of repetitions in positive direction)
+                mod = dr::select(((div & 1) == 0) ^ (pos < 0), mod, m_resolution - 1 - mod);
+
+            return mod;
+        }
+    }
 
 private:
     /// Grid storing pre-computed local majorants
@@ -509,6 +570,9 @@ private:
 
     bool m_adaptive;
     ScalarVector3i m_resolution;
+    dr::divisor<int32_t> m_inv_resolution[3];
+    dr::WrapMode m_wrap_mode;
+
     ScalarAffineTransform4f m_to_local;
 };
 


### PR DESCRIPTION
## Description

This PR modifies extremum grid so that periodic conditions are applied to traversal and point queries.
For traversal, this means that the extremum structure does not restrict the min and max distance anymore, and it is the medium's responsibility to provide proper `mint` and `maxt` in `prepare_medium_traversal`. This simplifies the setup required before starting a DDA. 
In the DDA logic, the position index gets wrapped in the same way a texture would. Because the underlying data is not a texture, it needs to reimplement the `wrap` method. For now, this has been kept within the `ExtremumGrid` plugin as I am unsure how we will handle periodic boundaries. 

In practice the extremum grid can be aligned to a `eoheterogenous` medium, which has aabb bounds larger than its `sigma_t` volume. As long as the the extremum grid in aligned with the underlying volume, and that the wrap mode is consistent, this should yield correct majorant and minorant information.

## Testing

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)