### PR TITLE
Implement the particlephase plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ strive to document breaking API changes in the release notes below.
   the underlying `sigma_t` volume bbox. In turns allows to exploit the wrap
   mechanism of the volume and implement periodic boundaries
   (PR [#32](https://github.com/eradiate/mitsuba3/pull/32)).
+- **`particlefieldphase` phase function**: A polarized phase function
+  tabulated on a grid of effective radius and effective variance, each grid
+  entry carrying its own irregular `cos(theta)` discretization. The 4
+  cornering entries at a query point are bilinearly blended using one
+  of 3 proposed methods (PR [#35](https://github.com/eradiate/mitsuba3/pull/35)).
 
 ### Improvements
 

--- a/docs_eradiate/plugin_reference/section_phase.rst
+++ b/docs_eradiate/plugin_reference/section_phase.rst
@@ -14,3 +14,6 @@ radiative transfer:
   matrix form) for polarized light transport through anisotropic media.
 - ``multiphase`` — linearly combines multiple phase functions, enabling
   composite media (*e.g.* a mixture of molecular and aerosol scattering).
+- ``particlefieldphase`` — polarized phase function tabulated on a grid of
+  effective radius and effective variance, read from two spatial fields at
+  the interaction point.

--- a/src/eradiate_plugins/phase/CMakeLists.txt
+++ b/src/eradiate_plugins/phase/CMakeLists.txt
@@ -4,5 +4,6 @@ add_plugin(rayleigh_polarized rayleigh_polarized.cpp)
 add_plugin(tabphase_irregular tabphase_irregular.cpp)
 add_plugin(tabphase_polarized tabphase_polarized.cpp)
 add_plugin(multiphase multiphase.cpp)
+add_plugin(particlefieldphase particlefieldphase.cpp)
 
 set(MI_PLUGIN_TARGETS "${MI_PLUGIN_TARGETS}" PARENT_SCOPE)

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -234,8 +234,8 @@ public:
             weight_values.push_back(eval_weight(mi, i, active));
             weight_sum += weight_values.back();
         }
-
-        Float inv_weight_sum = dr::rcp(weight_sum);
+        
+        Float inv_weight_sum = dr::select(weight_sum < dr::Epsilon<Float>, 1.0f, dr::rcp(weight_sum));
 
         if (unlikely(ctx.component != (uint32_t) -1)) {
             PhaseFunctionContext ctx2(ctx);

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -187,6 +187,10 @@ public:
                     for (size_t j = 0; j < m_nested_phases.size(); ++j) {
                         if (j == i) continue;
 
+                        // Ensure phases with zero weights are not called at all
+                        Mask mask_j = mask_i && (weight_values[j] > dr::Epsilon<Float>);
+                        if (!dr::any_or<true>(mask_j)) continue;
+                        
                         auto [val_j, pdf_j] = m_nested_phases[j]->eval_pdf(
                             ctx, mi, wo_i, mask_i
                         );
@@ -196,7 +200,7 @@ public:
                     }
 
                     Spectrum w_mis = dr::select(
-                        pdf_mixture > 1e-8f,
+                        pdf_mixture > dr::Epsilon<Float>,
                         phase_value_sum / pdf_mixture,
                         Spectrum(0.f)
                     );
@@ -259,6 +263,11 @@ public:
         Float pdf = 0.f;
 
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
+
+            //Ensure zero weighted phases are never called
+            Mask mask_i = active && (weight_values[i] > dr::Epsilon<Float>);
+            if (!dr::any_or<true>(mask_i)) continue;
+            
             auto [val_i, pdf_i] = m_nested_phases[i]->eval_pdf(ctx, mi, wo, active);
 
             Float phase_weight = weight_values[i] * inv_weight_sum;

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -52,29 +52,29 @@ multiple populations of scattering elements.
 
         <phase type="multiphase">
             <boolean name="use_mis" value="true"/>
-
-            <phase name="phase0" type="isotropic"/>
-            <float name="weight0" value="1.0"/>
-            <phase name="phase1" type="hg">
+            
+            <phase name="phase_0" type="isotropic"/>
+            <float name="weight_0" value="1.0"/>
+            <phase name="phase_1" type="hg">
                 <float name="g" value="0.5"/>
             </phase>
-            <float name="weight1" value="1.0"/>
-            <phase name="phase2" type="hg">
+            <float name="weight_1" value="1.0"/>
+            <phase name="phase_2" type="hg">
                 <float name="g" value="0.2"/>
             </phase>
-            <float name="weight2" value="1.0"/>
+            <float name="weight_2" value="1.0"/>
         </phase>
 
     .. code-tab:: python
 
         'type': 'multiphase',
         'use_mis': True,
-        'phase0': {'type': 'isotropic'},
-        'weight0': 1.0,
-        'phase1': {'type': 'hg', 'g': 0.5},
-        'weight1': 1.0,
-        'phase2': {'type': 'hg', 'g': 0.2},
-        'weight2': 1.0
+        'phase_0': {'type': 'isotropic'},
+        'weight_0': 1.0,
+        'phase_1': {'type': 'hg', 'g': 0.5},
+        'weight_1': 1.0,
+        'phase_2': {'type': 'hg', 'g': 0.2},
+        'weight_2': 1.0
 
 */
 
@@ -94,7 +94,7 @@ public:
         for (auto &prop : props.objects()) {
             if (Base *phase = prop.try_get<Base>()) {
                 m_nested_phases.push_back(phase);
-                m_weights.push_back(props.get_volume<Volume>("weight" + std::to_string(phase_count)));
+                m_weights.push_back(props.get_volume<Volume>("weight_" + std::to_string(phase_count)));
                 phase_count++;
             }
         }
@@ -119,8 +119,8 @@ public:
 
     void traverse(TraversalCallback *cb) override {
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
-            cb->put("phase" + std::to_string(i), m_nested_phases[i], ParamFlags::Differentiable);
-            cb->put("weight" + std::to_string(i), m_weights[i], ParamFlags::Differentiable);
+            cb->put("phase_" + std::to_string(i), m_nested_phases[i], ParamFlags::Differentiable);
+            cb->put("weight_" + std::to_string(i), m_weights[i], ParamFlags::Differentiable);
         }
     }
 

--- a/src/eradiate_plugins/phase/particlefieldphase.cpp
+++ b/src/eradiate_plugins/phase/particlefieldphase.cpp
@@ -1,0 +1,1127 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/string.h>
+#include <mitsuba/render/phase.h>
+#include <mitsuba/render/volume.h>
+#include <mitsuba/render/volumegrid.h>
+#include <mitsuba/render/eradiate/phase_utils.h>
+#include <iomanip>
+#include <sstream>
+
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _phase-particlefieldphase:
+
+Particle field phase function (:monosp:`particlefieldphase`)
+--------------------------------------------------------------
+
+.. pluginparameters::
+
+ * - r_eff_volume
+   - |volume|
+   - The medium's effective radius field.
+   - |exposed|
+
+ * - v_eff_volume
+   - |volume|
+   - The medium's effective variance field.
+   - |exposed|
+
+ * - r_eff_grid
+   - |float array|
+   - The regularly-spaced ``r_eff`` values the tabulation grid is defined
+     at. Its length is the tabulation grid's node count along the ``r_eff``
+     axis.
+   - |exposed|
+
+ * - v_eff_grid
+   - |float array|
+   - The regularly-spaced ``v_eff`` values the tabulation grid is defined
+     at. Its length is the tabulation grid's node count along the ``v_eff``
+     axis.
+   - |exposed|
+
+ * - nodes
+   - |float array|
+   - The per-entry :math:`\cos\theta` discretizations, concatenated back to
+     back (one sub-range per ``(r_eff, v_eff)`` grid entry, in row-major
+     ``r_eff * n_v + v_eff`` order) — not a single shared grid or union.
+     Each entry's own sub-range must start at -1, end at 1, and be strictly
+     increasing; see ``grid_start``/``grid_len``.
+   - |exposed|
+
+ * - phase_mueller
+   - |float array|
+   - Flat, 6-components-per-node Mueller matrix table, laid out the same way
+     as :ref:`phase-tabphase_polarized`'s ``m11``/``m12``/``m22``/``m33``/
+     ``m34``/``m44`` columns, one row per entry of ``nodes``.
+   - |exposed|
+
+ * - grid_start
+   - |uint array|
+   - Offset of each ``(r_eff, v_eff)`` grid entry's sub-range within the flat
+     ``nodes``/``phase_mueller`` arrays.
+   - |exposed|
+
+ * - grid_len
+   - |uint array|
+   - Length of each ``(r_eff, v_eff)`` grid entry's sub-range within the flat
+     ``nodes``/``phase_mueller`` arrays.
+   - |exposed|
+
+ * - sigma_s_weight
+   - |float array|
+   - Per-entry scattering-probability weight, used to rescale the bilinear
+     blend of the 4 corners cornering a query point.
+   - |exposed|
+
+ * - blending_method
+   - |string|
+   - How the 4 cornering entries are combined when sampling: ``"search"``
+     (default) blends the 4 corners' CDFs and inverts the result via
+     bisection; ``"stochastic"`` picks one cornering entry at random,
+     weighted by its blend weight, and samples it directly; ``"tabulate"``
+     merges the 4 corners onto one common grid on the host before sampling
+     and is scalar-only (construction throws under any JIT variant).
+
+ * - cdf, norm
+   - |float array|
+   - Optional, precomputed replacement for the CDF/normalization this plugin
+     would otherwise build itself from ``nodes``/``phase_mueller`` at
+     construction. Must be provided together. Supplying these bypasses the
+     node-layout validation ``nodes``/``phase_mueller`` otherwise go through.
+
+This plugin implements a phase function tabulated on a 2D grid of effective
+radius (``r_eff``) and effective variance (``v_eff``), each grid entry
+carrying its own tabulated, polarized phase matrix over an irregular
+:math:`\cos\theta` discretization. At a given interaction point,
+``r_eff_volume``/``v_eff_volume`` are evaluated to find the point's
+``(r_eff, v_eff)``, and the 4 grid entries cornering that value are
+bilinearly blended (further rescaled by ``sigma_s_weight``) according to
+``blending_method``.
+*/
+
+template <typename Float, typename Spectrum>
+class ParticleFieldPhaseFunction final : public PhaseFunction<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
+    MI_IMPORT_TYPES(PhaseFunctionContext, Volume, VolumeGrid)
+
+    using FloatStorage  = DynamicBuffer<Float>;
+    using UInt32Storage = DynamicBuffer<UInt32>;
+    using Vector6u      = dr::Array<UInt32, 6>;
+    using Vector6f      = dr::Array<Float, 6>;
+
+    enum class BlendingMethod { Stochastic, Tabulate, Search };
+
+    static BlendingMethod method_from_string(const std::string &method) {
+        if (method == "stochastic")  return BlendingMethod::Stochastic;
+        if (method == "tabulate")    return BlendingMethod::Tabulate;
+        if (method == "search")      return BlendingMethod::Search;
+        Throw("ParticleFieldPhaseFunction: unknown blending_method '%s'", method);
+    }
+
+    static std::string method_to_string(BlendingMethod method) {
+        switch (method) {
+            case BlendingMethod::Stochastic: return "stochastic";
+            case BlendingMethod::Tabulate:   return "tabulate";
+            case BlendingMethod::Search:     return "search";
+            default: Throw("ParticleFieldPhaseFunction: unknown blending method");
+        }
+    }
+
+    struct BilinearWeights {
+        Vector4u idx;
+        Vector4f w;
+    };
+
+    struct BisectionBounds {
+        Vector4u starts, lens;
+        Vector4f norm;
+        Float lo, hi, target, tol;
+        Vector4u lo4_at_hi;
+    };
+
+    template <size_t N>
+    struct ColumnEntry {
+        std::vector<ScalarFloat> x;
+        std::array<std::vector<ScalarFloat>, N> y;
+        ScalarFloat weight = 0.f;
+    };
+
+    template<typename data_t, typename storage_t>
+    storage_t load_grid(const Properties &props, const char *name) {
+        if (props.type(name) == Properties::Type::Object) {
+            ref<Object> obj = props.get<ref<Object>>(name);
+            auto *vg = dynamic_cast<VolumeGrid *>(obj.get());
+            if (!vg)
+                Throw("ParticleFieldPhaseFunction: property \"%s\" must be a VolumeGrid.", name);
+
+            size_t n = (size_t) vg->size().x();
+            const ScalarFloat *buf = vg->data();
+            storage_t out = dr::zeros<storage_t>(n);
+            for (size_t i = 0; i < n; ++i)
+                dr::scatter(out, data_t(buf[i]), UInt32(i));
+            return out;
+        }
+
+        return props.get_any<storage_t>(name);
+    }
+
+    explicit ParticleFieldPhaseFunction(const Properties &props) : Base(props) {
+        m_r_eff_volume = props.get_volume<Volume>("r_eff_volume");
+        m_v_eff_volume = props.get_volume<Volume>("v_eff_volume");
+
+        m_r_eff_grid    = load_grid<Float, FloatStorage>(props, "r_eff_grid");
+        m_v_eff_grid    = load_grid<Float, FloatStorage>(props, "v_eff_grid");
+        m_n_r = (int) dr::width(m_r_eff_grid);
+        m_n_v = (int) dr::width(m_v_eff_grid);
+        m_nodes         = props.get_any<FloatStorage>("nodes");
+        m_mueller       = props.get_any<FloatStorage>("phase_mueller");
+        m_grid_start    = load_grid<UInt32, UInt32Storage>(props, "grid_start");
+        m_grid_len      = load_grid<UInt32, UInt32Storage>(props, "grid_len");
+        m_sigma_s_weight = load_grid<Float, FloatStorage>(props, "sigma_s_weight");
+
+        m_blending_method = method_from_string(props.get<std::string>("blending_method", "search"));
+
+        if (m_blending_method == BlendingMethod::Tabulate && dr::is_jit_v<Float>)
+            Throw("ParticleFieldPhaseFunction: blending_method \"tabulate\" builds its "
+                  "merged CDF on the host from a single lane (dr::slice(u, 0)) and "
+                  "is only correct for the scalar variant; use \"search\" with the "
+                  "llvm/cuda variants.");
+
+        if (dr::width(m_mueller) != dr::width(m_nodes) * 6u)
+            Throw("ParticleFieldPhaseFunction: phase_mueller must have 6 * len(nodes) elements");
+        if (dr::width(m_sigma_s_weight) < (size_t)(m_n_r * m_n_v))
+            Throw("ParticleFieldPhaseFunction: sigma_s_weight must have at least n_r * n_v = %d elements", m_n_r * m_n_v);
+
+        if (props.has_property("cdf") && props.has_property("norm")) {
+            m_cdf  = props.get_any<FloatStorage>("cdf");
+            m_norm = props.get_any<FloatStorage>("norm");
+        } else if (props.has_property("cdf") || props.has_property("norm")) {
+            Throw("ParticleFieldPhaseFunction: cdf and norm must be provided together");
+        } else {
+            precompute_cdf();
+        }
+
+        m_flags = +PhaseFunctionFlags::Anisotropic;
+        m_components.clear();
+        m_components.push_back(m_flags);
+    }
+
+private:
+    /// Validate the node layout, then build the per-entry CDFs and their
+    /// normalization factors (\ref m_cdf, \ref m_norm), vectorized over one
+    /// lane per (r_eff, v_eff) entry.
+    void precompute_cdf() {
+        // Validate the node layout (scalar/host-side: needs concrete
+        // per-entry values to produce meaningful Throw() messages, so this
+        // cannot run as a vectorized JIT loop).
+        size_t total_pts = dr::width(m_nodes);
+        size_t n = (size_t)(m_n_r * m_n_v);
+
+        size_t expected_start = 0;
+
+        for (size_t i = 0; i < n; ++i) {
+            size_t start = dr::slice(m_grid_start, i);
+            size_t len   = dr::slice(m_grid_len,   i);
+
+            if (len < 2)
+                Throw("ParticleFieldPhaseFunction: entry %zu has grid_len=%zu (need >= 2).", i, len);
+            if (start + len > total_pts)
+                Throw("ParticleFieldPhaseFunction: entry %zu slice [%zu, %zu) exceeds nodes size %zu.",
+                      i, start, start + len, total_pts);
+            if (start != expected_start)
+                Throw("ParticleFieldPhaseFunction: entry %zu grid_start=%zu, expected %zu "
+                      "(start/len must form a contiguous concatenation; is 'nodes' a "
+                      "global union instead of the per-entry concatenation?).",
+                      i, start, expected_start);
+            expected_start = start + len;
+
+            bool invalid_s = dr::slice(m_nodes, start) != -1.f;
+            bool invalid_e = dr::slice(m_nodes, start + len - 1) != 1.f;
+            if (invalid_s || invalid_e)
+                Throw(
+                    "ParticleFieldPhaseFunction: invalid phase bound for entry %zu. Start is 1.0: %b, end is 1.0: %b",
+                    i, invalid_s, invalid_e
+                );
+
+            for (size_t k = 1; k < len; ++k) {
+                ScalarFloat prev = dr::slice(m_nodes, start + k - 1);
+                ScalarFloat cur  = dr::slice(m_nodes, start + k);
+                if (cur <= prev)
+                    Throw("ParticleFieldPhaseFunction: entry %zu not strictly increasing: "
+                          "nodes[%zu]=%.17g >= nodes[%zu]=%.17g (%s).",
+                          i, start + k - 1, prev, start + k, cur,
+                          cur == prev ? "duplicate" : "decreasing - descending cos(theta)?");
+            }
+        }
+
+        if (expected_start != total_pts)
+            Throw("ParticleFieldPhaseFunction: entries cover %zu nodes, 'nodes' has %zu.",
+                  expected_start, total_pts);
+
+        // Vectorized CDF construction: two passes on all entries, since the rescale factor
+        // for an entry isn't known until its own accumulation has fully
+        // finished.
+        using MaskStorage = dr::mask_t<FloatStorage>;
+
+        m_cdf  = dr::zeros<FloatStorage>(total_pts);
+        m_norm = dr::zeros<FloatStorage>(n);
+
+        UInt32Storage entry = dr::arange<UInt32Storage>((uint32_t) n);
+        UInt32Storage start = dr::gather<UInt32Storage>(m_grid_start, entry);
+        UInt32Storage len   = dr::gather<UInt32Storage>(m_grid_len,   entry);
+
+        dr::scatter(m_cdf, dr::zeros<FloatStorage>(n), start);
+
+        UInt32Storage k = dr::zeros<UInt32Storage>(n);
+        FloatStorage running = dr::zeros<FloatStorage>(n);
+        MaskStorage active_loop = k < (len - 1u);
+
+        std::tie(k, running, active_loop) = dr::while_loop(
+            std::make_tuple(k, running, active_loop),
+            [](const UInt32Storage &, const FloatStorage &, const MaskStorage &active_loop) {
+                return dr::any(active_loop);
+            },
+            [this, start, len](UInt32Storage &k, FloatStorage &running, MaskStorage &active_loop) {
+                UInt32Storage idx0 = start + k, idx1 = idx0 + 1u;
+
+                FloatStorage x0 = dr::gather<FloatStorage>(m_nodes,   idx0,      active_loop);
+                FloatStorage x1 = dr::gather<FloatStorage>(m_nodes,   idx1,      active_loop);
+                FloatStorage y0 = dr::gather<FloatStorage>(m_mueller, idx0 * 6u, active_loop);
+                FloatStorage y1 = dr::gather<FloatStorage>(m_mueller, idx1 * 6u, active_loop);
+
+                running = dr::select(active_loop,
+                                      running + 0.5f * (y0 + y1) * (x1 - x0),
+                                      running);
+                dr::scatter(m_cdf, running, idx1, active_loop);
+
+                k += 1u;
+                active_loop &= (k < (len - 1u));
+
+                // See Dr.Jit's docs, "Evaluation" > "Caching, continued".
+                dr::eval(k, running, active_loop, m_cdf);
+            },
+            "ParticleFieldPhaseFunction precompute_cdf (accumulate)");
+
+        // `running` now holds each entry's raw (unnormalized) total integral
+        MaskStorage has_mass = running > 0.f;
+        FloatStorage norm_per_entry = dr::select(has_mass, dr::rcp(running), FloatStorage(0.f));
+        dr::scatter(m_norm, norm_per_entry, entry);
+
+        UInt32Storage k2 = dr::zeros<UInt32Storage>(n);
+        MaskStorage active_loop2 = has_mass && (k2 < len);
+
+        std::tie(k2, active_loop2) = dr::while_loop(
+            std::make_tuple(k2, active_loop2),
+            [](const UInt32Storage &, const MaskStorage &active_loop2) {
+                return dr::any(active_loop2);
+            },
+            [this, start, len, norm_per_entry](UInt32Storage &k2, MaskStorage &active_loop2) {
+                UInt32Storage idx = start + k2;
+                FloatStorage val = dr::gather<FloatStorage>(m_cdf, idx, active_loop2);
+                dr::scatter(m_cdf, val * norm_per_entry, idx, active_loop2);
+
+                k2 += 1u;
+                active_loop2 &= (k2 < len);
+
+                // See Dr.Jit's docs, "Evaluation" > "Caching, continued".
+                dr::eval(k2, active_loop2, m_cdf);
+            },
+            "ParticleFieldPhaseFunction precompute_cdf (rescale)");
+    }
+
+    /// Locate the 4 entry indices in the r_eff, v_eff grids cornering the
+    /// (r_eff, v_eff) value at the current interaction point, and compute
+    /// the associated 4 interpolation weights. Assumes the r_eff and v_eff
+    /// grids are regular.
+    BilinearWeights get_bilinear_weights(Float r_eff, Float v_eff,
+                                         Float r_min, Float r_max,
+                                         Float v_min, Float v_max,
+                                         Mask active) const {
+        // r_eff dimension
+        UInt32 ir = 0u;
+        Float tr = Float(0.f);
+        if (m_n_r > 1) {
+            Float dr_   = (r_max - r_min) / Float(m_n_r - 1);
+            ir  = dr::clip(UInt32((r_eff - r_min) / dr_), 0u, UInt32(m_n_r - 2));
+            Float r0 = dr::fmadd(Float(ir),      dr_, r_min);
+            Float r1 = dr::fmadd(Float(ir + 1u), dr_, r_min);
+            Float dri = r1 - r0;
+            Float r_scale = dr::maximum(dr::abs(r_max - r_min), Float(1.f));
+            tr = dr::select(dr::abs(dri) > dr::Epsilon<Float> * r_scale, (r_eff - r0) / dri, Float(0.f));
+        }
+
+        // v_eff dimension
+        UInt32 iv = 0u;
+        Float tv = Float(0.f);
+        if (m_n_v > 1) {
+            Float dv_   = (v_max - v_min) / Float(m_n_v - 1);
+            iv  = dr::clip(UInt32((v_eff - v_min) / dv_), 0u, UInt32(m_n_v - 2));
+            Float v0 = dr::fmadd(Float(iv),      dv_, v_min);
+            Float v1 = dr::fmadd(Float(iv + 1u), dv_, v_min);
+            Float dvi = v1 - v0;
+            Float v_scale = dr::maximum(dr::abs(v_max - v_min), Float(1.f));
+            tv = dr::select(dr::abs(dvi) > dr::Epsilon<Float> * v_scale, (v_eff - v0) / dvi, Float(0.f));
+        }
+
+        // Calculate the geometric weight for each corner and store them in bw
+        Float _tr = 1.f - tr, _tv = 1.f - tv;
+        UInt32 n_v   = m_n_v;
+        UInt32 ir_hi = m_n_r > 1 ? ir + 1u : ir;
+        UInt32 iv_hi = m_n_v > 1 ? iv + 1u : iv;
+        BilinearWeights bw;
+        bw.idx = Vector4u(ir    * n_v + iv,
+                          ir    * n_v + iv_hi,
+                          ir_hi * n_v + iv,
+                          ir_hi * n_v + iv_hi);
+        bw.w   = Vector4f(_tr * _tv, _tr * tv, tr * _tv, tr * tv);
+
+        // Rescale each corner according to its scattering probability
+        Vector4f sca  = dr::gather<Vector4f>(m_sigma_s_weight, bw.idx, active);
+        bw.w         *= sca;
+        Float sca_sum = dr::sum(bw.w);
+        bw.w          = dr::select(sca_sum > dr::Epsilon<Float>, bw.w / sca_sum, bw.w);
+
+        return bw;
+    }
+
+private:
+    // =========================================================================
+    //  Helper methods
+    // =========================================================================
+
+    static constexpr Vector6u k_mueller_offsets() { return Vector6u(0u, 1u, 2u, 3u, 4u, 5u); }
+
+    /// Gather the 6 Mueller matrix components stored at `point`
+    Vector6f gather_mueller(UInt32 point, Mask active) const {
+        return dr::gather<Vector6f>(m_mueller, point * 6u + k_mueller_offsets(), active);
+    }
+
+private:
+    // =========================================================================
+    //  Search methods
+    // =========================================================================
+
+    /// Perform a binary search on 4 contiguous sub-sections of `arr`
+    /// independently. The 4 sub-sections are maintained using 4-value
+    /// vectors of indices (`Vector4u`) and values (`Vector4f`).
+    Vector4u ragged_searchsorted4(const FloatStorage &arr,
+                                   Vector4u start, Vector4u len,
+                                   Float query, Mask active) const {
+        Vector4u lo = start;
+        Vector4u hi = start + len;
+        dr::mask_t<Vector4u> running = dr::mask_t<Vector4u>(active) && (lo < hi);
+
+        std::tie(lo, hi, running) = dr::while_loop(
+            std::make_tuple(lo, hi, running),
+            [](const Vector4u &, const Vector4u &,
+               const dr::mask_t<Vector4u> &running) {
+                return dr::any(running);
+            },
+            [&arr, query](Vector4u &lo, Vector4u &hi,
+                          dr::mask_t<Vector4u> &running) {
+                Vector4u mid = (lo + hi) >> 1u;
+                Vector4f val = dr::gather<Vector4f>(arr, mid, running);
+                dr::mask_t<Vector4u> go_right = running && (val < Vector4f(query));
+                lo = dr::select(go_right, mid + 1u, lo);
+                hi = dr::select(running && !go_right, mid, hi);
+                running = running && (lo < hi);
+            },
+            "ParticleFieldPhaseFunction ragged_searchsorted4");
+
+        return dr::clip(lo, start + 1u, start + len - 1u) - 1u;
+    }
+
+    /// Perform a searchsorted operation on a single sub-section of `arr`.
+    /// Offloaded to dr::binary_search.
+    UInt32 searchsorted1(const FloatStorage &arr, UInt32 start, UInt32 len,
+                         Float query, Mask active) const {
+        UInt32 lo = dr::binary_search<UInt32>(
+            start, start + len,
+            [&arr, active, query](UInt32 i) DRJIT_INLINE_LAMBDA {
+                return active && (dr::gather<Float>(arr, i, active) < query);
+            });
+        UInt32 result = dr::clip(lo, start + 1u, start + len - 1u) - 1u;
+        return result;
+    }
+
+    /// Locate sample `u` in a CDF sub-section and perform the quadratic
+    /// inversion of its cosine.
+    Float sample_cos_theta_entry(Float u, UInt32 start, UInt32 len,
+                                 Float norm, Mask active) const {
+        UInt32 lo = searchsorted1(m_cdf, start, len, u, active);
+        UInt32 hi = lo + 1u;
+
+        Float x0 = dr::gather<Float>(m_nodes,   lo,      active);
+        Float x1 = dr::gather<Float>(m_nodes,   hi,      active);
+        Float c0 = dr::gather<Float>(m_cdf,     lo,      active);
+        Float y0 = dr::gather<Float>(m_mueller, lo * 6u, active) * norm;
+        Float y1 = dr::gather<Float>(m_mueller, hi * 6u, active) * norm;
+
+        Float h = x1 - x0;
+        Float s = (u - c0) / h;
+
+        // Numerically stable form of the quadratic root. The classical
+        // form (y0 - sqrt(y0^2 + 2*s*(y1-y0))) / (y0 - y1) subtracts two
+        // nearly-equal values whenever y0 ~ y1. This case is likely when 
+        // y0 and y1 are taken from a smoothly-varying phase function.
+        Float disc = dr::fmadd(y0, y0, 2.f*s*(y1-y0));
+        Float t    = 2.f*s * dr::rcp(y0 + dr::safe_sqrt(disc));
+        return dr::fmadd(dr::clip(t, 0.f, 1.f), h, x0);
+    }
+
+
+    /// Blend the 4 cornering CDFs at the given cosine x.
+    Float eval_blended_cdf_at(Float x, const BilinearWeights &bw, Vector4u lo4,
+                               Vector4f norm, Mask active) const {
+        Vector4u hi4   = lo4 + 1u;
+        Vector4f x0_4  = dr::gather<Vector4f>(m_nodes,   lo4,      active);
+        Vector4f x1_4  = dr::gather<Vector4f>(m_nodes,   hi4,      active);
+        Vector4f y0_4  = dr::gather<Vector4f>(m_mueller, lo4 * 6u, active);
+        Vector4f y1_4  = dr::gather<Vector4f>(m_mueller, hi4 * 6u, active);
+        Vector4f cdf0  = dr::gather<Vector4f>(m_cdf,     lo4,      active);
+        Vector4f dx    = x1_4 - x0_4;
+        Vector4f t4    = dr::clip(dr::select(dx > dr::Epsilon<Float>,
+                                             (Vector4f(x) - x0_4) / dx, 0.f), 0.f, 1.f);
+        Vector4f cdf_c = cdf0 + norm * dx * t4 * dr::fmadd(0.5f * t4, y1_4 - y0_4, y0_4);
+        return dr::dot(bw.w, cdf_c);
+    }
+
+    /// Locate cosine x in the 4 cornering CDFs and blend them using
+    /// \ref eval_blended_cdf_at.
+    Float eval_blended_cdf(Float x, const BilinearWeights &bw,
+                            Vector4u starts, Vector4u lens, Vector4f norm, Mask active) const {
+        Vector4u lo4 = ragged_searchsorted4(m_nodes, starts, lens, x, active);
+        return eval_blended_cdf_at(x, bw, lo4, norm, active);
+    }
+
+    /// Define the CDF bisection boundaries for a given set of 4 cornering
+    /// CDFs and their associated weights.
+    BisectionBounds
+    bisection_bounds(Float u, const BilinearWeights &bw, Mask active) const {
+        Vector4u starts = dr::gather<Vector4u>(m_grid_start, bw.idx, active);
+        Vector4u lens   = dr::gather<Vector4u>(m_grid_len,   bw.idx, active);
+        Vector4f norm   = dr::gather<Vector4f>(m_norm,       bw.idx, active);
+
+        Float lo = dr::max(dr::gather<Vector4f>(m_nodes, starts,             active));
+        Float hi = dr::min(dr::gather<Vector4f>(m_nodes, starts + lens - 1u, active));
+
+        Vector4u lo4_at_hi = ragged_searchsorted4(m_nodes, starts, lens, hi, active);
+        Float target = u * eval_blended_cdf_at(hi, bw, lo4_at_hi, norm, active);
+        Float tol    = 16 * dr::Epsilon<Float> * dr::maximum(dr::abs(hi), Float(1.f));
+
+        return { starts, lens, norm, lo, hi, target, tol, lo4_at_hi };
+    }
+
+private:
+
+    // =========================================================================
+    //  Blend methods implementations
+    // =========================================================================
+
+    /// Merge the 4 cornering phase-value discretizations onto a common grid,
+    /// then build and invert a CDF from the blend.
+    Float sample_cos_theta_tabulate(Float u, const BilinearWeights &bw, Mask active) const {
+        ScalarFloat lo_bound = 0.f, hi_bound = 0.f;
+        auto entries = gather_column_entries<1>(bw, active, lo_bound, hi_bound);
+
+        std::vector<ScalarFloat> merged;
+        std::array<std::vector<ScalarFloat>, 1> Y_cols;
+        merge_and_interpolate<1>(entries, true, lo_bound, hi_bound, merged, Y_cols);
+
+        const std::vector<ScalarFloat> &Y = Y_cols[0];
+        size_t n = merged.size();
+        std::vector<ScalarFloat> cdf(n, 0.0);
+        for (size_t k = 1; k < n; ++k)
+            cdf[k] = cdf[k - 1] + 0.5 * (Y[k - 1] + Y[k]) * (merged[k] - merged[k - 1]);
+
+        ScalarFloat total = cdf.back();
+        if (n < 2 || total <= 0.f)
+            return Float(lo_bound);
+
+        ScalarFloat target = dr::slice(u, 0) * total;
+
+        size_t hi_idx = (size_t)(std::lower_bound(cdf.begin(), cdf.end(), target) - cdf.begin());
+        hi_idx = std::min(std::max(hi_idx, (size_t) 1), n - 1);
+        size_t lo_idx = hi_idx - 1;
+
+        ScalarFloat x0 = merged[lo_idx], x1 = merged[hi_idx];
+        ScalarFloat y0 = Y[lo_idx],      y1 = Y[hi_idx];
+        ScalarFloat c0 = cdf[lo_idx];
+
+        ScalarFloat h = x1 - x0;
+        ScalarFloat s = h > 0.f ? (target - c0) / h : 0.f;
+
+        // Same rationalized form as sample_cos_theta_entry()
+        ScalarFloat disc = std::max(ScalarFloat(0.f), y0 * y0 + ScalarFloat(2.f) * s * (y1 - y0));
+        ScalarFloat t = ScalarFloat(2.f) * s / (y0 + std::sqrt(disc));
+        t = std::min(std::max(t, ScalarFloat(0.f)), ScalarFloat(1.f));
+
+        ScalarFloat cos_t = x0 + t * h;
+        return Float(cos_t);
+    }
+
+    /// Bisect the 4 cornering CDF entries for the sample until they have all
+    /// converged on their respective segment. Invert the cosine using the
+    /// quadratic formula on the blended CDF segment.
+    std::tuple<Float, Vector4u, Vector4u, Vector4u, Mask>
+    sample_cos_theta_search(Float u, const BilinearWeights &bw, Mask active) const {
+        auto [starts, lens, norm, lo, hi, target, tol, lo4_at_hi] = bisection_bounds(u, bw, active);
+
+        Vector4u lo4_at_lo = ragged_searchsorted4(m_nodes, starts, lens, lo, active);
+
+        UInt32 iter_count = 0u;
+        Mask active_loop = active && !dr::all(lo4_at_lo == lo4_at_hi) && ((hi - lo) > tol);
+
+        // We want to find the angle whose blended CDF equals the sample.
+        // The blended CDF where we search from is not expressed anywhere, so
+        // we bisect it to find the cosine segment in each corner's tabulated
+        // CDF where the sample is expressed first.
+        //
+        // This loop maintains a search window on the angle axis. At each
+        // step we compare the blended CDF at the window midpoint to the 
+        // sample. The search window on cosine is then updated accordingly.
+        //
+        // When it has shrunk enough that each corner found a matching cosine
+        // segment at the low and high bounds of the window, the loop stops
+        // and these segments are the ones to blend and invert.
+        std::tie(lo, hi, lo4_at_lo, lo4_at_hi, iter_count, active_loop) = dr::while_loop(
+            std::make_tuple(lo, hi, lo4_at_lo, lo4_at_hi, iter_count, active_loop),
+            [](const Float &, const Float &, const Vector4u &, const Vector4u &,
+               const UInt32 &, const Mask &active_loop) {
+                return active_loop;
+            },
+            [this, bw, starts, lens, norm, target, tol](
+                Float &lo, Float &hi, Vector4u &lo4_at_lo, Vector4u &lo4_at_hi,
+                UInt32 &iter_count, Mask &active_loop) {
+                Float mid = 0.5f * (lo + hi);
+                // Look for the segment in each corner containing mid
+                Vector4u lo4_at_mid =
+                    ragged_searchsorted4(m_nodes, starts, lens, mid, active_loop);
+                // Evaluate the blended CDF according to bw, and compare it to
+                // the sample
+                Mask go_right = active_loop &&
+                    (eval_blended_cdf_at(mid, bw, lo4_at_mid, norm, active_loop) < target);
+
+                Mask update_lo = active_loop && go_right;
+                Mask update_hi = active_loop && !go_right;
+                lo        = dr::select(update_lo, mid, lo);
+                hi        = dr::select(update_hi, mid, hi);
+                lo4_at_lo = dr::select(update_lo, lo4_at_mid, lo4_at_lo);
+                lo4_at_hi = dr::select(update_hi, lo4_at_mid, lo4_at_hi);
+
+                iter_count += 1u;
+                Mask stable = dr::all(lo4_at_lo == lo4_at_hi);
+                active_loop &= (iter_count < 30u) && !stable && ((hi - lo) > tol);
+            },
+            "ParticleFieldPhaseFunction search bisection");
+
+        // Now perform the blend and inversion
+        Mask stable = active && dr::all(lo4_at_lo == lo4_at_hi);
+
+        Vector4u lo4 = lo4_at_lo;
+        Vector4u hi4 = lo4 + 1u;
+        Vector4f x0_4   = dr::gather<Vector4f>(m_nodes,   lo4,      active);
+        Vector4f x1_4   = dr::gather<Vector4f>(m_nodes,   hi4,      active);
+        Vector4f y0_4   = dr::gather<Vector4f>(m_mueller, lo4 * 6u, active);
+        Vector4f y1_4   = dr::gather<Vector4f>(m_mueller, hi4 * 6u, active);
+        Vector4f cdf0_4 = dr::gather<Vector4f>(m_cdf,     lo4,      active);
+        Vector4f dx4    = x1_4 - x0_4;
+
+        Vector4f wn = bw.w * norm;
+        Vector4f k2 = dr::select(dx4 > dr::Epsilon<Float>, 0.5f * wn * (y1_4 - y0_4) / dx4, Vector4f(0.f));
+        Vector4f k1 = wn * y0_4;
+
+        Float A = dr::sum(k2);
+        Float B = dr::sum(k1 - 2.f * k2 * x0_4);
+        Float C = dr::sum(bw.w * cdf0_4 - k1 * x0_4 + k2 * x0_4 * x0_4) - target;
+
+        // Numerically stable quadratic formula: the naïve (-B ± sqrt(disc)) / (2*A)
+        // cancels whenever sqrt(disc) and B are close in value.
+        // Rewriting via q = -0.5*(B + sign(B)*sqrt(disc)) and roots {q/A, C/q} this.
+        Float disc  = dr::maximum(dr::fmadd(B, B, -4.f * A * C), 0.f);
+        Float sq    = dr::sqrt(disc);
+        Float q     = -0.5f * (B + dr::sign(B) * sq);
+        Float coeff_scale = dr::maximum(dr::maximum(dr::abs(A), dr::abs(B)), dr::maximum(dr::abs(C), Float(1.f)));
+        Float eps_scaled  = dr::Epsilon<Float> * coeff_scale;
+        Float root1 = dr::select(dr::abs(A) > eps_scaled, q / A, 0.f);
+        Float root2 = dr::select(dr::abs(q) > eps_scaled, C / q, 0.f);
+        Float root_lin = dr::select(dr::abs(B) > eps_scaled, -C / B, 0.5f * (lo + hi));
+
+        // Pick the root that needs the least clipping to land in [lo, hi],
+        // rather than a naïve inclusion test: the valid root can round
+        // outside [lo, hi] in single precision.
+        Float root1_clipped = dr::clip(root1, lo, hi);
+        Float root2_clipped = dr::clip(root2, lo, hi);
+        Mask  root1_closer   = dr::abs(root1 - root1_clipped) <= dr::abs(root2 - root2_clipped);
+        Float x_quad  = dr::select(root1_closer, root1_clipped, root2_clipped);
+        Float cos_t   = dr::select(dr::abs(A) > eps_scaled, x_quad, root_lin);
+        cos_t = dr::select(stable, dr::clip(cos_t, lo, hi), 0.5f * (lo + hi));
+
+        return { cos_t, starts, lens, lo4, stable };
+    }
+
+
+    /// Select one of the 4 cornering CDFs using \c u_select as a weight and
+    /// invert it.
+    std::tuple<Vector3f, Spectrum, Float>
+    sample_stochastic(const PhaseFunctionContext &ctx,
+                         const MediumInteraction3f &mei,
+                         Float u_select, const Point2f &sample2,
+                         const BilinearWeights &bw, Mask active) const {
+        Vector4f cumw(bw.w[0],
+                      bw.w[0] + bw.w[1],
+                      bw.w[0] + bw.w[1] + bw.w[2],
+                      bw.w[0] + bw.w[1] + bw.w[2] + bw.w[3]);
+
+        UInt32 idx = bw.idx[0];
+        idx = dr::select(u_select > cumw[0], bw.idx[1], idx);
+        idx = dr::select(u_select > cumw[1], bw.idx[2], idx);
+        idx = dr::select(u_select > cumw[2], bw.idx[3], idx);
+
+        // Weight of whichever corner ends up selected above (same comparison
+        // chain as idx). The corner *choice* stays detached below -- s/l/norm/
+        // cos_t never see a gradient from bw.w, matching how dielectric.cpp's
+        // reflection/transmission lobe choice is detached to avoid bias. What
+        // needs correcting is the returned *weight*: as bw.w varies, the
+        // probability of having landed on this corner varies too, which is a
+        // score-function (REINFORCE) contribution, not a pathwise one.
+        Float w_sel = bw.w[0];
+        w_sel = dr::select(u_select > cumw[0], bw.w[1], w_sel);
+        w_sel = dr::select(u_select > cumw[1], bw.w[2], w_sel);
+        w_sel = dr::select(u_select > cumw[2], bw.w[3], w_sel);
+
+        UInt32 s = dr::gather<UInt32>(m_grid_start, idx, active);
+        UInt32 l = dr::gather<UInt32>(m_grid_len,   idx, active);
+        Float  norm = dr::gather<Float>(m_norm, idx, active);
+
+        Float cos_t = sample_cos_theta_entry(sample2.x(), s, l, norm, active);
+        Float sin_t = dr::safe_sqrt(1.f - cos_t * cos_t);
+        auto [sin_phi, cos_phi] = dr::sincos(2.f * dr::Pi<ScalarFloat> * sample2.y());
+        Vector3f wo = -mei.to_world(Vector3f(sin_t * cos_phi, sin_t * sin_phi, cos_t));
+        wo = dr::select(active, wo, Vector3f(0.f));
+
+        auto [phase_val, pdf] = eval_pdf_flat(ctx, mei, wo, bw, active);
+
+        Spectrum weight = phase_val * dr::rcp(pdf);
+
+        // REINFORCE-style correction for the discrete corner choice above
+        // (same dr::replace_grad idiom as dielectric.cpp's lobe selection):
+        // numerically a no-op (w_sel / detach(w_sel) == 1), but injects
+        // d(log w_sel)/d(theta) into weight's gradient.
+        if constexpr (dr::is_diff_v<Float>) {
+            if (dr::grad_enabled(w_sel)) {
+                Float score = dr::replace_grad(Float(1.f), w_sel / dr::detach(w_sel));
+                weight *= score;
+            }
+        }
+
+        weight = dr::select(active, weight, Spectrum(0.f));
+        pdf    = dr::select(active, pdf, Float(0.f));
+
+        return { wo, weight, pdf };
+    }
+
+    /// Get the bilinear weights for r_eff, v_eff at the interaction location.
+    std::pair<BilinearWeights, Mask>
+    get_weights(const MediumInteraction3f &mei, Mask active) const {
+        Float r_eff = m_r_eff_volume->eval_1(mei, active);
+        Float v_eff = m_v_eff_volume->eval_1(mei, active);
+
+        // These sanity checks can only be done in scalar variants.
+        if constexpr (!dr::is_jit_v<Float>) {
+            Mask nan_mask = dr::isnan(r_eff) || dr::isnan(v_eff);
+            if (dr::any(active && nan_mask)) {
+                std::ostringstream oss;
+                oss << "ParticleFieldPhaseFunction: NaN r_eff or v_eff at interaction point.\n";
+                oss << "  mei.p       = " << mei.p << "\n";
+                oss << "  r_eff value = " << r_eff << "\n";
+                oss << "  v_eff value = " << v_eff << "\n";
+                oss << "  r_eff is NaN: " << dr::isnan(r_eff) << "\n";
+                oss << "  v_eff is NaN: " << dr::isnan(v_eff) << "\n";
+                oss << "  r_eff_volume to_local:\n" << m_r_eff_volume->bbox() << "\n";
+                oss << "  v_eff_volume to_local:\n" << m_v_eff_volume->bbox() << "\n";
+                Throw("%s", oss.str());
+            }
+        }
+
+        Float r_min = 0.f, r_max = 0.f;
+        if (m_n_r > 1) {
+            r_min = dr::gather<Float>(m_r_eff_grid, UInt32(0u), active);
+            r_max = dr::gather<Float>(m_r_eff_grid, UInt32(m_n_r - 1), active);
+            if constexpr (!dr::is_jit_v<Float>) {
+                if (dr::any(active && (r_eff < r_min || r_eff > r_max)))
+                    Throw("ParticleFieldPhaseFunction: r_eff out of dataset range. %s out of [%s; %s]", r_eff, r_min, r_max);
+            }
+        }
+
+        Float v_min = 0.f, v_max = 0.f;
+        if (m_n_v > 1) {
+            v_min = dr::gather<Float>(m_v_eff_grid, UInt32(0u), active);
+            v_max = dr::gather<Float>(m_v_eff_grid, UInt32(m_n_v - 1), active);
+            if constexpr (!dr::is_jit_v<Float>) {
+                if (dr::any(active && (v_eff < v_min || v_eff > v_max)))
+                    Throw("ParticleFieldPhaseFunction: v_eff out of dataset range.");
+            }
+        }
+
+        auto weights = get_bilinear_weights(r_eff, v_eff, r_min, r_max, v_min, v_max, active);
+
+        return { weights, active };
+    }
+
+
+
+    /// Scalar retrieval of the 4 cornering entries' phase values.
+    template <size_t N>
+    std::array<ColumnEntry<N>, 4>
+    gather_column_entries(const BilinearWeights &bw, Mask active,
+                           ScalarFloat &lo_bound, ScalarFloat &hi_bound) const {
+        Vector4u starts = dr::gather<Vector4u>(m_grid_start, bw.idx, active);
+        Vector4u lens   = dr::gather<Vector4u>(m_grid_len,   bw.idx, active);
+        Vector4f norms  = dr::gather<Vector4f>(m_norm,       bw.idx, active);
+
+        std::array<ColumnEntry<N>, 4> entries;
+        for (size_t i = 0; i < 4; ++i) {
+            size_t s = dr::slice(starts[i], 0);
+            size_t l = dr::slice(lens[i],   0);
+
+            ColumnEntry<N> &e = entries[i];
+            e.weight = dr::slice(bw.w[i], 0) * dr::slice(norms[i], 0);
+            e.x.resize(l);
+            for (auto &col : e.y)
+                col.resize(l);
+            for (size_t k = 0; k < l; ++k) {
+                e.x[k] = dr::slice(m_nodes, s + k);
+                for (size_t c = 0; c < N; ++c)
+                    e.y[c][k] = dr::slice(m_mueller, (s + k) * 6u + c);
+            }
+
+            ScalarFloat first = e.x.front(), last = e.x.back();
+            if (i == 0) { lo_bound = first; hi_bound = last; }
+            else        { lo_bound = std::max(lo_bound, first); hi_bound = std::min(hi_bound, last); }
+        }
+        return entries;
+    }
+
+    /// Scalar merge of the 4 cornering entries' nodes, interpolating and
+    /// accumulating their phase values onto the merged grid.
+    template <size_t N>
+    static void merge_and_interpolate(const std::array<ColumnEntry<N>, 4> &entries,
+                                       bool restrict_to_intersection,
+                                       ScalarFloat lo_bound, ScalarFloat hi_bound,
+                                       std::vector<ScalarFloat> &merged,
+                                       std::array<std::vector<ScalarFloat>, N> &Y) {
+        merged.clear();
+        if (restrict_to_intersection)
+            merged = { lo_bound, hi_bound };
+        for (const ColumnEntry<N> &e : entries)
+            for (ScalarFloat x : e.x)
+                if (!restrict_to_intersection || (x >= lo_bound && x <= hi_bound))
+                    merged.push_back(x);
+
+        std::sort(merged.begin(), merged.end());
+        merged.erase(std::unique(merged.begin(), merged.end()), merged.end());
+
+        size_t n = merged.size();
+        for (auto &col : Y)
+            col.assign(n, ScalarFloat(0.f));
+
+        for (const ColumnEntry<N> &e : entries) {
+            if (e.weight == 0.f || e.x.empty())
+                continue;
+
+            size_t l  = e.x.size();
+            size_t hi = 1;
+            for (size_t k = 0; k < n; ++k) {
+                ScalarFloat x = merged[k];
+                while (hi < l - 1 && e.x[hi] < x)
+                    ++hi;
+                size_t lo = hi - 1;
+
+                ScalarFloat h = e.x[hi] - e.x[lo];
+                ScalarFloat t = h > 0.f ? (x - e.x[lo]) / h : ScalarFloat(0.f);
+                t = std::clamp(t, ScalarFloat(0.f), ScalarFloat(1.f));
+
+                for (size_t c = 0; c < N; ++c)
+                    Y[c][k] += e.weight * (e.y[c][lo] + t * (e.y[c][hi] - e.y[c][lo]));
+            }
+        }
+    }
+
+private:
+
+    // =========================================================================
+    //  Post-processing
+    // =========================================================================
+
+    /// Blend and evaluate the PDF given a cosine angle and the associated
+    /// bilinear weights.
+    std::pair<Spectrum, Float>
+    eval_pdf_flat_at(const PhaseFunctionContext &ctx,
+                      const MediumInteraction3f &mei,
+                      const Vector3f &wo,
+                      const BilinearWeights &bw,
+                      Float cos_t,
+                      Vector4u starts, Vector4u lens, Vector4u lo4,
+                      Mask active) const {
+        Vector4u hi4        = lo4 + 1u;
+        Vector4f x0_4       = dr::gather<Vector4f>(m_nodes, lo4, active);
+        Vector4f x1_4       = dr::gather<Vector4f>(m_nodes, hi4, active);
+        Vector4f t4         = (Vector4f(cos_t) - x0_4) / (x1_4 - x0_4);
+        Vector4f norms      = dr::gather<Vector4f>(m_norm, bw.idx, active);
+
+        Vector4f domain_lo  = dr::gather<Vector4f>(m_nodes, starts,             active);
+        Vector4f domain_hi  = dr::gather<Vector4f>(m_nodes, starts + lens - 1u, active);
+        Vector4f w          = dr::select(Vector4f(cos_t) >= domain_lo && Vector4f(cos_t) <= domain_hi,
+                                          bw.w, Vector4f(0.f));
+
+        Spectrum phase_val(0.f);
+        Float pdf;
+
+        if constexpr (is_polarized_v<Spectrum>) {
+            Vector4f m11_4;
+            for (size_t c = 0; c < 4; ++c) {
+                Vector6f v0  = gather_mueller(lo4[c], active);
+                Vector6f v1  = gather_mueller(hi4[c], active);
+                Vector6f mi  = dr::fmadd(t4[c], v1 - v0, v0);
+                m11_4[c]     = mi[0];
+                Float scale  = norms[c] * dr::InvTwoPi<ScalarFloat> * w[c];
+                phase_val += MuellerMatrix<Float>(
+                    mi[0]*scale,  mi[1]*scale, 0.f,            0.f,
+                    mi[1]*scale,  mi[2]*scale, 0.f,            0.f,
+                    0.f,            0.f,           mi[3]*scale,  mi[4]*scale,
+                    0.f,            0.f,          -mi[4]*scale,  mi[5]*scale);
+            }
+            pdf = dr::dot(w * norms, m11_4) * dr::InvTwoPi<ScalarFloat>;
+
+            Vector3f wo_hat = ctx.mode == TransportMode::Radiance ? wo : mei.wi,
+                     wi_hat = ctx.mode == TransportMode::Radiance ? mei.wi : wo;
+            Vector3f x_hat      = dr::cross(-wo_hat, wi_hat),
+                     p_axis_in  = dr::normalize(dr::cross(x_hat, -wo_hat)),
+                     p_axis_out = dr::normalize(dr::cross(x_hat,  wi_hat));
+            phase_val = mueller::rotate_mueller_basis(
+                phase_val,
+                -wo_hat, p_axis_in,  mueller::stokes_basis(-wo_hat),
+                 wi_hat, p_axis_out, mueller::stokes_basis( wi_hat));
+            dr::masked(phase_val, dr::isnan(phase_val)) = depolarizer<Spectrum>(0.f);
+        } else {
+            Vector4f y0_m11 = dr::gather<Vector4f>(m_mueller, lo4 * 6u, active);
+            Vector4f y1_m11 = dr::gather<Vector4f>(m_mueller, hi4 * 6u, active);
+            Vector4f m11_4  = dr::fmadd(t4, y1_m11 - y0_m11, y0_m11);
+            pdf = dr::dot(w * norms, m11_4) * dr::InvTwoPi<ScalarFloat>;
+            phase_val = Spectrum(pdf);
+        }
+
+        return { phase_val, pdf };
+    }
+
+    /// Locate a cosine in the 4 cornering PDF sub-sections and evaluate
+    /// its blended PDF.
+    std::pair<Spectrum, Float>
+    eval_pdf_flat(const PhaseFunctionContext &ctx,
+                  const MediumInteraction3f &mei,
+                  const Vector3f &wo,
+                  const BilinearWeights &bw,
+                  Mask active) const {
+        Float cos_t     = -dr::dot(wo, mei.wi);
+        Vector4u starts = dr::gather<Vector4u>(m_grid_start, bw.idx, active);
+        Vector4u lens   = dr::gather<Vector4u>(m_grid_len,   bw.idx, active);
+        Vector4u lo4    = ragged_searchsorted4(m_nodes, starts, lens, cos_t, active);
+        return eval_pdf_flat_at(ctx, mei, wo, bw, cos_t, starts, lens, lo4, active);
+    }
+
+
+public:
+
+    std::tuple<Vector3f, Spectrum, Float>
+    sample(const PhaseFunctionContext &ctx,
+           const MediumInteraction3f &mei,
+           Float sample1,
+           const Point2f &sample2,
+           Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
+
+        auto [bw, valid] = get_weights(mei, active);
+        active = active && valid;
+
+        Float cos_t;
+        switch (m_blending_method) {
+            case BlendingMethod::Stochastic:
+                return sample_stochastic(ctx, mei, sample1, sample2, bw, active);
+
+            case BlendingMethod::Tabulate:
+                cos_t = sample_cos_theta_tabulate(sample2.x(), bw, active);
+                break;
+
+            case BlendingMethod::Search: {
+                auto [cos_t_s, starts, lens, lo4, stable] = sample_cos_theta_search(sample2.x(), bw, active);
+                Float sin_t = dr::safe_sqrt(1.f - cos_t_s * cos_t_s);
+                auto [sin_phi, cos_phi] = dr::sincos(2.f * dr::Pi<ScalarFloat> * sample2.y());
+                Vector3f wo{ sin_t * cos_phi, sin_t * sin_phi, cos_t_s };
+                wo = -mei.to_world(wo);
+
+                Vector4u lo4_fresh = ragged_searchsorted4(m_nodes, starts, lens, cos_t_s, active && !stable);
+                Vector4u lo4_final = dr::select(stable, lo4, lo4_fresh);
+
+                auto [phase_val, pdf] = eval_pdf_flat_at(ctx, mei, wo, bw, cos_t_s, starts, lens, lo4_final, active);
+                Spectrum weight = phase_val * dr::rcp(pdf);
+
+                wo     = dr::select(active, wo,     Vector3f(0.f));
+                weight = dr::select(active, weight, Spectrum(0.f));
+                pdf    = dr::select(active, pdf,    Float(0.f));
+                return { wo, weight, pdf };
+            }
+        }
+        Float sin_t = dr::safe_sqrt(1.f - cos_t * cos_t);
+        auto [sin_phi, cos_phi] =
+            dr::sincos(2.f * dr::Pi<ScalarFloat> * sample2.y());
+
+        Vector3f wo{ sin_t * cos_phi, sin_t * sin_phi, cos_t };
+        wo = -mei.to_world(wo);
+
+        auto [phase_val, pdf] = eval_pdf_flat(ctx, mei, wo, bw, active);
+        Spectrum weight = phase_val * dr::rcp(pdf);
+
+        wo     = dr::select(active, wo,     Vector3f(0.f));
+        weight = dr::select(active, weight, Spectrum(0.f));
+        pdf    = dr::select(active, pdf,    Float(0.f));
+
+        return { wo, weight, pdf };
+    }
+
+    std::pair<Spectrum, Float>
+    eval_pdf(const PhaseFunctionContext &ctx,
+             const MediumInteraction3f &mei,
+             const Vector3f &wo,
+             Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
+
+        auto [bw, valid] = get_weights(mei, active);
+        active = active && valid;
+        auto [val, pdf] = eval_pdf_flat(ctx, mei, wo, bw, active);
+
+        val = dr::select(active, val, Spectrum(0.f));
+        pdf = dr::select(active, pdf, Float(0.f));
+
+        return { val, pdf };
+    }
+
+    void parameters_changed(const std::vector<std::string> &keys = {}) override {
+        // precompute_cdf() only depends on nodes/phase_mueller/grid_start/grid_len
+        // (r_eff_volume, v_eff_volume, r_eff_grid, v_eff_grid, sigma_s_weight are
+        // read later, at query time, so they don't need it re-run).
+        if (keys.empty() || string::contains(keys, "nodes") ||
+            string::contains(keys, "phase_mueller") ||
+            string::contains(keys, "grid_start") ||
+            string::contains(keys, "grid_len"))
+            precompute_cdf();
+    }
+
+    void traverse(TraversalCallback *cb) override {
+        cb->put("r_eff_volume",  m_r_eff_volume.get(), ParamFlags::Differentiable);
+        cb->put("v_eff_volume",  m_v_eff_volume.get(), ParamFlags::Differentiable);
+        cb->put("r_eff_grid",    m_r_eff_grid,         ParamFlags::NonDifferentiable);
+        cb->put("v_eff_grid",    m_v_eff_grid,         ParamFlags::NonDifferentiable);
+        cb->put("nodes",           m_nodes,              ParamFlags::NonDifferentiable);
+        cb->put("phase_mueller",   m_mueller,            ParamFlags::Differentiable | ParamFlags::Discontinuous);
+        cb->put("grid_start",      m_grid_start,         ParamFlags::NonDifferentiable);
+        cb->put("grid_len",        m_grid_len,           ParamFlags::NonDifferentiable);
+        cb->put("sigma_s_weight",  m_sigma_s_weight,     ParamFlags::Differentiable);
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "ParticleFieldPhaseFunction[" << std::endl
+            << "  n_r = " << m_n_r << "," << std::endl
+            << "  n_v = " << m_n_v << "," << std::endl
+            << "  total_pts = " << dr::width(m_nodes) << "," << std::endl
+            << "  blending_method = " << method_to_string(m_blending_method) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    FloatStorage get_envelope_nodes() const override {
+        size_t n = dr::width(m_nodes);
+        std::vector<ScalarFloat> tmp(n);
+        for (size_t i = 0; i < n; ++i)
+            tmp[i] = dr::slice(m_nodes, i);
+
+        std::sort(tmp.begin(), tmp.end());
+        auto last = std::unique(tmp.begin(), tmp.end());
+        tmp.erase(last, tmp.end());
+
+        return dr::load<FloatStorage>(tmp.data(), tmp.size());
+    }
+
+
+    void accumulate_envelope(const FloatStorage &nodes, FloatStorage &values) const override {
+        size_t n = dr::width(nodes);
+        std::vector<ScalarFloat> tmp_values(n, ScalarFloat(0));
+
+        for (int ir = 0; ir < m_n_r; ++ir) {
+            for (int iv = 0; iv < m_n_v; ++iv) {
+                size_t entry = ir * m_n_v + iv;
+                size_t start = dr::slice(m_grid_start, entry);
+                size_t len   = dr::slice(m_grid_len,   entry);
+                ScalarFloat norm = dr::slice(m_norm,      entry);
+
+                size_t lo = start;
+
+                for (size_t i = 0; i < n; ++i) {
+                    ScalarFloat cos_t = dr::slice(nodes, i);
+
+                    while (lo < start + len - 2 && dr::slice(m_nodes, lo + 1) < cos_t)
+                        ++lo;
+
+                    size_t hi     = lo + 1;
+                    ScalarFloat x0  = dr::slice(m_nodes, lo);
+                    ScalarFloat x1  = dr::slice(m_nodes, hi);
+                    ScalarFloat t   = dr::clip((cos_t - x0) / (x1 - x0), ScalarFloat(0.f), ScalarFloat(1.f));
+                    ScalarFloat y0  = dr::slice(m_mueller, lo * 6u);
+                    ScalarFloat y1  = dr::slice(m_mueller, hi * 6u);
+                    ScalarFloat m11 = dr::fmadd(t, y1 - y0, y0) * norm * dr::InvTwoPi<ScalarFloat>;
+                    tmp_values[i] = dr::maximum(tmp_values[i], m11);
+                }
+            }
+        }
+
+        values = dr::maximum(
+	        dr::load<FloatStorage>(tmp_values.data(), tmp_values.size()),
+	        values
+        );
+    }
+
+    MI_DECLARE_CLASS(ParticleFieldPhaseFunction)
+
+private:
+    ref<Volume> m_r_eff_volume;
+    ref<Volume> m_v_eff_volume;
+
+    FloatStorage  m_r_eff_grid;
+    FloatStorage  m_v_eff_grid;
+    FloatStorage  m_nodes;
+    FloatStorage  m_mueller;
+    UInt32Storage m_grid_start;
+    UInt32Storage m_grid_len;
+    FloatStorage  m_cdf;
+    FloatStorage  m_norm;
+    FloatStorage  m_sigma_s_weight;
+
+    int m_n_r = 0;
+    int m_n_v = 0;
+
+    BlendingMethod m_blending_method;
+};
+
+MI_EXPORT_PLUGIN(ParticleFieldPhaseFunction)
+
+NAMESPACE_END(mitsuba)

--- a/src/eradiate_plugins/tests/phase/test_particlefieldphase.py
+++ b/src/eradiate_plugins/tests/phase/test_particlefieldphase.py
@@ -1,0 +1,797 @@
+import time
+
+import pytest
+from pytest import fixture
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+
+#################################
+# Helper construction functions #
+#################################
+
+BLENDING_METHODS = ["search", "stochastic", "tabulate"]
+SCALAR_AND_LLVM_VARIANTS = ["scalar_mono_polarized", "llvm_ad_rgb"]
+
+
+def blending_methods():
+    """List of blending methods supported by the active variant"""
+    methods = list(BLENDING_METHODS)
+    if mi.variant() not in {v for v in mi.variants() if v.startswith("scalar")}:
+        methods.remove("tabulate")
+    return methods
+
+
+def storage_types():
+    """Return the (array, array_u) dynamic-buffer types for the active variant"""
+    variant = mi.variant()
+    if variant.startswith("scalar"):
+        array = dr.scalar.ArrayXf64 if "double" in variant else dr.scalar.ArrayXf
+        return array, dr.scalar.ArrayXu
+    return mi.Float, mi.UInt32
+
+
+def make_phase_grid(rng, n_r=10, n_v=10, min_pts=50, max_pts=200,
+                    array=None, array_u=None):
+    """Generate a random set of nodes and populate the phase with Henyey-Greenstein phase functions"""
+
+    if array is None or array_u is None:
+        default_array, default_array_u = storage_types()
+        array = array if array is not None else default_array
+        array_u = array_u if array_u is not None else default_array_u
+
+    n_entries = n_r * n_v
+    grid_len   = rng.integers(min_pts, max_pts, n_entries).astype(np.uint32)
+    grid_start = np.concatenate([[0], np.cumsum(grid_len[:-1])]).astype(np.uint32)
+    total_pts  = int(grid_len.sum())
+
+    nodes         = np.empty(total_pts)
+    phase_mueller = np.empty((total_pts, 6))
+
+    for i in range(n_entries):
+        s, l = int(grid_start[i]), int(grid_len[i])
+        cos_vals = np.sort(rng.uniform(-1.0, 1.0, l))
+        cos_vals[0], cos_vals[-1] = -1.0, 1.0
+        # De-duplicate at float32 precision: single-precision variants store
+        # nodes as float32 (see storage_types()), and with ~1000 points
+        # continuously sampled into float32's coarser grid, two draws
+        # rounding to the same value is a possibility.
+        cos_vals = cos_vals.astype(np.float32)
+        for k in range(1, l):
+            if cos_vals[k] <= cos_vals[k - 1]:
+                cos_vals[k] = np.nextafter(cos_vals[k - 1], np.float32(1.0))
+        nodes[s : s + l] = cos_vals
+
+        g  = rng.uniform(-0.9, 0.9)
+        g2 = g * g
+        denom = (1.0 + g2 - 2.0 * g * cos_vals) ** 1.5
+        m11 = (1.0 - g2) / denom / (4.0 * np.pi)
+        phase_mueller[s : s + l, 0] = m11
+        phase_mueller[s : s + l, 1] = m11 * 0.1
+        phase_mueller[s : s + l, 2] = m11 * 0.9
+        phase_mueller[s : s + l, 3] = m11 * 0.8
+        phase_mueller[s : s + l, 4] = m11 * 0.05
+        phase_mueller[s : s + l, 5] = m11 * 0.8
+
+    return (
+        array(nodes),
+        array_u(grid_start),
+        array_u(grid_len),
+        array(phase_mueller.flatten()),
+    )
+
+
+def make_rv_volumes(rng, r_eff_bounds, v_eff_bounds, shape=(1, 1, 1)):
+    """Build random spatial gridvolumes of r_eff and v_eff within the provided bounds"""
+
+    if r_eff_bounds[0] == r_eff_bounds[1]:
+        r_eff_val = np.full(shape, r_eff_bounds[0])
+    else:
+        r_eff_val = r_eff_bounds[0] + rng.random(shape) * (r_eff_bounds[1] - r_eff_bounds[0])
+    if v_eff_bounds[0] == v_eff_bounds[1]:
+        v_eff_val = np.full(shape, v_eff_bounds[0])
+    else:
+        v_eff_val = v_eff_bounds[0] + rng.random(shape) * (v_eff_bounds[1] - v_eff_bounds[0])
+
+    return (
+        { "type": "gridvolume", "grid": mi.VolumeGrid(r_eff_val), "filter_type": "nearest" },
+        { "type": "gridvolume", "grid": mi.VolumeGrid(v_eff_val), "filter_type": "nearest" },
+    )
+
+
+def make_rv_grid(n_r=22, n_v=3, r_bounds=(4.0, 25.0), v_bounds=(0.1, 0.2), sigma_s_weight=None):
+    """Build a regular grid of r_eff and v_eff points"""
+
+    r_eff_grid = np.linspace(r_bounds[0], r_bounds[1], n_r)
+    v_eff_grid = np.linspace(v_bounds[0], v_bounds[1], n_v)
+
+    if sigma_s_weight is None:
+        sigma_s_weight = np.ones(n_r * n_v)
+    sigma_s_weight = np.asarray(sigma_s_weight)
+
+    return (
+        mi.VolumeGrid(r_eff_grid.reshape(1, 1, -1, 1)),
+        mi.VolumeGrid(v_eff_grid.reshape(1, 1, -1, 1)),
+        mi.VolumeGrid(sigma_s_weight.reshape(1, 1, -1, 1)),
+    )
+
+
+def make_interaction(wi=(0, 0, 1), p=(0.5, 0.5, 0.5)):
+    """Build a medium interaction with the given incoming direction and position"""
+    mei         = mi.MediumInteraction3f()
+    mei.wi      = mi.Vector3f(wi)
+    mei.p       = mi.Point3f(p)
+    mei.sh_frame = mi.Frame3f(mei.wi)
+    return mei
+
+
+def make_query_interactions(rng, n_points, r_bounds, v_bounds, wi=(0, 0, 1)):
+    """Build a batch of interactions and their matching (r_eff, v_eff) volumes"""
+    rv_volumes = make_rv_volumes(rng, r_bounds, v_bounds, shape=(1, 1, n_points))
+    meis = [
+        make_interaction(wi=wi, p=(float(rng.random()), 0.5, 0.5))
+        for _ in range(n_points)
+    ]
+    return rv_volumes, meis
+
+
+def make_phase(
+        r_eff_volume, v_eff_volume,
+        r_eff_grid,   v_eff_grid,
+        nodes, phase_mueller,
+        grid_start, grid_len,
+        blending_method,
+        sigma_s_weight,
+    ):
+    """Build a complete phase dictionary"""
+
+    phase = mi.load_dict({
+        "type": "particlefieldphase",
+        "r_eff_volume": r_eff_volume,
+        "v_eff_volume": v_eff_volume,
+        "r_eff_grid": r_eff_grid,
+        "v_eff_grid": v_eff_grid,
+        "nodes": nodes,
+        "phase_mueller": phase_mueller,
+        "grid_start": grid_start,
+        "grid_len": grid_len,
+        "blending_method": blending_method,
+        "sigma_s_weight": sigma_s_weight,
+    })
+    return phase
+
+
+def build_grid(rng, n_r, n_v, r_bounds=(10.0, 11.0), v_bounds=(0.1, 0.2), sigma_s_weight=None,
+               min_pts=10, max_pts=11):
+    """Build grid parameters (nodes, mueller matrix, and r_eff/v_eff grids)"""
+
+    nodes, grid_start, grid_len, phase_mueller = make_phase_grid(rng, n_r=n_r, n_v=n_v, min_pts=min_pts, max_pts=max_pts)
+    r_eff_grid, v_eff_grid, sigma_s_weight = make_rv_grid(
+        n_r=n_r, n_v=n_v, r_bounds=r_bounds, v_bounds=v_bounds, sigma_s_weight=sigma_s_weight)
+    return nodes, grid_start, grid_len, phase_mueller, r_eff_grid, v_eff_grid, sigma_s_weight
+
+
+def build_phase_function(grid, rv_volumes, blending_method):
+    """Construct a phase function from grid parameters"""
+
+    nodes, grid_start, grid_len, phase_mueller, r_eff_grid, v_eff_grid, sigma_s_weight = grid
+    r_eff, v_eff = rv_volumes
+
+    phase = make_phase(
+        r_eff, v_eff, r_eff_grid, v_eff_grid,
+        nodes, phase_mueller,
+        grid_start, grid_len,
+        blending_method,
+        sigma_s_weight,
+    )
+
+    return phase, r_eff, v_eff, r_eff_grid, v_eff_grid, nodes, phase_mueller, grid_start, grid_len, sigma_s_weight
+
+
+def bilinear_corners(r_eff_volume, v_eff_volume, r_eff_grid, v_eff_grid, sigma_s_weight, mei):
+    """Calculate bilinear interpolation weights rescaled by sigma_s from an interaction and r_eff, v_eff volumes"""
+
+    r_eff_grid_np     = np.array(r_eff_grid).ravel()
+    v_eff_grid_np     = np.array(v_eff_grid).ravel()
+    sigma_s_weight_np = np.array(sigma_s_weight).ravel()
+
+    n_r = len(r_eff_grid_np)
+    n_v = len(v_eff_grid_np)
+
+    r_eff = float(dr.slice(mi.load_dict(r_eff_volume).eval_1(mei), 0))
+    v_eff = float(dr.slice(mi.load_dict(v_eff_volume).eval_1(mei), 0))
+
+    if n_r > 1:
+        ir = int(np.clip(np.searchsorted(r_eff_grid_np, r_eff, side="right") - 1, 0, n_r - 2))
+        tr = (r_eff - r_eff_grid_np[ir]) / (r_eff_grid_np[ir + 1] - r_eff_grid_np[ir])
+    else:
+        ir, tr = 0, 0.0
+
+    if n_v > 1:
+        iv = int(np.clip(np.searchsorted(v_eff_grid_np, v_eff, side="right") - 1, 0, n_v - 2))
+        tv = (v_eff - v_eff_grid_np[iv]) / (v_eff_grid_np[iv + 1] - v_eff_grid_np[iv])
+    else:
+        iv, tv = 0, 0.0
+
+    ir_hi = ir + 1 if n_r > 1 else ir
+    iv_hi = iv + 1 if n_v > 1 else iv
+
+    idx = np.array([
+        ir    * n_v + iv,
+        ir    * n_v + iv_hi,
+        ir_hi * n_v + iv,
+        ir_hi * n_v + iv_hi,
+    ])
+    w = np.array([
+        (1.0 - tr) * (1.0 - tv),
+        (1.0 - tr) * tv,
+        tr * (1.0 - tv),
+        tr * tv,
+    ]) * sigma_s_weight_np[idx]
+    w_sum = w.sum()
+    if w_sum > 0:
+        w = w / w_sum
+
+    return idx, w
+
+
+def entry_cdf(grid_start_np, grid_len_np, nodes_np, phase_mueller_np, e):
+    """Calculate the CDF of a single entry"""
+
+    s, l = int(grid_start_np[e]), int(grid_len_np[e])
+    entry_nodes = nodes_np[s : s + l]
+    m11 = phase_mueller_np[s : s + l, 0]
+    increments = 0.5 * (m11[:-1] + m11[1:]) * np.diff(entry_nodes)
+    cdf = np.concatenate(([0.0], np.cumsum(increments)))
+    total = cdf[-1]
+    if total > 0:
+        cdf = cdf / total
+    return cdf, total
+
+
+def union_grid(idx, w, grid_start_np, grid_len_np, nodes_np, lo_bound, hi_bound):
+    """Merge two cosine discretizations using a simple union"""
+
+    merged = [lo_bound, hi_bound]
+    for e, wgt in zip(idx, w):
+        if wgt == 0.0:
+            continue
+        e = int(e)
+        s, l = int(grid_start_np[e]), int(grid_len_np[e])
+        entry_nodes = nodes_np[s : s + l]
+        mask = (entry_nodes >= lo_bound) & (entry_nodes <= hi_bound)
+        merged.extend(entry_nodes[mask].tolist())
+    return np.unique(np.array(merged))
+
+
+def mock_phase(
+        r_eff_volume, v_eff_volume,
+        r_eff_grid,   v_eff_grid,
+        nodes, phase_mueller,
+        grid_start, grid_len,
+        sigma_s_weight,
+        mei,
+    ):
+    """Build a reference phase function via tabphase_polarized, reproducing the blended "tabulate" result at the interaction point"""
+
+    nodes_np         = np.array(nodes)
+    grid_start_np    = np.array(grid_start)
+    grid_len_np      = np.array(grid_len)
+    phase_mueller_np = np.array(phase_mueller).reshape(-1, 6)
+
+    idx, w = bilinear_corners(
+        r_eff_volume, v_eff_volume, r_eff_grid, v_eff_grid, sigma_s_weight, mei)
+
+    lo_bound = max(nodes_np[int(grid_start_np[int(e)])] for e in idx)
+    hi_bound = min(nodes_np[int(grid_start_np[int(e)]) + int(grid_len_np[int(e)]) - 1] for e in idx)
+
+    grid = union_grid(idx, w, grid_start_np, grid_len_np, nodes_np, lo_bound, hi_bound)
+
+    columns = np.zeros((6, len(grid)))
+    for e, wgt in zip(idx, w):
+        if wgt == 0.0:
+            continue
+        e = int(e)
+        s, l = int(grid_start_np[e]), int(grid_len_np[e])
+        entry_nodes = nodes_np[s : s + l]
+        _, total = entry_cdf(grid_start_np, grid_len_np, nodes_np, phase_mueller_np, e)
+        norm = 1.0 / total if total > 0 else 0.0
+        for c in range(6):
+            columns[c] += wgt * norm * np.interp(grid, entry_nodes, phase_mueller_np[s : s + l, c])
+
+    fmt = lambda v: ",".join(repr(float(x)) for x in v)
+
+    return mi.load_dict({
+        "type": "tabphase_polarized",
+        "nodes": fmt(grid),
+        "m11": fmt(columns[0]),
+        "m12": fmt(columns[1]),
+        "m22": fmt(columns[2]),
+        "m33": fmt(columns[3]),
+        "m34": fmt(columns[4]),
+        "m44": fmt(columns[5]),
+    })
+
+
+def eval_and_sample(rng, phase, mei):
+    """Sample and evaluate the phase function at the same interaction, for pdf-consistency checks"""
+
+    ctx = mi.PhaseFunctionContext(None)
+
+    sample1 = float(rng.random())
+    sample2 = mi.Point2f(float(rng.random()), float(rng.random()))
+
+    wo, weight, pdf_sample = phase.sample(ctx, mei, sample1, sample2)
+    val, pdf_eval = phase.eval_pdf(ctx, mei, wo)
+
+    return wo, weight, pdf_sample, val, pdf_eval
+
+
+def check_phase_consistency(
+        rng,
+        phase,
+        r_eff, v_eff, r_eff_grid, v_eff_grid,
+        nodes, phase_mueller, grid_start, grid_len,
+        sigma_s_weight,
+        mei,
+    ):
+    """Check sample/eval self-consistency and agreement with the mock_phase reference"""
+
+    wo, weight, pdf_sample, val, pdf_eval = eval_and_sample(rng, phase, mei)
+
+    assert np.isclose(float(dr.slice(pdf_sample, 0)), float(dr.slice(pdf_eval, 0)))
+
+    mock = mock_phase(
+        r_eff, v_eff, r_eff_grid, v_eff_grid,
+        nodes, phase_mueller, grid_start, grid_len, sigma_s_weight, mei)
+    ctx = mi.PhaseFunctionContext(None)
+    val_mock, pdf_mock = mock.eval_pdf(ctx, mei, wo)
+
+    assert np.isclose(float(dr.slice(pdf_eval, 0)), float(dr.slice(pdf_mock, 0)), rtol=1e-4)
+    assert np.allclose(np.array(val), np.array(val_mock), rtol=1e-3, atol=1e-6)
+
+
+def cell_query_points(r_nodes, v_nodes):
+    """Create test evaluation points at the r_eff/v_eff volumes cell centers"""
+
+    points = []
+    for i in range(len(r_nodes) - 1):
+        r_lo, r_hi = r_nodes[i], r_nodes[i + 1]
+        r_mid = 0.5 * (r_lo + r_hi)
+        for j in range(len(v_nodes) - 1):
+            v_lo, v_hi = v_nodes[j], v_nodes[j + 1]
+            v_mid = 0.5 * (v_lo + v_hi)
+            points.append((r_mid, v_mid))
+            points.append((r_lo, v_mid))
+            points.append((r_mid, v_lo))
+    return points
+
+
+def reference_eval_envelope(query_nodes, grid_start_np, grid_len_np, phase_mueller_np, nodes_np, n_entries):
+    """Reference implementation of accumulate_envelope: per-node max of the normalized phase value across all entries"""
+
+    values = np.zeros(len(query_nodes))
+    for e in range(n_entries):
+        s, l = int(grid_start_np[e]), int(grid_len_np[e])
+        entry_nodes = nodes_np[s : s + l]
+        _, total = entry_cdf(grid_start_np, grid_len_np, nodes_np, phase_mueller_np, e)
+        norm = 1.0 / total if total > 0 else 0.0
+        m11 = np.interp(query_nodes, entry_nodes, phase_mueller_np[s : s + l, 0])
+        values = np.maximum(values, m11 * norm / (2.0 * np.pi))
+    return values
+
+
+############################
+# Parametrization fixtures #
+############################
+
+
+@fixture(params=SCALAR_AND_LLVM_VARIANTS)
+def variants_scalar_or_llvm(request):
+    """Enable one representative scalar variant and one LLVM variant, with conftest's usual per-test cleanup"""
+    return request.getfixturevalue(f"variant_{request.param}")
+
+
+@fixture(params=BLENDING_METHODS)
+def blending_method(request, variants_scalar_or_llvm):
+    """One blending method, skipped for combinations the active variant doesn't support"""
+    if request.param not in blending_methods():
+        pytest.skip("tabulate is scalar-only")
+    return request.param
+
+
+@fixture
+def grid_single(variants_scalar_or_llvm, np_rng):
+    """Simple single-entry (n_r=n_v=1) grid, 10 node points"""
+    return build_grid(np_rng, 1, 1)
+
+
+@fixture
+def rv_volumes_single(np_rng):
+    """Simple constant r_eff v_eff volumes"""
+    return make_rv_volumes(np_rng, (10.0, 10.0), (0.1, 0.1))
+
+
+@fixture
+def interaction_centrenadir():
+    """Basic interaction"""
+    return make_interaction(wi=(0, 0, 1), p=(0.5, 0.5, 0.5))
+
+
+@fixture(params=[
+        (0, 0, 1),
+        (0, 0, -1),
+        (1, 0, 0),
+        (-1, 0, 0),
+        (0, 1, 0),
+        (0, -1, 0),
+        (1, 1, 1),
+        (0.27, -0.64, 0.53),
+    ], ids=["nadir", "zenith", "+x", "-x", "+y", "-y", "oblique", "generic"])
+def interaction_directions(request):
+    """Create several interactions with different directions"""
+    wi = np.array(request.param, dtype=float)
+    wi = wi / np.linalg.norm(wi)
+    return make_interaction(wi=wi, p=(0.5, 0.5, 0.5))
+
+
+@fixture
+def phase_function_single(blending_method, grid_single, rv_volumes_single):
+    """Basic particlefieldphase function using constant r_eff, v_eff properties"""
+    return build_phase_function(grid_single, rv_volumes_single, blending_method)
+
+
+@fixture(params=[(2, 1), (1, 2), (2, 2)], ids=["2x1", "1x2", "2x2"])
+def grid_dual(request, variants_scalar_or_llvm, np_rng):
+    """Build 1 dim and 2 dim interpolation grid parameters"""
+    n_r, n_v = request.param
+    return build_grid(np_rng, n_r, n_v)
+
+
+@fixture(params=[(10.0, 0.1), (10.5, 0.15), (11.0, 0.2)], ids=["low", "mid", "high"])
+def rv_volumes_dual(request, np_rng):
+    """Make several spatial volumes of constant (r_eff, v_eff) values"""
+    r_eff_val, v_eff_val = request.param
+    return make_rv_volumes(np_rng, (r_eff_val, r_eff_val), (v_eff_val, v_eff_val))
+
+
+@fixture
+def phase_function_dual(blending_method, grid_dual, rv_volumes_dual):
+    """Build phase functions of 1 to 2 dim interpolation grid parameters"""
+    return build_phase_function(grid_dual, rv_volumes_dual, blending_method)
+
+
+@fixture(params=[
+        [1.0,    1.0, 1.0, 1.0],
+        [1000.0, 1.0, 1.0, 1.0],
+        [1.0,    1.0, 1.0, 1000.0],
+        [1e-6,   1.0, 1.0, 1.0],
+    ], ids=["uniform", "corner0_dominant", "corner3_dominant", "corner0_suppressed"])
+def grid_sigma_s(request, variants_scalar_or_llvm, np_rng):
+    """Build sigma_s weights for a 2x2 interpolation grid of (r_eff, v_eff)"""
+    return build_grid(np_rng, 2, 2, sigma_s_weight=request.param)
+
+
+@fixture
+def phase_function_sigma_s(blending_method, grid_sigma_s, np_rng):
+    """Build different phase functions with varying sigma_s weights"""
+    rv_volumes = make_rv_volumes(np_rng, (10.5, 10.5), (0.15, 0.15))
+    return build_phase_function(grid_sigma_s, rv_volumes, blending_method)
+
+
+@fixture(params=[
+        (100.0, 0.15, "out of dataset range"),
+        (10.5, 100.0,  "out of dataset range"),
+        (float("nan"), 0.15, "NaN"),
+    ], ids=["r_eff_out_of_range", "v_eff_out_of_range", "nan_r_eff"])
+def phase_invalid_query(request, variant_scalar_mono_polarized, np_rng):
+    """Purposefully build an invalid spatial r_eff or v_eff volume"""
+    r_eff_val, v_eff_val, match = request.param
+    grid = build_grid(np_rng, 2, 2)
+    rv_volumes = make_rv_volumes(np_rng, (r_eff_val, r_eff_val), (v_eff_val, v_eff_val))
+    phase, *_ = build_phase_function(grid, rv_volumes, "search")
+    return phase, match
+
+
+#########
+# Tests #
+#########
+
+
+def test_instantiate(phase_function_single):
+    """Check that a single-entry phase function loads successfully"""
+    phase, *_ = phase_function_single
+    assert phase is not None
+
+
+def test_single_directions(phase_function_single, interaction_directions, np_rng):
+    """Check sample/eval self-consistency of a single-entry phase function across several incoming directions"""
+    check_phase_consistency(np_rng, *phase_function_single, interaction_directions)
+
+
+def test_dual_directions(phase_function_dual, interaction_directions, np_rng):
+    """Check sample/eval self-consistency across 1 and 2 dim (r_eff, v_eff) interpolation grids"""
+    check_phase_consistency(np_rng, *phase_function_dual, interaction_directions)
+
+
+def test_sigma_s_weight(phase_function_sigma_s, interaction_centrenadir, np_rng):
+    """Check sample/eval self-consistency under varying per-corner sigma_s weights"""
+    check_phase_consistency(np_rng, *phase_function_sigma_s, interaction_centrenadir)
+
+
+def test_invalid_query_raises(phase_invalid_query, interaction_centrenadir):
+    """Check that out-of-range or NaN (r_eff, v_eff) queries raise instead of returning silently wrong values"""
+    phase, match = phase_invalid_query
+    ctx = mi.PhaseFunctionContext(None)
+    with pytest.raises(Exception, match=match):
+        phase.eval_pdf(ctx, interaction_centrenadir, mi.Vector3f([0, 0, -1]))
+
+
+def _check_sample_distribution(cos_theta, n_query):
+    """search/stochastic/tabulate cross-check used by test_sample_distribution"""
+
+    failures = []
+    ref = cos_theta["search"]
+
+    if "tabulate" in cos_theta:
+        tab = cos_theta["tabulate"]
+        n = tab.shape[1]
+        close = np.isclose(tab, ref[:, :n], atol=1e-4, rtol=1e-4)
+        n_bad = int((~close).sum())
+        print(f"tabulate: {int(close.sum())}/{close.size} samples matched search "
+              f"to numerical precision ({n_bad} mismatches)")
+
+        if n_bad:
+            q_idx, k_idx = np.unravel_index(np.flatnonzero(~close)[:5], close.shape)
+            failures.append(
+                f"tabulate: {n_bad}/{close.size} samples disagreed with search "
+                f"beyond numerical precision; first mismatches at (query,sample)="
+                f"{list(zip(q_idx.tolist(), k_idx.tolist()))[0]}"
+            )
+
+    if "stochastic" in cos_theta:
+        stoch = cos_theta["stochastic"]
+        cur_mean, cur_std = stoch.mean(axis=1), stoch.std(axis=1)
+        ref_mean, ref_std = ref.mean(axis=1), ref.std(axis=1)
+
+        good = np.isclose(cur_mean, ref_mean, atol=0.05) & np.isclose(cur_std, ref_std, rtol=0.05)
+        bad = ~good
+        print(f"stochastic: {int(good.sum())}/{n_query} interactions matched search in "
+              f"distribution (up to 10 first bad query indices: {np.flatnonzero(bad).tolist()[:10]})")
+
+        if bad.any():
+            failures.append(
+                f"stochastic: {int(bad.sum())}/{n_query} interactions mismatched vs search"
+            )
+
+    assert not failures, "\n".join(failures)
+
+
+def _sample_distribution_grid(rng):
+    """Grid and query points used by test_sample_distribution"""
+    r_bounds, v_bounds = (4.0, 25.0), (0.1, 0.2)
+    grid = build_grid(rng, 22, 2, r_bounds=r_bounds, v_bounds=v_bounds, min_pts=700, max_pts=1000)
+    n_query = 100
+    rv_volumes, meis = make_query_interactions(rng, n_query, r_bounds, v_bounds)
+    return grid, rv_volumes, meis, n_query
+
+
+def _print_sample_timing(method, n_total, elapsed):
+    """Print the per-method sampling throughput for test_sample_distribution"""
+    print(f"{method}: {n_total} samples in {elapsed*1e3:.2f} ms "
+          f"({elapsed/n_total*1e6:.2f} us/sample)")
+
+
+def _sample_cos_theta_scalar(phase, ctx, meis, n_samples, u_all, phi_all, s1_all):
+    """Sample cos_theta one element at a time (scalar variant)"""
+    arr = np.empty((len(meis), n_samples))
+    for q, mei in enumerate(meis):
+        for k in range(n_samples):
+            s1 = float(s1_all[q, k])
+            s2 = mi.Point2f(float(u_all[q, k]), float(phi_all[q, k]))
+            wo, weight, pdf = phase.sample(ctx, mei, s1, s2)
+            arr[q, k] = float(dr.slice(-dr.dot(wo, mei.wi), 0))
+    return arr
+
+
+def _sample_cos_theta_llvm(phase, ctx, mei_batched, n_query, n_samples, u_all, phi_all, s1_all):
+    """Sample cos_theta in batched calls (LLVM variant)"""
+    wo, weight, pdf = phase.sample(
+        ctx, mei_batched,
+        mi.Float(s1_all.reshape(-1)),
+        mi.Point2f(u_all.reshape(-1), phi_all.reshape(-1)),
+    )
+    return np.array(-dr.dot(wo, mei_batched.wi)).reshape(n_query, n_samples)
+
+
+def _batch_interactions(meis, n_samples_per_query):
+    """Tile each query's interaction across its samples (LLVM variant)"""
+    n = len(meis) * n_samples_per_query
+    px = np.repeat([float(dr.slice(mei.p.x, 0)) for mei in meis], n_samples_per_query)
+    py = np.repeat([float(dr.slice(mei.p.y, 0)) for mei in meis], n_samples_per_query)
+    pz = np.repeat([float(dr.slice(mei.p.z, 0)) for mei in meis], n_samples_per_query)
+    wi0 = meis[0].wi
+
+    mei_batched = mi.MediumInteraction3f()
+    mei_batched.wi = mi.Vector3f(
+        [float(dr.slice(wi0.x, 0))] * n,
+        [float(dr.slice(wi0.y, 0))] * n,
+        [float(dr.slice(wi0.z, 0))] * n,
+    )
+    mei_batched.p = mi.Point3f(px, py, pz)
+    mei_batched.sh_frame = mi.Frame3f(mei_batched.wi)
+    return mei_batched
+
+
+def test_sample_distribution(variants_scalar_or_llvm, np_rng):
+    """Check search/tabulate exact agreement and stochastic/search distribution agreement"""
+    rng_local = np.random.default_rng(42)
+
+    grid, rv_volumes, meis, n_query = _sample_distribution_grid(np_rng)
+    ctx = mi.PhaseFunctionContext(None)
+
+    n_samples_per_query = 4000
+    n_samples_tabulate = 100
+
+    u_all = rng_local.random((n_query, n_samples_per_query))
+    phi_all = rng_local.random((n_query, n_samples_per_query))
+    s1_all = rng_local.random((n_query, n_samples_per_query))
+
+    is_scalar = variants_scalar_or_llvm.startswith("scalar")
+    mei_batched = _batch_interactions(meis, n_samples_per_query) if not is_scalar else None
+
+    cos_theta = {}
+    for method in blending_methods():
+        phase, *_ = build_phase_function(grid, rv_volumes, method)
+        n_samples = n_samples_tabulate if method == "tabulate" else n_samples_per_query
+
+        t0 = time.perf_counter()
+        if is_scalar:
+            cos_theta[method] = _sample_cos_theta_scalar(
+                phase, ctx, meis, n_samples, u_all, phi_all, s1_all)
+        else:
+            cos_theta[method] = _sample_cos_theta_llvm(
+                phase, ctx, mei_batched, n_query, n_samples, u_all, phi_all, s1_all)
+        _print_sample_timing(method, n_query * n_samples, time.perf_counter() - t0)
+
+    _check_sample_distribution(cos_theta, n_query)
+
+
+@pytest.mark.parametrize("n_r,n_v", [
+    (n_r, n_v) for n_r in range(10, 60, 10) for n_v in range(10, 60, 10)
+])
+def test_grid_sizes(n_r, n_v, blending_method, np_rng):
+    """Check finite, positive pdf across a set of (r_eff, v_eff) grid shapes"""
+    grid = build_grid(np_rng, n_r, n_v)
+    *_, r_eff_grid, v_eff_grid, _ = grid
+
+    r_eff_grid_np = np.array(r_eff_grid).ravel()
+    v_eff_grid_np = np.array(v_eff_grid).ravel()
+    r_eff_val = float(r_eff_grid_np[len(r_eff_grid_np) // 2])
+    v_eff_val = float(v_eff_grid_np[len(v_eff_grid_np) // 2])
+
+    rv_volumes = make_rv_volumes(np_rng, (r_eff_val, r_eff_val), (v_eff_val, v_eff_val))
+    mei = make_interaction(wi=(0, 0, 1))
+    ctx = mi.PhaseFunctionContext(None)
+
+    phase, *_ = build_phase_function(grid, rv_volumes, blending_method)
+    val, pdf = phase.eval_pdf(ctx, mei, mi.Vector3f([0, 0, -1]))
+    pdf = float(dr.slice(pdf, 0))
+    assert np.isfinite(pdf)
+    assert pdf > 0.0
+
+
+@pytest.mark.parametrize("blending_method", BLENDING_METHODS)
+def test_large_grid_sweep(blending_method, variant_scalar_mono_polarized, interaction_directions, np_rng):
+    """Check sample/eval self-consistency at many query points scattered across a 4x4 grid's cells"""
+    grid = build_grid(np_rng, 4, 4, r_bounds=(10.0, 14.0), v_bounds=(0.1, 0.2))
+    *_, r_eff_grid, v_eff_grid, _ = grid
+
+    r_eff_grid_np = np.array(r_eff_grid).ravel()
+    v_eff_grid_np = np.array(v_eff_grid).ravel()
+    query_points = cell_query_points(r_eff_grid_np, v_eff_grid_np)
+
+    for r_val, v_val in query_points:
+        rv_volumes = make_rv_volumes(np_rng, (r_val, r_val), (v_val, v_val))
+        phase_bundle = build_phase_function(grid, rv_volumes, blending_method)
+        check_phase_consistency(np_rng, *phase_bundle, interaction_directions)
+
+
+def test_get_envl_and_eval_envl(variants_scalar_or_llvm, np_rng):
+    """Check get_envelope_nodes/accumulate_envelope against a reference per-node max of the normalized phase value"""
+    n_r, n_v = 3, 3
+    grid = build_grid(np_rng, n_r, n_v)
+    nodes, grid_start, grid_len, phase_mueller, *_ = grid
+    rv_volumes = make_rv_volumes(np_rng, (10.5, 10.5), (0.15, 0.15))
+    phase, *_ = build_phase_function(grid, rv_volumes, "search")
+
+    nodes_np         = np.array(nodes)
+    grid_start_np    = np.array(grid_start)
+    grid_len_np      = np.array(grid_len)
+    phase_mueller_np = np.array(phase_mueller).reshape(-1, 6)
+
+    nds = phase.get_envelope_nodes()
+    nds_np = np.array(nds)
+    assert np.allclose(nds_np, np.unique(nodes_np))
+
+    array, _ = storage_types()
+    values = array(np.zeros(len(nds_np)))
+    phase.accumulate_envelope(nds, values)
+
+    ref_values = reference_eval_envelope(nds_np, grid_start_np, grid_len_np, phase_mueller_np, nodes_np, n_r * n_v)
+
+    assert np.allclose(np.array(values), ref_values, rtol=1e-4, atol=1e-8)
+
+
+def test_degenerate_directions(blending_method, interaction_directions, np_rng):
+    """Check finite, non-negative pdf and agreement with the mock reference when wo is exactly aligned/anti-aligned with wi"""
+    mei = interaction_directions
+    ctx = mi.PhaseFunctionContext(None)
+    grid = build_grid(np_rng, 2, 2)
+    rv_volumes = make_rv_volumes(np_rng, (10.5, 10.5), (0.15, 0.15))
+
+    phase, r_eff, v_eff, r_eff_grid, v_eff_grid, nodes, phase_mueller, grid_start, grid_len, sigma_s_weight = \
+        build_phase_function(grid, rv_volumes, blending_method)
+    mock = mock_phase(
+        r_eff, v_eff, r_eff_grid, v_eff_grid,
+        nodes, phase_mueller, grid_start, grid_len, sigma_s_weight, mei)
+
+    for wo in (mi.Vector3f(mei.wi), -mi.Vector3f(mei.wi)):
+        val, pdf = phase.eval_pdf(ctx, mei, wo)
+        pdf = float(dr.slice(pdf, 0))
+        assert np.all(np.isfinite(np.array(val)))
+        assert np.isfinite(pdf)
+        assert pdf >= 0.0
+
+        val_mock, pdf_mock = mock.eval_pdf(ctx, mei, wo)
+        assert np.isclose(pdf, float(dr.slice(pdf_mock, 0)), rtol=1e-4)
+        assert np.allclose(np.array(val), np.array(val_mock), rtol=1e-3, atol=1e-6)
+
+
+def test_llvm_variant(variant_llvm_ad_rgb, np_rng):
+    """Check that tabulate correctly refuses to instantiate under LLVM"""
+    grid = build_grid(np_rng, 2, 2)
+    rv_volumes = make_rv_volumes(np_rng, (10.5, 10.5), (0.15, 0.15))
+    with pytest.raises(Exception, match="tabulate"):
+        build_phase_function(grid, rv_volumes, "tabulate")
+
+
+def test_chi2(variants_vec_backends_once_rgb, np_rng):
+    """Check sample/pdf statistical consistency via a chi-squared test against the spherical domain"""
+    n_r, n_v = 2, 2
+    r_bounds, v_bounds = (4.0, 25.0), (0.1, 0.2)
+
+    nodes, grid_start, grid_len, phase_mueller = make_phase_grid(
+        np_rng, n_r=n_r, n_v=n_v, min_pts=20, max_pts=40,
+        array=mi.Float, array_u=mi.UInt32,
+    )
+    r_eff_grid, v_eff_grid, sigma_s_weight = make_rv_grid(
+        n_r=n_r, n_v=n_v, r_bounds=r_bounds, v_bounds=v_bounds,
+    )
+    r_eff_volume, v_eff_volume = make_rv_volumes(np_rng, r_bounds, v_bounds, shape=(1, 1, 1))
+
+    phase_dict = {
+        "type": "particlefieldphase",
+        "r_eff_volume": r_eff_volume,
+        "v_eff_volume": v_eff_volume,
+        "r_eff_grid": r_eff_grid,
+        "v_eff_grid": v_eff_grid,
+        "nodes": nodes,
+        "phase_mueller": phase_mueller,
+        "grid_start": grid_start,
+        "grid_len": grid_len,
+        "blending_method": "search",
+        "sigma_s_weight": sigma_s_weight,
+    }
+
+    sample_func, pdf_func = mi.chi2.PhaseFunctionAdapter("particlefieldphase", phase_dict)
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+    )
+
+    result = chi2.run()
+    assert result


### PR DESCRIPTION
## Description

Requires https://github.com/eradiate/mitsuba3/pull/46.

This PR introduces a new plugin, `particlefieldphase`. This plugin is made to support spatially varying phase functions, interpolated from their physical properties at the interaction point.

## Interpolation weights

Each interaction point gets a couple ($r_{reff}, v_{eff}$), obtained from evaluating the `r_eff` and `v_eff` gridvolumes defined in 3D space. The plugin interpolates this couple bilinearly against two regular grids ($R_{eff}, V_{eff}$) where the phase functions are actually defined.

The interpolation weight of the 4 bilinear interpolation corners is defined as the geometric weight of the query's position in $(R_{eff}, V_{eff})$, rescaled by each corner's own scattering probability and renormalized.

<img width="981" height="441" alt="image" src="https://github.com/user-attachments/assets/9cdfb3da-523b-47c5-a610-dc72f7393875" />

## Interpolation methods

Three interpolation/blending methods are implemented, treating the ragged structure of phase function discretizations differently. Individual phase functions at the ($R_{eff}$, $V_{eff}$) grid nodes or at a query point ($r_{eff}$, $v_{eff}$) are treated as tabulated phases defined on the cosine of the scattering angle $\mu$. For each phase function of the ($R_{eff}$, $V_{eff}$) grid $\mu$ can be defined on an independent arbitrary irregular discretization. As a result, the interpolated phase at ($r_{eff}$, $v_{eff}$) is defined on a $\mu^u$ grid that is not provided by the user. $\mu^u$ is the union of the discretizations of the 4 ($R_{eff}$, $V_{eff}$) corners bracketing ($r_{eff}$, $v_{eff}$). This plugin implements several strategies to express $\mu^u$ explicitly or implicitly:
 - `tabulate`: Explicitly build $\mu^u$ and reimplements the feature set of `tabphase_polarized` without paying the plugin construction cost. Used for testing/debug and benchmark purposes
 - `search`: Perform a bisection of the cosine coordinate to find the segments to invert in the cornering phases of the ($R_{eff}$, $V_{eff}$) regular grid.
 - `stochastic`: Select one of the 4 corner phases according to their interpolation weight. The selected phase is then treated like a tabulated phase, and the PDF is evaluated as the corners' weighted PDF.

| Method | Union grid materialized | Domain used | Init (time / mem) | eval_pdf (time / mem) | sample (time / mem) |
|---|---|---|---|---|---|
| stochastic | never | corner's own | $O(N)$ / $O(N)$ | $O(\log L)$ / $O(1)$ | $O(\log L)$ / $O(1)$ |
| search | never (implicit) | intersection | $O(N)$ / $O(N)$ | $O(\log L)$ / $O(1)$ | $O(I_{\text{search}} \log L)$, $I_{\text{search}} \le 30$ / $O(1)$ |
| tabulate | yes, $M_{11}$ only | intersection | $O(N)$ / $O(N)$ | $O(\log L)$ / $O(1)$ | $O(n \log n)$ / $O(n)$ |

**With:**
  - $L$ — number of $\mu$ tabulation points in the largest of the 4 corner phase functions bracketing the query.
  - $n$ — total number of $\mu$ tabulation points summed across those same 4 corners
  - $N$ — total number of $\mu$ tabulation points across the whole plugin (all grid entries)
  - $I_{\text{search}}$ — number of loop iterations actually run by the search method, capped at 30 respectively.

### Search method

Search method performs a bisection of the $\mu$ dimention to find the segments of each corner's discretization to invert. Here is a small breakdown using only 2 corners to visually represent the process:
<img width="860" height="435" alt="image" src="https://github.com/user-attachments/assets/b3ac63ca-f8ab-473f-bd63-6aac6ae77048" />
The algo inspect iteratively the middle point of a search window until all corners only have one segment in that window
<img width="855" height="444" alt="image" src="https://github.com/user-attachments/assets/ef0506d9-5fa5-445a-bc9e-30e498e43cb9" />
<img width="869" height="462" alt="image" src="https://github.com/user-attachments/assets/4cd23a9f-4427-4a71-a440-b816dbb9086d" />
In other words, it's a continuous binary search. At each iteration, the blended cdf is evaluated using the 4 corners. When the correct segment is located in the 4 corners, the loop stops and the segments are inverted.

## Performances

Sampling throughput measured on a realistic-scale configuration test (a $22 \times 2$ ($R_{eff}$, $V_{eff}$) grid, 700 to 1000 $\mu$ nodes per entry, cycling through roughly 200 independent random query points):

| Method | Time per sample |
|---|---|
| stochastic | $\approx 1.7$ μs |
| search | $\approx 3.4$ μs |
| tabulate | $\approx 140$ μs |

## Testing

Tests are performed under `src/eradiate_plugins/tests/phase/test_particlephase.py`. 

A ground truth `tabphase_polarized` phase function is rebuilt separately to evaluate correctness against an external implementation. Tests are progressive and check consistency between $\mu^u$ expression methods.

The `stochastic` method is compared within a given error threshold.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `llvm_*` variants.
- [ ] My code also compiles for `cuda_*` variants.
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)