### PR TITLE
[Fix] Clear dirty flag of shapes held by the shapegroup.

### DIFF
--- a/include/mitsuba/render/shapegroup.h
+++ b/include/mitsuba/render/shapegroup.h
@@ -51,6 +51,11 @@ public:
     /// Returns a union of ShapeType flags denoting what is present in the ShapeGroup
     uint32_t shape_types() const { return m_shape_types; }
 
+// #ERADIATE_CHANGE_BEGIN: This fix resets the dirty flags to avoid rebuilding the kdtree (from #b494500)
+    /// Read-only access to the contained shapes.
+    const std::vector<ref<Base>> &shapes() const { return m_shapes; }
+// #ERADIATE_CHANGE_END
+
     void traverse(TraversalCallback *callback) override;
     void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override;
     bool parameters_grad_enabled() const override;

--- a/src/render/scene.cpp
+++ b/src/render/scene.cpp
@@ -636,8 +636,15 @@ MI_VARIANT void Scene<Float, Spectrum>::static_accel_shutdown() {
 MI_VARIANT void Scene<Float, Spectrum>::clear_shapes_dirty() {
     for (auto &s : m_shapes)
         s->m_dirty = false;
-    for (auto &s : m_shapegroups)
+// #ERADIATE_CHANGE_BEGIN: This fix resets the dirty flags to avoid rebuilding the kdtree (from #b494500)
+    for (auto &s : m_shapegroups) {
         s->m_dirty = false;
+        // Clear the group's children too (consumed into its accel by the same
+        // build); a backend's per-group dirty check relies on this.
+        for (auto &c : s->shapes())
+            const_cast<Shape *>(c.get())->m_dirty = false;
+    }
+// #ERADIATE_CHANGE_END
 }
 
 MI_VARIANT void Scene<Float, Spectrum>::static_accel_initialization_cpu() { }


### PR DESCRIPTION
## Description

Hello, 
This PR fixes an issue pertaining to the `KDTree` and `Shapegroup`. It was found that when using `KDTrees`, the `Shapegroup`'s internal `Shapes` never cleared their dirty flags, as opposed to the Embree or Optix configuration. The fix is borrowed from [a commit from the main Mitsuba 3 repo](https://github.com/mitsuba-renderer/mitsuba3/commit/b494500dd04d4750294b59e5956ac0bccbe98670), meaning that no further changes will be needed when rebasing to version 3.9. 

The fix adds an interface to expose the shape list of the `Shapegroup`. This is then used by the scene to clear the dirty flag of all the shapes in `clear_shapes_dirty`. Note that in its current state, this will do redundant work with Embree and Optix, as those configurations already clear the dirty flags. I preferred keeping this non-breaking redundancy to favor future compatibility.

## Testing

The eradiate test suite was run. Testing was also done by inspecting the output of the following script: 

```
import mitsuba as mi
mi.set_variant("scalar_rgb")
mi.set_log_level(mi.LogLevel.Info)

scene = mi.load_dict({
    "type":"scene",
    "sg":{
        "type":"shapegroup",
        "cube":{
            "type":"cube",
            "bsdf":{"type":"diffuse", "reflectance":0.5},
            "to_world":mi.ScalarAffineTransform4f(),
        }
    }
})

params = mi.traverse(scene)
params["sg.cube.bsdf.reflectance.value"] = 0.3
_ = params.update()
params["sg.cube.bsdf.reflectance.value"] = 0.4
_ = params.update()
```
Without the fix, 3 updates occur against 1 with the fix. I believe Shapegroups doe not have binding, it is therefore not trivial to add testing for it. 

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)