### PR TITLE
[Enhancement] Create a new `eradiate` module that implements a custom scene traversal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ strive to document breaking API changes in the release notes below.
 - Add an experimental implementation for periodic boundaries of extremum grid
   structures
   (PR [#34](https://github.com/eradiate/mitsuba3/pull/34)).
+- Create a new custom scene traversal function which traverses all parents of
+  a node, not just the first one. Combine it with Eradiate's traversal function
+  (PR [#37](https://github.com/eradiate/mitsuba3/pull/37)).
 
 ## v0.5.0 (9th June 2026)
 

--- a/src/python/python/__init__.py
+++ b/src/python/python/__init__.py
@@ -1,4 +1,5 @@
 from .util import traverse, SceneParameters, render, cornell_box, variant_context, scoped_set_variant
+from . import eradiate
 from . import chi2
 from . import ad
 from . import math_py

--- a/src/python/python/eradiate.py
+++ b/src/python/python/eradiate.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import drjit as dr
+import mitsuba as mi
+
+from .util import SceneParameters, _jit_id_hash
+
+
+class EradiateSceneParameters(SceneParameters):
+    """
+    An extended :py:class:`~mitsuba.SceneParameters` that traverses all
+    parents of a node. Also collects the nodes' deduplicated ``names``.
+
+    Plain :py:func:`mitsuba.traverse` only remembers the first parent it
+    encounters in traversal. :py:meth:`~mitsuba.SceneParameters.update` only
+    notifies this parent and ignores any additional parents it might have.
+    Additionally, the name of the node it traverses is not guaranteed to be
+    based on its id depending on the order it is traversed.
+
+    Use :py:func:`eradiate.traverse` to get an :py:class:`EradiateSceneParameters`
+    instead, whose :py:meth:`update` notifies every parent.
+    """
+
+    def __init__(self, properties=None, hierarchy=None, names=None):
+        super().__init__(properties, hierarchy)
+        self.names = names if names is not None else {}
+        self._depth_cache = {}
+
+    def __repr__(self) -> str:
+        result = super().__repr__()
+        return result.replace("SceneParameters", self.__class__.__name__)
+
+    def copy(self):
+        return EradiateSceneParameters(
+            dict(self.properties),
+            {k: list(v) for k, v in self.hierarchy.items()},
+            names=dict(self.names),
+        )
+
+    def _depth(self, node):
+        """
+        Recursively compute the maximum depth of a node by walking through all
+        its parents. Cache the result in ``_depth_cache`` to amortize cost.
+        """
+        if node not in self._depth_cache:
+            parents = self.hierarchy.get(node, [])
+            self._depth_cache[node] = 1 + max(
+                (self._depth(p) for p, _ in parents if p is not None), default=-1
+            )
+        return self._depth_cache[node]
+
+    def set_dirty(self, key: str, expanded=None):
+        value, _, node, flags = self.properties[key]
+
+        is_nondifferentiable = flags & mi.ParamFlags.NonDifferentiable
+        if is_nondifferentiable and dr.grad_enabled(value):
+            mi.Log(
+                mi.LogLevel.Warn,
+                f"Parameter '{key}' is marked as non-differentiable but has "
+                "gradients enabled, unexpected results may occur!",
+            )
+
+        self.nodes_to_update.setdefault(node, set()).add(key.rsplit(".", 1)[-1])
+
+        # Climb the tree through all parent nodes using a stack based approach.
+        stack = list(self.hierarchy[node])
+        if expanded is None:
+            expanded = set()
+        while stack:
+            parent, name = stack.pop()
+            if parent is None:
+                continue
+            self.nodes_to_update.setdefault(parent, set()).add(name)
+            if parent in expanded:
+                continue
+            expanded.add(parent)
+            stack.extend(self.hierarchy[parent])
+
+        return self.properties[key]
+
+    def update(self, values=None):
+        if values is not None:
+            for k, v in values.items():
+                if k in self:
+                    self[k] = v
+
+        update_candidate_keys = list(self.update_candidates.keys())
+        expanded = set()
+        for key in update_candidate_keys:
+            # Candidate objects might have been modified inplace, we must check
+            # the JIT identifiers to see if the object has truly changed.
+            if _jit_id_hash(self[key]) == self.update_candidates[key]:
+                continue
+
+            self.set_dirty(key, expanded)
+
+        for key in self.keys():
+            # explicitely reproduce __get_value__ as it cannot be called.
+            value, value_type, node, _ = self.properties[key]
+            if value_type is not None:
+                value = self.get_property(value, value_type, node)
+            dr.schedule(value)
+
+        work_list = sorted(
+            self.nodes_to_update.items(),
+            key=lambda item: self._depth(item[0]),
+            reverse=True,
+        )
+        out = []
+        for node, keys in work_list:
+            node.parameters_changed(list(keys))
+            out.append((node, keys))
+
+        self.nodes_to_update.clear()
+        self.update_candidates.clear()
+        dr.eval()
+
+        return out
+
+
+def traverse(node: mi.Object, name_id_override=None) -> EradiateSceneParameters:
+    """
+    Like :py:func:`mitsuba.traverse`, but returns an
+    :py:class:`EradiateSceneParameters`: a subsequent call to
+    :py:meth:`~EradiateSceneParameters.update` notifies every parent of a
+    shared object, not just the first one traversal happened to discover.
+
+    Parameter ``node`` (``mi.Object``):
+        Node to be traversed.
+
+    Parameter ``name_id_override`` (``bool``, ``str``, ``[str]``, ``None``):
+        If set, this argument will be used to select nodes in the scene tree
+        whose names will be "pinned" to their ID. Passed values are used as
+        regular expressions, with all that it implies regarding ID string
+        matching. If this parameter is set to ``True``, a regex that matches
+        anything is used.
+
+    Returns → :py:class:`EradiateSceneParameters`:
+        The scene parameters obtained from traversing ``node``.
+    """
+
+    import re
+
+    if name_id_override is None or name_id_override is False:
+        name_id_override = []
+
+    if name_id_override is True:
+        name_id_override = [r".*"]
+
+    if type(name_id_override) is not list:
+        name_id_override = [name_id_override]
+
+    regexps = [re.compile(k).match for k in name_id_override]
+
+    class EradiateSceneTraversal(mi.TraversalCallback):
+        def __init__(
+            self,
+            node,
+            parent=None,
+            properties=None,
+            hierarchy=None,
+            prefixes=None,
+            name=None,
+            local_name=None,
+            flags=+mi.ParamFlags.Differentiable,
+            names=None,
+        ):
+            mi.TraversalCallback.__init__(self)
+            self.properties = dict() if properties is None else properties
+            self.hierarchy = dict() if hierarchy is None else hierarchy
+            self.prefixes = set() if prefixes is None else prefixes
+            self.names = dict() if names is None else names
+
+            node_id = node.id()
+            if name_id_override and node_id:
+                for r in regexps:
+                    if r(node_id):
+                        name = node_id
+                        break
+
+            if name is not None:
+                ctr, name_len = 1, len(name)
+                while name in self.prefixes:
+                    name = "%s_%i" % (name[:name_len], ctr)
+                    ctr += 1
+                self.prefixes.add(name)
+
+            self.name = name
+            self.node = node
+            # fully resolved (deduplicated) name.
+            self.names[node] = name
+            # An object can be reached from more than one parent (shared via
+            # a scene-level reference): record every parent edge, keyed by
+            # the name under which that specific parent refers to it.
+            self.hierarchy.setdefault(node, []).append((parent, local_name))
+            self.flags = flags
+
+        def put(self, name, value, flags, cpptype=None):
+            if isinstance(value, mi.Object):
+                self.put_object(name, value, flags)
+            else:
+                self.put_value(name, value, flags, cpptype)
+
+        def put_value(self, name, ptr, flags, cpptype):
+            name = name if self.name is None else self.name + "." + name
+
+            flags = self.flags | flags
+            if (flags & mi.ParamFlags.NonDifferentiable) != 0:
+                flags = flags & ~mi.ParamFlags.Discontinuous
+
+            self.properties[name] = (ptr, cpptype, self.node, self.flags | flags)
+
+        def put_object(self, name, obj, flags):
+            if obj is None:
+                return
+            if obj in self.hierarchy:
+                # Exists in hierarchy: add parent edge but don't traverse again.
+                self.hierarchy[obj].append((self.node, name))
+                return
+            cb = EradiateSceneTraversal(
+                node=obj,
+                parent=self.node,
+                properties=self.properties,
+                hierarchy=self.hierarchy,
+                prefixes=self.prefixes,
+                name=name if self.name is None else self.name + "." + name,
+                local_name=name,
+                flags=self.flags | flags,
+                names=self.names,
+            )
+            obj.traverse(cb)
+
+    cb = EradiateSceneTraversal(node)
+    node.traverse(cb)
+
+    return EradiateSceneParameters(cb.properties, cb.hierarchy, names=cb.names)


### PR DESCRIPTION
## Description

Hello, 
This PR is linked to [Eradiate PR 593](https://github.com/eradiate/eradiate/pull/593).
This PR adds a new `eradiate.py` module to the kernel that includes implementations of a custom scene traversal function.
The aim is twofold:
  - Add support for multiple parent node traversal. The stock Mitsuba implementation of the node traversal only ever records and propagates updates to the first parent of a node, even when there are multiple. This change allows to do so to all parents of a node.
  - Bring the name id overriding features that were previously in the `eradiate` repository directly in the kernel.

**Why**
Multiple parent traversal allows for more robust traversal. This has been a problem when it came to implementing features such as extremum structures and DDIS phase functions that required updating their nodes based on children nodes. Very often, the parent node would never get updated because it was not recorded as the first discovered parent. 

Porting the name id overriding feature ensures feature parity with the previously implemented custom traversal function from the Eradiate repository. 

Additionally, localizing the traversal code in the kernel repository ensures the kernel can be used independently from the Eradiate interface.

**How**
By recording all parents in the hierarchy and traversing them through a stack based approach. Given the changes in the traversal i.e. not string based anymore, I dropped the used of `self.aliases`. To also ensure that the kernel and Eradiate are as independent as possible, I refrained from passing any `KernelSceneParameterMap` to the traversal function. 
This means that filling the `uparam.parameter_id` needs to be done after the traversal (see Eradiate's companion PR for more details).

## Testing

Ran the Eradiate test suite and added a test for multiple parent traversal. 
Let me know if you would prefer to now move those tests to this repository.

Since we are now traversing many more nodes at a time, I make sure to cache as many things as possible (see the `_depth_cache` or the use of `expanded`). Also ran some benchmark tests that allowed to uncover the bug found in PR #36. Here are some numbers that show how this scales with number of parents:

| parents | traversal new (ms) | traversal old (ms)  |
|-----------|--------------------|---------------------|
| 100       | 0.289             | 0.227              |
| 10000     | 25.521             | 21.399              |

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)