### PR TITLE
[Enhancement] Add the `wrap` parameter to the `grid` plugin.

### DIFF
--- a/src/eradiate_plugins/tests/volumes/test_grid.py
+++ b/src/eradiate_plugins/tests/volumes/test_grid.py
@@ -1,0 +1,48 @@
+import drjit as dr
+import mitsuba as mi
+import pytest
+
+
+def test_wrap(variant_all_backends_once):
+    grid = dr.full(mi.TensorXf, 1.0, [3, 3, 3])
+    grid[0, 0, 0] = 0.0
+    grid[1, 1, 1] = 0.5
+    volume_grid = mi.VolumeGrid(grid)
+    inside_value = (6 * 1.0 + 1 * 0.5 + 1 * 0.0) / 8  # interpolated value
+
+    it = mi.Interaction3f()
+
+    # wrap=False: queries outside [0, 1]^3 evaluate to zero, queries inside
+    # evaluate normally
+    vol = mi.load_dict({"type": "gridvolume", "grid": volume_grid, "wrap": False})
+
+    it.p = mi.Point3f(1.0) / 3
+    assert dr.allclose(vol.eval(it), inside_value)
+
+    for p in [
+        (-0.1, 0.5, 0.5),
+        (1.1, 0.5, 0.5),
+        (0.5, -0.1, 0.5),
+        (0.5, 1.1, 0.5),
+        (0.5, 0.5, -0.1),
+        (0.5, 0.5, 1.1),
+    ]:
+        it.p = mi.Point3f(*p)
+        assert dr.allclose(vol.eval(it), 0.0)
+
+    # The [0, 1]^3 domain is inclusive: querying exactly on the boundary
+    # (x=0 or x=1, away from the two special cells so clamp-mode
+    # interpolation resolves to the constant 1.0 slice) must not be zeroed.
+    for p in [(0.0, 0.5, 0.5), (1.0, 0.5, 0.5)]:
+        it.p = mi.Point3f(*p)
+        assert dr.allclose(vol.eval(it), 1.0)
+
+    # wrap=True (default): queries outside [0, 1]^3 are handled by
+    # wrap_mode instead of evaluating to zero
+    vol_wrap = mi.load_dict({"type": "gridvolume", "grid": volume_grid, "wrap": True})
+
+    it.p = mi.Point3f(1.0) / 3
+    assert dr.allclose(vol_wrap.eval(it), inside_value)
+
+    it.p = mi.Point3f(-0.1, 0.5, 0.5)
+    assert not dr.allclose(vol_wrap.eval(it), 0.0)

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -13,6 +13,7 @@
 NAMESPACE_BEGIN(mitsuba)
 
 
+// #ERADIATE_CHANGE_BEGIN: Add `wrap` parameter
 /**!
 .. _volume-gridvolume:
 
@@ -56,6 +57,11 @@ Grid-based volume data source (:monosp:`gridvolume`)
 
      - ``nearest``: disable interpolation. In this mode, the plugin
        performs nearest neighbor lookups of volume values.
+
+ * - wrap
+   - |bool|
+   - Specify whether wrap conditions should be applied outside of [0,1]^3. When
+     not applied, queries outside the domain evaluate to zero (Default: true).
 
  * - wrap_mode
    - |string|
@@ -142,6 +148,7 @@ little endian encoding and is specified as follows:
         }
 
 */
+// #ERADIATE_CHANGE_END
 
 /**
  * Interpolated 3D grid texture of scalar or color values.
@@ -172,6 +179,10 @@ public:
         else
             Throw("Invalid filter type \"%s\", must be one of: \"nearest\" or "
                   "\"trilinear\"!", filter_type_str);
+
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        m_wrap = props.get<bool>("wrap", true);
+// #ERADIATE_CHANGE_END
 
         std::string_view wrap_mode_st = props.get<std::string_view>("wrap_mode", "clamp");
         dr::WrapMode wrap_mode;
@@ -455,8 +466,11 @@ public:
             out[i] = m_max_per_channel[i];
     }
 
-// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
-    ScalarFloat min() const override { return m_min; }
+// #ERADIATE_CHANGE_BEGIN: Tracking estimators extension && add `wrap` parameter
+    ScalarFloat min() const override {
+        // possibility to evaluate to zero outside [0,1]^3
+        return m_wrap ? m_min : 0.f;
+    }
 
     void min_per_channel(ScalarFloat *out) const override {
         for (size_t i=0; i<m_min_per_channel.size(); ++i)
@@ -593,6 +607,7 @@ public:
             << "  max = " << m_max << "," << std::endl
 // #ERADIATE_CHANGE_BEGIN: Tracking estimators extension
             << "  min = " << m_min << "," << std::endl
+            << "  wrap = " << m_wrap << "," << std::endl
 // #ERADIATE_CHANGE_END
             << "  channels = " << m_texture.shape()[3] << std::endl
             << "]";
@@ -618,6 +633,18 @@ protected:
         return channels;
     }
 
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+    /**
+     * \brief Calculates the wrap mask given a position
+     *
+     * Evaluates to true if `m_wrap` is true or that `p` is within [0,1]^3
+     * (inclusive). Otherwise evaluates to false.
+     */
+    MI_INLINE Mask wrap_mask(const Point3f &p) const {
+        return m_wrap || !dr::any((p < 0.f) || (p > 1.f));
+    }
+// #ERADIATE_CHANGE_END
+
     /**
      * \brief Evaluates the volume at the given interaction using spectral
      * upsampling
@@ -627,6 +654,12 @@ protected:
         MI_MASK_ARGUMENT(active);
 
         Point3f p = m_to_local * it.p;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        active &= wrap_mask(p);
+        if (dr::any_or<false>(!active)) {
+            return 0.f;
+        }
+// #ERADIATE_CHANGE_END
 
         if (m_texture.filter_mode() == dr::FilterMode::Linear) {
             dr::Array<Float, 4> d000, d100, d010, d110, d001, d101, d011, d111;
@@ -702,6 +735,13 @@ protected:
         MI_MASK_ARGUMENT(active);
 
         Point3f p = m_to_local * it.p;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        active &= wrap_mask(p);
+        if (dr::any_or<false>(!active)) {
+            return 0.f;
+        }
+// #ERADIATE_CHANGE_END
+
         Float result;
         if (m_accel)
             m_texture.template eval<Float>(p, &result, active);
@@ -721,6 +761,13 @@ protected:
         MI_MASK_ARGUMENT(active);
 
         Point3f p = m_to_local * it.p;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        active &= wrap_mask(p);
+        if (dr::any_or<false>(!active)) {
+            return 0.f;
+        }
+// #ERADIATE_CHANGE_END
+
         Color3f result;
         if (m_accel)
             m_texture.template eval<Float>(p, result.data(), active);
@@ -740,6 +787,13 @@ protected:
         MI_MASK_ARGUMENT(active);
 
         Point3f p = m_to_local * it.p;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        active &= wrap_mask(p);
+        if (dr::any_or<false>(!active)) {
+            return 0.f;
+        }
+// #ERADIATE_CHANGE_END
+
         dr::Array<Float, 6> result;
         if (m_accel)
             m_texture.template eval<Float>(p, result.data(), active);
@@ -760,6 +814,13 @@ protected:
         MI_MASK_ARGUMENT(active);
 
         Point3f p = m_to_local * it.p;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+        active &= wrap_mask(p);
+        if (dr::any_or<false>(!active)) {
+            return;
+        }
+// #ERADIATE_CHANGE_END
+
         if (m_accel)
             m_texture.template eval<Float>(p, out, active);
         else
@@ -781,6 +842,9 @@ protected:
     Texture3f m_texture;
     bool m_accel;
     bool m_raw;
+// #ERADIATE_CHANGE_BEGIN: add `wrap` parameter
+    bool m_wrap = true;
+// #ERADIATE_CHANGE_END
     bool m_fixed_max = false;
     ScalarFloat m_max;
     std::vector<ScalarFloat> m_max_per_channel;


### PR DESCRIPTION
## Description

Hello, 
This PR adds a boolean `wrap` parameter to the `grid` parameter. 
When enabled, `eval` queries to the plugin are performed as before: the policy specified in `wrap_mode` is used for queries outside the local [0,1]^3 range. 
When disabled, `eval` queries to the plugin return zero when positioned outside the local [0,1]^3.

**Why** 
As we move towards overlapping media, we need to be able to have volumes restricted by their domain. At first glance, we could use the medium's domain, i.e. its aabb, to restrict the queries. However, doing so restricts us to having axis-aligned volumes. Any rotation introduces a gap between the volume's transformed domain and the medium `aabb`. It therefore indicates that there is a gap to be filled in the grid evaluation where we need to evaluate the volume to zero when outside its [0,1]^3 range.

**How**
My first consideration was to extend the `wrap_mode` parameter to accept a `none` string. This had two major pitfalls:
- `WrapMode` is a `drjit` enum, meaning that we cannot extend it. Using a separate member variable in `GridVolume` could work, but the repr would still show the initial `wrap_mode`, making it confusing.
- `wrap_mode` directs the indexing of the queries rather than the queried value itself, meaning that `none` would be a departure from the original intended use.

For these reasons, I opted for a separate `wrap` parameter that toggles the ability to wrap the volume or not. In scalar mode, interpolation function will do an early exit if outside the range with `wrap=false`.

## Testing

A unit test was added the function of the parameter. 
Compatibility of the parameter with extremum structures was not tested as the Extremum and Volume interface will change in a coming PR.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)