### PR TITLE
[enhancement] Refactor extremum interface

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -2960,12 +2960,17 @@ R"doc(Abstract base class for extremum structures
 
 ExtremumStructure provides an interface for spatial data structures
 that store local extrema (majorant/minorant) of volumetric extinction
-coefficients. This enables efficient delta tracking with locally-
-adaptive majorants.
+coefficients. This enables efficient use of tracking algorithms with
+locally-adaptive majorants and minorants.
 
 To minimize virtual function overhead, the ``traverse_extremum()``
 method encapsulates the entire traversal loop internally, requiring
-only a single virtual call per distance sample.)doc";
+only a single virtual call per distance sample.
+
+The extremum structure needs to be built using the ``update_extremum``
+function, it is **not** called automatically in the constructor. The
+caller, usually a ``Medium``, passes the volumetric data the extremum
+is derived from.)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_2 = R"doc()doc";
 
@@ -2987,7 +2992,17 @@ static const char *__doc_mitsuba_ExtremumStructure_ExtremumStructure = R"doc(//!
 
 static const char *__doc_mitsuba_ExtremumStructure_ExtremumStructure_2 = R"doc()doc";
 
-static const char *__doc_mitsuba_ExtremumStructure_bbox = R"doc(Return the bounding box of the extremum structure)doc";
+static const char *__doc_mitsuba_ExtremumStructure_bbox = R"doc(//! @{ \name Non-virtual query methods)doc";
+
+static const char *__doc_mitsuba_ExtremumStructure_build =
+R"doc(Build the extremum structure of ``volume``.
+
+Implements the logic that constructs the extremum structure from a
+``volume``. Called by ``update_extremum`` which is itself called by
+the owning ``Medium``
+
+Parameter ``volume``:
+    Volume to compute extremum values from)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_class_name = R"doc()doc";
 
@@ -3007,7 +3022,13 @@ Returns:
     The minorant and majorant values at the medium interaction point.
     Clamped values outside bounds.)doc";
 
-static const char *__doc_mitsuba_ExtremumStructure_m_bbox = R"doc(Bounding box of the extremum structure in world space)doc";
+static const char *__doc_mitsuba_ExtremumStructure_m_bbox = R"doc(The bbox over which the extremum structure must be valid.)doc";
+
+static const char *__doc_mitsuba_ExtremumStructure_m_scale = R"doc(Scale by which to multiply the extremum values.)doc";
+
+static const char *__doc_mitsuba_ExtremumStructure_set_bbox = R"doc(Setter for the bbox over which the structure must be valid.)doc";
+
+static const char *__doc_mitsuba_ExtremumStructure_set_scale = R"doc(Setter for the scale by which to multiply the extremum values.)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_traverse_extremum =
 R"doc(Traverse the extremum along a ray and applies a callback at each
@@ -3050,6 +3071,24 @@ force the requirement for bindings, which are incompatible with
 function types.)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_type = R"doc()doc";
+
+static const char *__doc_mitsuba_ExtremumStructure_update_extremum =
+R"doc(Update the bbox and scale, and rebuild the structure.
+
+The ``bbox`` parameters indicates the domain over which the extremum
+structure can be queried. It can be larger or smaller than the
+underlying volume bbox. It is the extremum's responsibility to be
+valid over this area. The building implementation is handled in
+``build``.
+
+Parameter ``bbox``:
+    The validity bbox of the extremum structure
+
+Parameter ``volume``:
+    The volume from which to derive the extremum structure
+
+Parameter ``scale``:
+    The scale by which to multiply the extremum values)doc";
 
 static const char *__doc_mitsuba_ExtremumStructure_variant_name = R"doc()doc";
 
@@ -11102,6 +11141,12 @@ static const char *__doc_mitsuba_Volume_8 = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_9 = R"doc()doc";
 
+static const char *__doc_mitsuba_VolumeCoordFlag = R"doc(Volume's coordinate type.)doc";
+
+static const char *__doc_mitsuba_VolumeCoordFlag_Grid = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeCoordFlag_Spherical = R"doc()doc";
+
 static const char *__doc_mitsuba_VolumeGrid =
 R"doc(Class to read and write 3D volume grids
 
@@ -11221,6 +11266,18 @@ R"doc(Write an encoded form of the volume grid to a stream
 Parameter ``stream``:
     Target stream that will receive the encoded output)doc";
 
+static const char *__doc_mitsuba_VolumeParametrization = R"doc(Frame parameters of radially parameterized volumes in world space.)doc";
+
+static const char *__doc_mitsuba_VolumeParametrization_VolumeParametrization = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeParametrization_VolumeParametrization_2 = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeParametrization_flag = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeParametrization_to_world = R"doc()doc";
+
+static const char *__doc_mitsuba_VolumeParametrization_uv_range = R"doc()doc";
+
 static const char *__doc_mitsuba_Volume_PinGuard =
 R"doc(A Scoped Guard that pins the reference count of the volume.
 
@@ -11318,6 +11375,8 @@ R"doc(Compute local minorant (minimum) over a spatial region
 
 Convenience method that returns only the minorant. The default
 implementation calls `extremum()` and returns the first element.)doc";
+
+static const char *__doc_mitsuba_Volume_parametrization = R"doc()doc";
 
 static const char *__doc_mitsuba_Volume_pin = R"doc()doc";
 
@@ -14231,6 +14290,8 @@ static const char *__doc_mitsuba_warp_uniform_spherical_lune_to_square = R"doc(I
 static const char *__doc_mitsuba_warp_uniform_triangle_to_square = R"doc(Inverse of the mapping square_to_uniform_triangle)doc";
 
 static const char *__doc_mitsuba_warp_von_mises_fisher_to_square = R"doc(Inverse of the mapping von_mises_fisher_to_square)doc";
+
+static const char *__doc_mitsuba_wrap = R"doc(Applies the configured texture wrapping mode to an integer position)doc";
 
 static const char *__doc_mitsuba_xyz_to_srgb = R"doc(Convert XYZ tristimulus values to ITU-R Rec. BT.709 linear RGB)doc";
 

--- a/include/mitsuba/render/eradiate/extremum.h
+++ b/include/mitsuba/render/eradiate/extremum.h
@@ -7,6 +7,8 @@
 #include <mitsuba/render/eradiate/tracking.h>
 #include <drjit/call.h>
 
+#include <optional>
+
 NAMESPACE_BEGIN(mitsuba)
 
 /**
@@ -14,22 +16,61 @@ NAMESPACE_BEGIN(mitsuba)
  *
  * ExtremumStructure provides an interface for spatial data structures that
  * store local extrema (majorant/minorant) of volumetric extinction coefficients.
- * This enables efficient delta tracking with locally-adaptive majorants.
+ * This enables efficient use of tracking algorithms with locally-adaptive
+ * majorants and minorants.
  *
  * To minimize virtual function overhead, the ``traverse_extremum()`` method
  * encapsulates the entire traversal loop internally, requiring only a single
  * virtual call per distance sample.
+ *
+ * The extremum structure needs to be built using the ``update_extremum``
+ * function, it is **not** called automatically in the constructor. The caller,
+ * usually a ``Medium``, passes the volumetric data the extremum is derived from.
  */
 template <typename Float, typename Spectrum>
 class MI_EXPORT_LIB ExtremumStructure : public JitObject<ExtremumStructure<Float, Spectrum>> {
 public:
-    MI_IMPORT_TYPES(Medium, Sampler)
+    MI_IMPORT_TYPES(Medium, Sampler, Volume)
 
     using TrackingStateType    = TrackingState<Float, Spectrum>;
     using TrackingFunctionType = TrackingFunction<Float, Spectrum>;
 
     /// Destructor
     ~ExtremumStructure();
+
+    /// Setter for the bbox over which the structure must be valid.
+    MI_INLINE void set_bbox(ScalarBoundingBox3f bbox) { m_bbox = bbox; };
+
+    /// Setter for the scale by which to multiply the extremum values.
+    MI_INLINE void set_scale(ScalarFloat scale) { m_scale = scale; }
+
+    /**
+     * \brief Update the bbox and scale, and rebuild the structure.
+     *
+     * The \c bbox parameters indicates the domain over which the extremum
+     * structure can be queried. It can be larger or smaller than the underlying
+     * volume bbox. It is the extremum's responsibility to be valid over this
+     * area. The building implementation is handled in ``build``.
+     *
+     * \param bbox      The validity bbox of the extremum structure
+     * \param volume    The volume from which to derive the extremum structure
+     * \param scale     The scale by which to multiply the extremum values
+     */
+    void update_extremum(const ScalarBoundingBox3f &bbox,
+                         const Volume *volume,
+                         std::optional<ScalarFloat> scale);
+
+    /**
+     * \brief Build the extremum structure of \c volume.
+     *
+     * Implements the logic that constructs the extremum structure from a
+     * \c volume. Called by ``update_extremum`` which is itself called by
+     * the owning ``Medium``
+     *
+     * \param volume  Volume to compute extremum values from
+     */
+    virtual void build(const Volume *volume) = 0;
+
 
     /**
      * \brief Traverse the extremum along a ray and applies a callback at each
@@ -92,7 +133,6 @@ public:
     //! @{ \name Non-virtual query methods
     // =============================================================
 
-    /// Return the bounding box of the extremum structure
     ScalarBoundingBox3f bbox() const { return m_bbox; }
     //! @}
     // =============================================================
@@ -104,8 +144,10 @@ protected:
     ExtremumStructure(const Properties &props);
 
 protected:
-    /// Bounding box of the extremum structure in world space
+    /// The bbox over which the extremum structure must be valid.
     ScalarBoundingBox3f m_bbox;
+    /// Scale by which to multiply the extremum values.
+    ScalarFloat m_scale;
 };
 
 MI_EXTERN_CLASS(ExtremumStructure)

--- a/include/mitsuba/render/eradiate/volume_utils.h
+++ b/include/mitsuba/render/eradiate/volume_utils.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <mitsuba/core/fwd.h>
+#include <mitsuba/core/platform.h>
+#include <mitsuba/core/vector.h>
+#include <drjit/texture.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**
+ * \brief Volume's coordinate type.
+ */
+enum class VolumeCoordFlag : uint32_t {
+    Grid,
+    Spherical
+};
+
+
+/**
+ * \brief Frame parameters of radially parameterized volumes in world space.
+ */
+template<typename Float>
+struct VolumeParametrization {
+
+    using Point3f = Point<Float, 3>;
+    using BoundingBox3f = BoundingBox<Point3f>;
+    using AffineTransform4f = Transform<Point<Float, 4>, true>;
+
+    AffineTransform4f to_world;
+    BoundingBox3f uv_range; // e.g. dim 0 -> [rmin, rmax] in spherical coords.
+    VolumeCoordFlag flag; // defaults to Grid.
+
+    VolumeParametrization():
+        to_world(AffineTransform4f()),
+        uv_range(BoundingBox3f(Point3f(0.f), Point3f(1.f))),
+        flag(VolumeCoordFlag::Grid) {}
+
+    VolumeParametrization(
+        AffineTransform4f to_world, BoundingBox3f uv_range, VolumeCoordFlag flag):
+        to_world(to_world),
+        uv_range(uv_range),
+        flag(flag) {}
+};
+
+/**
+ * \brief Applies the configured texture wrapping mode to an integer
+ * position
+ */
+template <typename T> T wrap(
+    const T &pos, const T &res,
+    const dr::divisor<dr::scalar_t<T>> *inv_res,
+    dr::WrapMode wrap_mode) {
+    using Scalar = dr::scalar_t<T>;
+
+    constexpr size_t Dimension = dr::size_v<T>;
+
+    static_assert(
+        std::is_integral_v<Scalar> &&
+        std::is_signed_v<Scalar>
+    );
+
+    if (wrap_mode == dr::WrapMode::Clamp) {
+        return clip(pos, 0, res - 1);
+    } else {
+        T value_shift_neg = select(pos < 0, pos + 1, pos);
+
+        T div;
+        for (size_t i = 0; i < Dimension; ++i)
+            div[i] = inv_res[i](value_shift_neg[i]);
+
+        T mod = pos - div * res;
+        mod[mod < 0] += T(res);
+
+        if (wrap_mode == dr::WrapMode::Mirror)
+            // Starting at 0, flip the texture every other repetition
+            // (flip when: even number of repetitions in negative direction,
+            // or odd number of repetitions in positive direction)
+            mod = select(((div & 1) == 0) ^ (pos < 0), mod, res - 1 - mod);
+
+        return mod;
+    }
+}
+
+NAMESPACE_END(mitsuba)

--- a/include/mitsuba/render/volume.h
+++ b/include/mitsuba/render/volume.h
@@ -6,6 +6,9 @@
 #include <mitsuba/render/interaction.h>
 #include <mitsuba/render/shape.h>
 #include <mitsuba/render/texture.h>
+// #ERADIATE_CHANGE_BEGIN: Local extremum Support
+#include <mitsuba/render/eradiate/volume_utils.h>
+// #ERADIATE_CHANGE_END
 
 #include <drjit/texture.h>
 
@@ -109,6 +112,12 @@ public:
      */
     virtual Float minorant(const BoundingBox3f& bbox, Mask local = true) const {
         return extremum(bbox, local).first;
+    }
+
+    virtual VolumeParametrization<ScalarFloat> parametrization() const {
+        VolumeParametrization<ScalarFloat> param;
+        param.to_world = m_to_local.inverse();
+        return param;
     }
 // #ERADIATE_CHANGE_END
 

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -1351,10 +1351,13 @@ void transform_merge_equivalent(const ParserConfig &/*config*/, ParserState &sta
         for (size_t i = 0; i < state.size(); ++i) {
             size_t repr = canonical[i];
 
+// #ERADIATE_CHANGE_BEGIN: Extremum Structures acquire per-medium state at build time, don't merge
             // Skip merging for emitters and shapes
             if (state[repr].type == ObjectType::Emitter ||
-                state[repr].type == ObjectType::Shape)
+                state[repr].type == ObjectType::Shape ||
+                state[repr].type == ObjectType::ExtremumStructure)
                 continue;
+// #ERADIATE_CHANGE_END
 
             // Try to find an equivalent node
             auto [it, inserted] = dedup_map.insert({repr, repr});

--- a/src/eradiate_plugins/extremum/extremum_global.cpp
+++ b/src/eradiate_plugins/extremum/extremum_global.cpp
@@ -12,17 +12,6 @@ NAMESPACE_BEGIN(mitsuba)
 Extremum global structure (:monosp:`extremum_global`)
 -----------------------------------------------------
 
-.. pluginparameters::
-
- * - volume
-   - |volume|
-   - Extinction coefficient volume to build extremum grid from.
-   - |exposed|
-
- * - scale
-   - |float|
-   - Scale factor for the extremum values. Default: 1.0
-
 This plugin holds the global minorant and majorant values of a volume.
 At runtime, traversal is performed via a single segment determined by the
 passed ``mint`` and ``maxt`` values.
@@ -31,38 +20,18 @@ passed ``mint`` and ``maxt`` values.
 template <typename Float, typename Spectrum>
 class ExtremumGlobal final : public ExtremumStructure<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(ExtremumStructure, m_bbox)
+    MI_IMPORT_BASE(ExtremumStructure, m_bbox, m_scale)
     MI_IMPORT_TYPES(Volume)
 
     using TrackingStateType    = TrackingState<Float, Spectrum>;
     using TrackingFunctionType = TrackingFunction<Float, Spectrum>;
 
-    ExtremumGlobal(const Properties &props) : Base(props) {
-        // Volume Parameters
-        m_volume = nullptr;
-        for (auto &prop : props.objects()) {
-            if (auto *vol = prop.try_get<Volume>()) {
-                m_volume = vol;
-                break;
-            }
-        }
+    ExtremumGlobal(const Properties &props) : Base(props) {}
 
-        if (!m_volume)
-            Throw("ExtremumGlobal requires at least one volume");
-
-        m_scale = props.get<ScalarFloat>("scale", 1.f);
-        m_bbox = m_volume->bbox();
-
-        m_majorant = m_volume->max();
-        m_minorant = m_volume->min();
+    void build(const Volume *volume) override {
+        m_minorant = volume->min();
+        m_majorant = volume->max();
     }
-
-    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
-        m_bbox = m_volume->bbox();
-        m_majorant = m_volume->max();
-        m_minorant = m_volume->min();
-    }
-
 
     TrackingStateType traverse_extremum(
         const Ray3f &/*ray*/,
@@ -116,6 +85,7 @@ public:
         oss << "ExtremumGlobal[" << std::endl
             << "  minorant = " << m_minorant << "," << std::endl
             << "  majorant = " << m_majorant << "," << std::endl
+            << "  scale = " << m_scale << "," << std::endl
             << "]";
         return oss.str();
     }
@@ -123,9 +93,6 @@ public:
     MI_DECLARE_CLASS(ExtremumGlobal)
 
 private:
-    ref<Volume> m_volume;
-    ScalarFloat m_scale;
-
     ScalarFloat m_minorant;
     ScalarFloat m_majorant;
 };

--- a/src/eradiate_plugins/extremum/extremum_grid.cpp
+++ b/src/eradiate_plugins/extremum/extremum_grid.cpp
@@ -16,19 +16,6 @@ Extremum grid structure (:monosp:`extremum_grid`)
 
 .. pluginparameters::
 
- * - volume
-   - |volume|
-   - Extinction coefficient volume to build extremum grid from.
-   - |exposed|
-
- * - to_world
-   - |transform|
-   - Specifies the 4×4 transformation matrix of the underlying volume.
-
- * - scale
-   - |float|
-   - Scale factor for the extremum values. Default: 1.0
-
  * - resolution
    - |vector|
    - Grid resolution along the XYZ axis. Does not have to be a multiple of
@@ -42,6 +29,8 @@ Extremum grid structure (:monosp:`extremum_grid`)
      :monosp:`repeat`, :monosp:`mirror`. Should match the underlying volume to
      ensure consistent extremum representation. Note that this is experimental
      until proper periodic boundary conditions are defined for media.
+     **WARNING**: This is leftover for now, kept for proper function, will
+     soon change.
      Default: :monosp:`clamp`
 
 This plugin creates a regular grid structure storing local extremum values for
@@ -60,30 +49,15 @@ bounds and periodic behaviours.;
 template <typename Float, typename Spectrum>
 class ExtremumGrid final : public ExtremumStructure<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(ExtremumStructure, m_bbox)
+    MI_IMPORT_BASE(ExtremumStructure, m_bbox, m_scale)
     MI_IMPORT_TYPES(Volume)
 
     using TrackingStateType    = TrackingState<Float, Spectrum>;
     using TrackingFunctionType = TrackingFunction<Float, Spectrum>;
     using FloatStorage         = DynamicBuffer<Float>;
+    using ScalarMask3          = dr::mask_t<ScalarVector3i>;
 
     ExtremumGrid(const Properties &props) : Base(props) {
-        // Volume Parameters
-        m_volume = nullptr;
-        for (auto &prop : props.objects()) {
-            if (auto *vol = prop.try_get<Volume>()) {
-                m_volume = vol;
-                break;
-            }
-        }
-
-        if (!m_volume)
-            Throw("ExtremumGrid requires at least one volume");
-
-        m_bbox = m_volume->bbox();
-
-        m_to_local = props.get<ScalarAffineTransform4f>("to_world", ScalarAffineTransform4f()).inverse();
-        m_scale = props.get<ScalarFloat>("scale", 1.0f);
 
         std::string_view wrap_mode_str = props.get<std::string_view>("wrap_mode", "clamp");
         if (wrap_mode_str == "repeat")
@@ -99,29 +73,32 @@ public:
         // Resolution Parameters
         m_resolution = props.get<ScalarVector3i>("resolution", ScalarVector3i(1,1,1));
 
-        m_adaptive = false;
-        if (dr::all(m_resolution <= ScalarVector3i(0))) {
-            m_adaptive = true;
-            m_resolution = find_resolution(m_volume);
+        m_adaptive_dims = m_resolution <= ScalarVector3i(0);
+    }
+
+    void build(const Volume *volume) override {
+
+        VolumeParametrization<ScalarFloat> volume_param = volume->parametrization();
+
+        m_to_local = volume_param.to_world.inverse();
+
+        if (dr::any(m_adaptive_dims))
+            m_resolution = find_resolution(volume);
+
+        ScalarVector3i clamped  = dr::clip(m_resolution, 1, volume->resolution());
+        if (dr::any(clamped != m_resolution)) {
+            Log(Info,
+                "ExtremumGrid: requested resolution %s is finer than the "
+                "underlying volume's resolution %s; clamping to %s.",
+                m_resolution, volume->resolution(), clamped);
+            m_resolution = clamped;
         }
 
         for (size_t i = 0; i < 3; ++i)
             m_inv_resolution[i] = dr::divisor<int32_t>((int32_t) m_resolution[i]);
 
-
-        build_grid(m_volume.get(), m_resolution);
+        build_grid(volume, m_resolution);
     }
-
-    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
-        if (m_adaptive) {
-            m_resolution = find_resolution(m_volume.get());
-
-            for (size_t i = 0; i < 3; ++i)
-                m_inv_resolution[i] = dr::divisor<int32_t>((int32_t) m_resolution[i]);
-        }
-        build_grid(m_volume.get(), m_resolution);
-    }
-
 
     TrackingStateType traverse_extremum(
         const Ray3f &ray,
@@ -146,12 +123,14 @@ public:
     std::tuple<Float, Float> eval_1(const Interaction3f &it,
                                     Mask active) const override {
         Point3f po = m_to_local * it.p;
-        Vector3i piw = wrap(dr::floor2int<Vector3i>(po * m_resolution));
+        Vector3i piw = wrap<Vector3i>(
+            dr::floor2int<Vector3i>(po * m_resolution), m_resolution,
+            m_inv_resolution, m_wrap_mode);
 
         UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
                                m_resolution.x(), piw.x());
         Vector2f extremum = dr::gather<Vector2f>(m_extremum_grid, idx, active);
-        return { extremum.x(), extremum.y() };
+        return { m_scale * extremum.x(), m_scale * extremum.y() };
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -181,6 +160,7 @@ public:
         oss << "ExtremumGrid[" << std::endl
             << "  resolution = " << m_resolution << "," << std::endl
             << "  bbox = " << m_bbox << "," << std::endl
+            << "  scale = " << m_scale << "," << std::endl
             << "  wrap_mode = " << wrap_str << "," << std::endl
             << "]";
         return oss.str();
@@ -256,8 +236,12 @@ private:
         };
 
         // Ternary search over the xyz dimensions to find the best resolution.
-        result = dr::maximum(fine_res / 2, 1);
+        result = dr::select(m_adaptive_dims, dr::maximum(fine_res / 2, 1), m_resolution);
         for (uint8_t i = 0; i < 3; ++i) {
+            // skip dimension if not adaptive
+            if (!m_adaptive_dims[i])
+                continue;
+
             ScalarUInt32 left  = 1;
             ScalarUInt32 right = fine_res[i];
 
@@ -289,8 +273,8 @@ private:
             result[i] = left_cost <= right_cost ? left : right;
         }
 
-        // safety net, result should never be outside those bounds.
-        result = dr::clip(result, 1, m_resolution - 1);
+        // safety net, result should never be lower than one
+        result = dr::maximum(result, 1);
         return result;
     }
 
@@ -320,8 +304,9 @@ private:
         // Early return if using the global majorant.
         if (n == 1) {
             ScalarFloat max = volume->max();
+            ScalarFloat min = volume->min();
             dr::scatter(m_extremum_grid,
-                        m_scale * Vector2f(0.f, max) * safety_factor,
+                        Vector2f(min, max) * safety_factor,
                         UInt32(0));
             return;
         }
@@ -353,8 +338,7 @@ private:
                         auto [min, maj] = volume->extremum(cell_bounds);
 
                         dr::scatter(m_extremum_grid,
-                                    m_scale * Vector2f(min, maj) *
-                                        safety_factor,
+                                    Vector2f(min, maj) * safety_factor,
                                     UInt32(idx));
                     }
                 });
@@ -375,8 +359,8 @@ private:
 
             auto [min, maj]= volume->extremum(cell_bounds);
 
-            dr::scatter(m_extremum_grid, m_scale * min * safety_factor.x(), idx*2);
-            dr::scatter(m_extremum_grid, m_scale * maj * safety_factor.y(), idx*2+1);
+            dr::scatter(m_extremum_grid, min * safety_factor.x(), idx*2);
+            dr::scatter(m_extremum_grid, maj * safety_factor.y(), idx*2+1);
             dr::sync_thread();
         }
 
@@ -447,7 +431,7 @@ private:
         Vector3i step      = dr::select(d_pos, 1, -1);
         Vector3f abs_rcp_d = abs(rcp_d);
 
-        // #NOFIX: Possibly overflow in case the number of cells in the domain
+        // #NOFIX: Possibly overflow in case the number of cells in the bbox
         // is larger than the range of int32. This check prevents this from
         // happening, future iterations will probably change the way periodic bounds
         // will be implemented.
@@ -503,11 +487,12 @@ private:
 
             // Note: not multiplying the index by 2 because we gather using
             // Vector2f.
-            Vector3i piw = wrap(pi);
+            Vector3i piw = wrap<Vector3i>(pi, m_resolution, m_inv_resolution, m_wrap_mode);
             UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
                                    m_resolution.x(), piw.x());
 
-            const Vector2f extremum    = dr::gather<Vector2f>(m_extremum_grid, idx);
+            const Vector2f extremum =
+                m_scale * dr::gather<Vector2f>(m_extremum_grid, idx);
 
             // Store segment for lanes that reached target
             Float t_curr = mint + t_max - t_rem;
@@ -531,41 +516,11 @@ private:
         return ls.state;
     };
 
-    /**
-     * \brief Applies the configured texture wrapping mode to an integer
-     * position
-     */
-    Vector3i wrap(const Vector3i &pos) const {
-        if (m_wrap_mode == dr::WrapMode::Clamp) {
-            return dr::clip(pos, 0, m_resolution - 1);
-        } else {
-            Vector3i value_shift_neg = dr::select(pos < 0, pos + 1, pos);
-
-            Vector3i div;
-            for (size_t i = 0; i < 3; ++i)
-                div[i] = m_inv_resolution[i](value_shift_neg[i]);
-
-            Vector3i mod = pos - div * m_resolution;
-            mod[mod < 0] += Vector3i(m_resolution);
-
-            if (m_wrap_mode == dr::WrapMode::Mirror)
-                // Starting at 0, flip the texture every other repetition
-                // (flip when: even number of repetitions in negative direction,
-                // or odd number of repetitions in positive direction)
-                mod = dr::select(((div & 1) == 0) ^ (pos < 0), mod, m_resolution - 1 - mod);
-
-            return mod;
-        }
-    }
-
 private:
     /// Grid storing pre-computed local majorants
     FloatStorage m_extremum_grid;
 
-    ref<Volume> m_volume;
-    ScalarFloat m_scale;
-
-    bool m_adaptive;
+    ScalarMask3 m_adaptive_dims;
     ScalarVector3i m_resolution;
     dr::divisor<int32_t> m_inv_resolution[3];
     dr::WrapMode m_wrap_mode;

--- a/src/eradiate_plugins/extremum/extremum_spherical.cpp
+++ b/src/eradiate_plugins/extremum/extremum_spherical.cpp
@@ -20,35 +20,10 @@ Extremum spherical structure (:monosp:`extremum_spherical`)
 -----------------------------------------------------------
 
 .. pluginparameters::
-
- * - volume
-   - |volume|
-   - Spherical-coordinates volume to build extremum from
-   - |exposed|
-
- * - to_world
-   - |transform|
-   - Specifies an optional 4×4 transformation matrix that will be applied to
-     volume coordinates.
-
- * - rmin
-   - |float|
-   - Inner shell radius. It should preferably match the underlying volume.
-     Default: 0
-
- * - rmax
-   - |float|
-   - Outer shell radius. It should preferably match the underlying volume.
-     Default: 1
-
  * - resolution
    - |vector|
    - Grid resolution as :math:`(r, \theta, \phi)`. Grids with variations on only
      the radial resolution have optimized traversal. Default: [1,1,1]
-
- * - scale
-   - |float|
-   - Scale factor for extinction coefficients. Default: 1.0
 
 This plugin creates a spherical extremum structure storing local extremum values
 for efficient delta tracking in spherical media. The grid is constructed by
@@ -63,7 +38,7 @@ radially-varying media such as planetary atmospheres.
 template <typename Float, typename Spectrum>
 class ExtremumSpherical final : public ExtremumStructure<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(ExtremumStructure, m_bbox)
+    MI_IMPORT_BASE(ExtremumStructure, m_bbox, m_scale)
     MI_IMPORT_TYPES(Volume)
 
     using TrackingStateType    = TrackingState<Float, Spectrum>;
@@ -83,12 +58,7 @@ public:
         }
 
         // Mark all properties as queried so they don't warn in expand()
-        props.mark_queried("volume");
-        props.mark_queried("to_world");
-        props.mark_queried("rmin");
-        props.mark_queried("rmax");
         props.mark_queried("resolution");
-        props.mark_queried("scale");
     }
 
     template <SphericalTraversalType TT>
@@ -109,6 +79,10 @@ public:
         return { result };
     }
 
+    void build(const Volume *) override {
+        NotImplementedError("build");
+    }
+
     // Stub overrides — never called, expand() replaces this object
     TrackingStateType traverse_extremum(const Ray3f &, Float, Float, UInt32,
                     TrackingStateType, TrackingFunctionType*, Mask) const override {
@@ -118,7 +92,6 @@ public:
     std::tuple<Float, Float> eval_1(const Interaction3f &,
                                     Mask) const override {
         NotImplementedError("eval_1");
-        return { 0.f, 0.f };
     }
 
     MI_DECLARE_CLASS(ExtremumSpherical)
@@ -136,7 +109,7 @@ protected:
 template <typename Float, typename Spectrum, SphericalTraversalType TraversalType>
 class ExtremumSphericalImpl final : public ExtremumStructure<Float, Spectrum> {
 public:
-    MI_IMPORT_BASE(ExtremumStructure, m_bbox)
+    MI_IMPORT_BASE(ExtremumStructure, m_bbox, m_scale)
     MI_IMPORT_TYPES(Volume)
 
     using TrackingStateType    = TrackingState<Float, Spectrum>;
@@ -144,31 +117,21 @@ public:
     using FloatStorage         = DynamicBuffer<Float>;
 
     ExtremumSphericalImpl(const Properties &props) : Base(props) {
-        // Get volume
-        ref<Volume> volume = nullptr;
-        for (auto &prop : props.objects()) {
-            if (auto *vol = prop.try_get<Volume>()) {
-                volume = vol;
-                break;
-            }
-        }
-
-        if (!volume)
-            Throw("ExtremumSpherical requires a volume");
-
-        m_volume = volume;
-        m_bbox = m_volume->bbox();
-
-        ScalarAffineTransform4f to_world = props.get<ScalarAffineTransform4f>(
-            "to_world", ScalarAffineTransform4f());
-        m_center   = to_world.translation();
-        m_to_local = to_world.inverse();
-
-        m_rmin = props.get<ScalarFloat>("rmin", 0.f);
-        m_rmax = props.get<ScalarFloat>("rmax", 1.f);
         m_resolution =
             props.get<ScalarVector3i>("resolution", ScalarVector3i(1, 1, 1));
-        m_scale = props.get<ScalarFloat>("scale", 1.0f);
+    }
+
+    void build(const Volume *volume) override {
+
+        VolumeParametrization<ScalarFloat> volume_param = volume->parametrization();
+
+        if (volume_param.flag != VolumeCoordFlag::Spherical)
+            Throw("ExtremumSpherical only compatible with volumes that have a spherical parametrization.");
+
+        m_center   = volume_param.to_world.translation();
+        m_to_local = volume_param.to_world.inverse();
+        m_rmin     = volume_param.uv_range.min[0];
+        m_rmax     = volume_param.uv_range.max[0];
 
         if (m_rmin >= m_rmax)
             Throw("rmin must be less than rmax!");
@@ -176,11 +139,7 @@ public:
         m_dr = (m_rmax - m_rmin) / m_resolution.x();
         m_idr = dr::rcp(m_dr);
 
-        build_grid(m_volume.get());
-    }
-
-    void parameters_changed(const std::vector<std::string> &/*keys*/ = {}) override {
-        build_grid(m_volume.get());
+        build_grid(volume);
     }
 
     TrackingStateType traverse_extremum(
@@ -218,7 +177,7 @@ public:
         Float fillval = -1.f;
         dr::masked(fillval, r < m_rmin) = m_fillmin;
         dr::masked(fillval, r > m_rmax) = m_fillmax;
-        Mask fill = fillval > 0.f;
+        Mask fill = fillval >= 0.f;
         Vector2f extremum = dr::zeros<Vector2f>();
 
         if constexpr (TraversalType == SphericalTraversalType::RadialOnly) {
@@ -237,7 +196,7 @@ public:
                 fill, Vector2f(fillval, fillval), extremum
         );
 
-        return { extremum.x(), extremum.y() };
+        return { m_scale * extremum.x(), m_scale * extremum.y() };
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -260,6 +219,7 @@ public:
             << "  rmax = "       << m_rmax << std::endl
             << "  fillmin = "    << m_fillmin << "," << std::endl
             << "  fillmax = "    << m_fillmax << std::endl
+            << "  scale = " << m_scale << "," << std::endl
             << "]";
         return oss.str();
     }
@@ -309,7 +269,7 @@ private:
                         auto [min, maj] = volume->extremum(cell_bounds);
 
                         dr::scatter(m_extremum_grid,
-                                    m_scale * Vector2f(min, maj) * safety_factor,
+                                    Vector2f(min, maj) * safety_factor,
                                     UInt32(idx));
                     }
                 }
@@ -330,8 +290,8 @@ private:
 
             auto [min, maj] = volume->extremum(cell_bounds);
 
-            dr::scatter(m_extremum_grid, m_scale * min * safety_factor.x(), idx * 2);
-            dr::scatter(m_extremum_grid, m_scale * maj * safety_factor.y(), idx * 2 + 1);
+            dr::scatter(m_extremum_grid, min * safety_factor.x(), idx * 2);
+            dr::scatter(m_extremum_grid, maj * safety_factor.y(), idx * 2 + 1);
             dr::sync_thread();
         }
 
@@ -339,10 +299,10 @@ private:
         Interaction3f it = dr::zeros<Interaction3f>();
 
         it.p          = m_center;
-        Float fillmin = volume->eval_1(it, true) * m_scale;
+        Float fillmin = volume->eval_1(it, true);
 
         it.p          = m_center + m_rmax + ScalarVector3f(0.f, 0.f, 1.f);
-        Float fillmax = volume->eval_1(it, true) * m_scale;
+        Float fillmax = volume->eval_1(it, true);
 
         if constexpr (dr::is_jit_v<Float>) {
             m_fillmin = fillmin[0];
@@ -510,7 +470,7 @@ private:
                 // Look up extremum values for this shell
                 Vector2f extremum = dr::gather<Vector2f>(
                     m_extremum_grid, ls.layer_idx, ls.active && !fill);
-                extremum = dr::select(!fill, extremum, fill_value);
+                extremum = m_scale * dr::select(!fill, extremum, fill_value);
 
                 dr::masked(ls.segment, update) = ExtremumSegment(
                     ls.current_t, t_next, extremum
@@ -545,9 +505,6 @@ private:
     ScalarPoint3f m_center;
     ScalarFloat m_dr, m_idr;
 
-    ref<Volume> m_volume;
-
-    ScalarFloat m_scale;
     ScalarAffineTransform4f m_to_local;
 };
 

--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -116,11 +116,8 @@ public:
 
         if (!m_extremum_structure) {
             // Create a default global extremum structure.
-            Properties props_extr("extremum_global");
-            props_extr.set("volume", (Object *) m_sigmat.get());
-            props_extr.set("scale", m_scale);
             m_extremum_structure =
-                PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+                PluginManager::instance()->create_object<ExtremumStructure>(Properties("extremum_global"));
         }
 
         m_ddis_threshold = props.get<ScalarFloat>("ddis_threshold", 0.1f);
@@ -135,6 +132,10 @@ public:
             ScalarPoint3f aabb_max = props.get<ScalarPoint3f>("aabb_max");
             m_aabb = ScalarBoundingBox3f(aabb_min, aabb_max);
         }
+
+        m_extremum_structure->update_extremum(
+            dr::select(m_aabb.valid(), m_aabb, m_sigmat->bbox()),
+            m_sigmat.get(), m_scale);
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -153,9 +154,15 @@ public:
         if(string::contains(keys, "phase_function"))
             update_ddis_phase_function();
 
-        // #TODO: refactor extremum interface to expose a build function for more robust updates
-        if (string::contains(keys, "sigma_t"))
-            m_extremum_structure->parameters_changed(keys);
+        if (string::contains(keys, "sigma_t")) {
+            // we assume that the AABB cannot change and so is not recomputed.
+            m_extremum_structure->update_extremum(
+                dr::select(m_aabb.valid(), m_aabb, m_sigmat->bbox()),
+                m_sigmat.get(), std::nullopt);
+        }
+
+        if (string::contains(keys, "scale"))
+            m_extremum_structure->set_scale(m_scale);
     }
 
     UnpolarizedSpectrum
@@ -188,10 +195,7 @@ public:
 
     std::tuple<Mask, Float, Float>
     intersect_aabb(const Ray3f &ray) const override {
-        if (m_aabb.valid()) {
-            return m_aabb.ray_intersect(ray);
-        }
-        return m_sigmat->bbox().ray_intersect(ray);
+        return m_aabb.ray_intersect(ray);
     }
 
     std::string to_string() const override {

--- a/src/eradiate_plugins/media/piecewise.cpp
+++ b/src/eradiate_plugins/media/piecewise.cpp
@@ -185,11 +185,8 @@ public:
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
 
         // Create a default global extremum structure.
-        Properties props_extr("extremum_global");
-        props_extr.set("volume", (Object *) m_sigmat.get());
-        props_extr.set("scale", m_scale);
         m_extremum_structure =
-            PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+            PluginManager::instance()->create_object<ExtremumStructure>(Properties("extremum_global"));
 
         precompute_optical_thickness();
 
@@ -198,6 +195,9 @@ public:
         if (m_ddis_threshold > 0.f) {
             m_ddis_phase_function = static_cast<PhaseFunction*>(create_ddis_phase_function());
         }
+
+        m_extremum_structure->update_extremum(
+            m_sigmat->bbox(), m_sigmat.get(), m_scale);
     }
 
     std::tuple<MediumInteraction3f, UnpolarizedSpectrum, UnpolarizedSpectrum>
@@ -455,9 +455,12 @@ public:
         if(string::contains(keys, "phase_function"))
             update_ddis_phase_function();
 
-        // #TODO: refactor extremum interface to expose a build function for more robust updates
         if (string::contains(keys, "sigma_t"))
-            m_extremum_structure->parameters_changed(keys);
+            m_extremum_structure->update_extremum(
+                m_sigmat->bbox(), m_sigmat.get(), std::nullopt);
+
+        if (string::contains(keys, "scale"))
+            m_extremum_structure->set_scale(m_scale);
     }
 
     void precompute_optical_thickness() {

--- a/src/eradiate_plugins/tests/extremum/test_extremum_global.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_global.py
@@ -17,11 +17,22 @@ def _make_grid_volume(values, n):
 
 def test_build(variant_scalar_mono_double):
     volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
-    extremum = mi.load_dict({"type": "extremum_global", "volume": volume})
+    extremum = mi.load_dict({"type": "extremum_global"})
+    extremum.update_extremum(volume.bbox(), volume)
 
     it = mi.Interaction3f()
     it.p = mi.Point3f(0.0, 0.0, 0.0)
     assert np.allclose(extremum.eval_1(it), (1.0, 4.0))
+
+
+def test_set_scale(variant_scalar_mono_double):
+    volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
+    extremum = mi.load_dict({"type": "extremum_global"})
+    extremum.update_extremum(volume.bbox(), volume, 2.0)
+
+    it = mi.Interaction3f()
+    it.p = mi.Point3f(0.0, 0.0, 0.0)
+    assert np.allclose(extremum.eval_1(it), (2.0, 8.0))
 
 
 @pytest.mark.parametrize(
@@ -51,3 +62,25 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
 
     got = np.array(medium.extremum_structure().eval_1(it))
     assert np.allclose(got, expected)
+
+
+@pytest.mark.parametrize(
+    "medium_type", ["heterogeneous", "eoheterogeneous", "piecewise", "homogeneous"]
+)
+def test_update_on_scale_change(variant_scalar_mono_double, medium_type):
+    # A scale-only update must go through `set_scale()` without building
+    # the extremum structure from `sigma_t`.
+    volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
+    medium = mi.load_dict(
+        {"type": medium_type, "sigma_t": volume, "albedo": 0.5, "scale": 1.0}
+    )
+
+    it = mi.Interaction3f()
+    it.p = mi.Point3f(0.0, 0.0, 0.0)
+
+    params = mi.eradiate.traverse(medium)
+    params["scale"] = mi.Float(2.0)
+    params.update()
+
+    got = np.array(medium.extremum_structure().eval_1(it))
+    assert np.allclose(got, (2.0, 8.0))

--- a/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
@@ -22,8 +22,9 @@ def generate_extremum_grid(
         }
     )
     extremum_struct = mi.load_dict(
-        {"type": "extremum_grid", "volume": volume, "resolution": extremum_res}
+        {"type": "extremum_grid", "resolution": extremum_res}
     )
+    extremum_struct.update_extremum(volume.bbox(), volume)
 
     extremum_grid = mi.traverse(extremum_struct)["data"].numpy()
     extremum_grid = extremum_grid.reshape(
@@ -178,6 +179,113 @@ def test_build_scaled(variant_scalar_rgb):
     pass
 
 
+def test_build_adaptive_full(variant_scalar_rgb):
+    n_x, n_y, n_z = 8, 8, 8
+    n_prod = n_x * n_y * n_z
+    data = np.linspace(1, n_prod, n_prod).reshape(n_x, n_y, n_z)
+    volume_grid = mi.VolumeGrid(data.transpose(2, 1, 0))
+
+    volume = mi.load_dict(
+        {
+            "type": "gridvolume",
+            "grid": volume_grid,
+            "filter_type": "nearest",
+            "accel": False,
+        }
+    )
+
+    extremum_struct = mi.load_dict(
+        {"type": "extremum_grid", "resolution": mi.ScalarVector3i(0, 0, 0)}
+    )
+    extremum_struct.update_extremum(volume.bbox(), volume)
+
+    resolution = np.array(mi.traverse(extremum_struct)["resolution"])
+    fine_res = np.array([n_x, n_y, n_z])
+
+    # Fully adaptive search must pick a resolution no finer than the
+    # underlying volume on every axis, and never collapse to zero cells.
+    assert np.all(resolution >= 1)
+    assert np.all(resolution <= fine_res)
+
+    # The grid extrema must still conservatively bound the volume's data.
+    extremum_grid = mi.traverse(extremum_struct)["data"].numpy().reshape(-1, 2)
+    assert extremum_grid[:, 0].min() <= data.min()
+    assert extremum_grid[:, 1].max() >= data.max()
+
+
+def test_build_adaptive_partial(variant_scalar_rgb):
+    n_x, n_y, n_z = 8, 8, 4
+    n_prod = n_x * n_y * n_z
+    data = np.linspace(1, n_prod, n_prod).reshape(n_x, n_y, n_z)
+    volume_grid = mi.VolumeGrid(data.transpose(2, 1, 0))
+
+    volume = mi.load_dict(
+        {
+            "type": "gridvolume",
+            "grid": volume_grid,
+            "filter_type": "nearest",
+            "accel": False,
+        }
+    )
+
+    # Only the x axis is left adaptive (0). y and z are user-fixed (coarser
+    # than the volume's own resolution), to check that fixed dimensions are
+    # preserved exactly and are not touched by the adaptive search.
+    fixed_y, fixed_z = 4, 2
+    extremum_struct = mi.load_dict(
+        {
+            "type": "extremum_grid",
+            "resolution": mi.ScalarVector3i(0, fixed_y, fixed_z),
+        }
+    )
+    extremum_struct.update_extremum(volume.bbox(), volume)
+
+    resolution = np.array(mi.traverse(extremum_struct)["resolution"])
+
+    # Fixed dimensions must be preserved exactly.
+    assert resolution[1] == fixed_y
+    assert resolution[2] == fixed_z
+
+    # The adaptive x dimension must fall within the search's valid bounds.
+    assert 1 <= resolution[0] <= n_x
+
+    extremum_grid = mi.traverse(extremum_struct)["data"].numpy().reshape(-1, 2)
+    assert extremum_grid[:, 0].min() <= data.min()
+    assert extremum_grid[:, 1].max() >= data.max()
+
+
+def test_build_resolution_clamped_to_volume(variant_scalar_rgb):
+    # A fixed resolution requested finer than the volume's own resolution
+    # along some axis is not a valid extremum grid (it wouldn't be coarser
+    # than what it summarizes), so that axis must be clamped down to match
+    # the volume's resolution. TODO: Come back to this if change to world
+    # coordinates.
+    n_x, n_y, n_z = 8, 8, 4
+    n_prod = n_x * n_y * n_z
+    data = np.linspace(1, n_prod, n_prod).reshape(n_x, n_y, n_z)
+    volume_grid = mi.VolumeGrid(data.transpose(2, 1, 0))
+
+    volume = mi.load_dict(
+        {
+            "type": "gridvolume",
+            "grid": volume_grid,
+            "filter_type": "nearest",
+            "accel": False,
+        }
+    )
+
+    extremum_struct = mi.load_dict(
+        {
+            "type": "extremum_grid",
+            "resolution": mi.ScalarVector3i(n_x, n_y * 2, n_z),
+        }
+    )
+    extremum_struct.update_extremum(volume.bbox(), volume)
+
+    resolution = np.array(mi.traverse(extremum_struct)["resolution"])
+    assert np.array_equal(resolution, [n_x, n_y, n_z])
+
+
 def _make_grid_volume(values, n):
     data = np.array(values, dtype=float).reshape(n, 1, 1)
     return mi.load_dict(
@@ -209,17 +317,14 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
     after = [5.0, 6.0, 7.0, 8.0]
 
     volume = _make_grid_volume(before, n)
-    extremum = mi.load_dict(
-        {"type": "extremum_grid", "volume": volume, "resolution": resolution}
-    )
+    extremum = mi.load_dict({"type": "extremum_grid", "resolution": resolution})
     medium = _make_medium(medium_type, volume, extremum)
 
     # Ground truth: an extremum structure built directly from the "after"
     # data, independently of the update mechanism under test.
     ref_volume = _make_grid_volume(after, n)
-    ref_extremum = mi.load_dict(
-        {"type": "extremum_grid", "volume": ref_volume, "resolution": resolution}
-    )
+    ref_extremum = mi.load_dict({"type": "extremum_grid", "resolution": resolution})
+    ref_extremum.update_extremum(ref_volume.bbox(), ref_volume)
     expected = np.array(mi.traverse(ref_extremum)["data"])
 
     params = mi.eradiate.traverse(medium)

--- a/src/eradiate_plugins/tests/extremum/test_extremum_spherical.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_spherical.py
@@ -33,14 +33,9 @@ def generate_extremum_spherical(
         }
     )
     extremum_struct = mi.load_dict(
-        {
-            "type": "extremum_spherical",
-            "volume": volume,
-            "resolution": extremum_res,
-            "rmin": rmin,
-            "rmax": rmax,
-        }
+        {"type": "extremum_spherical", "resolution": extremum_res}
     )
+    extremum_struct.update_extremum(volume.bbox(), volume)
 
     extremum_grid = mi.traverse(extremum_struct)["data"].numpy()
     extremum_grid = extremum_grid.reshape(
@@ -128,29 +123,16 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
     after = [5.0, 6.0, 7.0, 8.0]
 
     volume = _make_spherical_volume(before, n, rmin, rmax)
-    extremum = mi.load_dict(
-        {
-            "type": "extremum_spherical",
-            "volume": volume,
-            "resolution": resolution,
-            "rmin": rmin,
-            "rmax": rmax,
-        }
-    )
+    extremum = mi.load_dict({"type": "extremum_spherical", "resolution": resolution})
     medium = _make_medium(medium_type, volume, extremum)
 
     # Ground truth: an extremum structure built directly from the "after"
     # data, independently of the update mechanism under test.
     ref_volume = _make_spherical_volume(after, n, rmin, rmax)
     ref_extremum = mi.load_dict(
-        {
-            "type": "extremum_spherical",
-            "volume": ref_volume,
-            "resolution": resolution,
-            "rmin": rmin,
-            "rmax": rmax,
-        }
+        {"type": "extremum_spherical", "resolution": resolution}
     )
+    ref_extremum.update_extremum(ref_volume.bbox(), ref_volume)
     expected = np.array(mi.traverse(ref_extremum)["data"])
 
     params = mi.eradiate.traverse(medium)

--- a/src/eradiate_plugins/volumes/sphericalcoords.cpp
+++ b/src/eradiate_plugins/volumes/sphericalcoords.cpp
@@ -154,7 +154,6 @@ public:
 
     ScalarVector3i resolution() const override { return m_volume->resolution(); };
 
-// #ERADIATE_CHANGE_BEGIN: Spatial extremum queries for grid volumes
     std::pair<Float, Float>
     extremum(BoundingBox3f bbox, Mask local) const override {
 
@@ -186,9 +185,16 @@ public:
         return { min, maj };
     }
 
-    typename Base::PinGuard pin() const override { return m_volume->pin(); };
+    VolumeParametrization<ScalarFloat> parametrization() const override {
+        return VolumeParametrization<ScalarFloat>(
+            m_to_local.inverse(),
+            ScalarBoundingBox3f(
+                ScalarPoint3f(m_rmin, 0.f, 0.f),
+                ScalarPoint3f(m_rmax, 1.f, 1.f)),
+            VolumeCoordFlag::Spherical);
+    }
 
-// #ERADIATE_CHANGE_END
+    typename Base::PinGuard pin() const override { return m_volume->pin(); };
 
     void traverse(TraversalCallback *cb) override {
         cb->put("volume", m_volume.get(), ParamFlags::NonDifferentiable);

--- a/src/media/heterogeneous.cpp
+++ b/src/media/heterogeneous.cpp
@@ -177,12 +177,12 @@ public:
 
         if (!m_extremum_structure) {
             // Create a default global extremum structure.
-            Properties props_extr("extremum_global");
-            props_extr.set("volume", (Object *) m_sigmat.get());
-            props_extr.set("scale", m_scale);
             m_extremum_structure =
-                PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
+                PluginManager::instance()->create_object<ExtremumStructure>(Properties("extremum_global"));
         }
+
+        m_extremum_structure->update_extremum(
+            m_sigmat->bbox(), m_sigmat.get(), m_scale);
 // #ERADIATE_CHANGE_END
     }
 
@@ -198,9 +198,12 @@ public:
         m_max_density = dr::opaque<Float>(m_scale * m_sigmat->max());
         m_min_density = dr::opaque<Float>(m_scale * m_sigmat->min());
 
-        // #TODO: refactor extremum interface to expose a build function for more robust updates
         if (string::contains(keys, "sigma_t"))
-            m_extremum_structure->parameters_changed(keys);
+            m_extremum_structure->update_extremum(
+                m_sigmat->bbox(), m_sigmat.get(), std::nullopt);
+
+        if (string::contains(keys, "scale"))
+            m_extremum_structure->set_scale(m_scale);
     }
 // #ERADIATE_CHANGE_END
 

--- a/src/media/homogeneous.cpp
+++ b/src/media/homogeneous.cpp
@@ -147,12 +147,14 @@ public:
         m_has_spectral_extinction = props.get<bool>("has_spectral_extinction", true);
 
         // Create a default global extremum structure
-        Properties props_extr("extremum_global");
-        props_extr.set("volume", (Object *) m_sigmat.get());
-        props_extr.set("scale", m_scale);
         m_extremum_structure =
-            PluginManager::instance()->create_object<ExtremumStructure>(props_extr);
-// #ERADIATE_CHANGE_END
+            PluginManager::instance()->create_object<ExtremumStructure>(Properties("extremum_global"));
+
+        m_extremum_structure->update_extremum(
+            ScalarBoundingBox3f(-dr::Infinity<ScalarFloat>,
+                                dr::Infinity<ScalarFloat>),
+            m_sigmat.get(), m_scale);
+        // #ERADIATE_CHANGE_END
     }
 
     void traverse(TraversalCallback *cb) override {
@@ -164,9 +166,14 @@ public:
 
 // #ERADIATE_CHANGE_BEGIN:
     void parameters_changed(const std::vector<std::string> &keys = {}) override {
-        // #TODO: refactor extremum interface to expose a build function for more robust updates
         if (string::contains(keys, "sigma_t"))
-            m_extremum_structure->parameters_changed(keys);
+            m_extremum_structure->update_extremum(
+                ScalarBoundingBox3f(-dr::Infinity<ScalarFloat>,
+                                    dr::Infinity<ScalarFloat>),
+                m_sigmat.get(), std::nullopt);
+
+        if (string::contains(keys, "scale"))
+            m_extremum_structure->set_scale(m_scale);
     }
 // #ERADIATE_CHANGE_END
 

--- a/src/render/eradiate/extremum.cpp
+++ b/src/render/eradiate/extremum.cpp
@@ -4,14 +4,30 @@
 NAMESPACE_BEGIN(mitsuba)
 
 MI_VARIANT ExtremumStructure<Float, Spectrum>::ExtremumStructure()
-    : JitObject<ExtremumStructure>(""){
+    : JitObject<ExtremumStructure>(""), m_scale(1.f) {
 }
 
 MI_VARIANT ExtremumStructure<Float, Spectrum>::ExtremumStructure(const Properties &props)
-    : JitObject<ExtremumStructure>(props.id()){
+    : JitObject<ExtremumStructure>(props.id()), m_scale(1.f) {
 }
 
 MI_VARIANT ExtremumStructure<Float, Spectrum>::~ExtremumStructure() {
+}
+
+MI_VARIANT void ExtremumStructure<Float, Spectrum>::update_extremum(
+    const ScalarBoundingBox3f &bbox, const Volume *volume,
+    std::optional<ScalarFloat> scale) {
+    // set scale if provided
+    if (scale)
+        set_scale(scale.value());
+    // set validity bbox
+    set_bbox(bbox);
+
+    if (!m_bbox.valid())
+        Throw("ExtremumStructure::update_extremum() called with an invalid bbox.");
+
+    // rebuild the extremum structure
+    build(volume);
 }
 
 MI_VARIANT

--- a/src/render/python/eradiate/extremum_v.cpp
+++ b/src/render/python/eradiate/extremum_v.cpp
@@ -3,6 +3,7 @@
 #include <mitsuba/render/eradiate/extremum_segment.h>
 #include <mitsuba/python/python.h>
 #include <nanobind/trampoline.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
@@ -40,10 +41,14 @@ MI_PY_EXPORT(ExtremumSegment) {
 // has not been solved yet.
 MI_VARIANT class PyExtremumStructure : public ExtremumStructure<Float, Spectrum> {
 public:
-    MI_IMPORT_TYPES(ExtremumStructure)
-    NB_TRAMPOLINE(ExtremumStructure, 4);
+    MI_IMPORT_TYPES(ExtremumStructure, Volume)
+    NB_TRAMPOLINE(ExtremumStructure, 5);
 
     PyExtremumStructure(const Properties &props) : ExtremumStructure(props) {}
+
+    void build(const Volume * volume) override {
+        NB_OVERRIDE_PURE(build, volume);
+    }
 
     std::tuple<Float, Float> eval_1(
         const Interaction3f &it,
@@ -87,6 +92,15 @@ MI_PY_EXPORT(ExtremumStructure) {
     auto extremum = MI_PY_TRAMPOLINE_CLASS(PyExtremumStructure, ExtremumStructure, Object)
         .def(nb::init<const Properties &>(), "props"_a)
         .def("__repr__", &ExtremumStructure::to_string)
+        .def("set_bbox", &ExtremumStructure::set_bbox,
+             "bbox"_a, D(ExtremumStructure, set_bbox))
+        .def("set_scale", &ExtremumStructure::set_scale,
+             "scale"_a, D(ExtremumStructure, set_scale))
+        .def("update_extremum", &ExtremumStructure::update_extremum,
+             "bbox"_a, "volume"_a, "scale"_a = nb::none(),
+             D(ExtremumStructure, update_extremum))
+        .def("build", &ExtremumStructure::build,
+             "volume"_a, D(ExtremumStructure, build))
         .def("bbox", &ExtremumStructure::bbox, D(ExtremumStructure, bbox));
 
     drjit::bind_traverse(extremum);


### PR DESCRIPTION
## Description

This PR refactors the extremum structure building API to make the interface more robust and less prone to user errors. 

- Building extremum structures is now handled by the `build` function whereas it was previously handled by the constructor and `parameters_changed`. This function provides an opportunity to pass the data relevant to the structure's construction, as opposed to passing it through properties. 
- Decouple `m_scale` from the underlying extremum structure and add the `set_scale` function. This separation and new entry point allow to update the scale without having to rebuild the full structure, making it very cheap. This can be useful for example for clouds where the density can vary homogeneously over the whole medium with respect to wavelength.
- Delegate the responsibility to call `extremum->build(...)` and `extremum->set_scale(...)` at construction and update to the medium. 

The combination of those three changes enables to massively simplify the extrema structures. It goes from:
```
        'sigma_t':{
                'type': 'gridvolume',
                'id':'sigma_t',
                'grid': # sigma_t data,
                'to_world': # sigma_t transform,
                'filter_type':'nearest',
        },
        'cloud':{
            'type': 'cube',
            'bsdf': { 'type': 'null' },  
            'interior': {
                "type": "eoheterogeneous",
                "scale": 1.0,
                "albedo": 1.0,
                'sigma_t': {'type':'ref', 'id':'sigma_t'},
                'extremum': {
                    'type':'extremum_grid',
                    'volume': {'type':'ref', 'id':'sigma_t'},
                    'resolution':[25,25,25],
                    'to_world': # sigma_t transform,
                },
                "phase": {"type": ","g": 0.7}
            },
        }
```

to:
```
        'cloud':{
            'type': 'cube',
            'bsdf': { 'type': 'null' },  
            'interior': {
                "type": "eoheterogeneous",
                "scale": 1.0,
                "albedo": 1.0,
                'sigma_t': {
                    'type': 'gridvolume',
                    'grid': # sigma_t data,
                    'to_world': # sigma_t transform,
                    'filter_type':'nearest',
                },
                'extremum': {
                    'type':'extremum_grid',
                    'resolution':[25,25,25],
                },
                "phase": {"type": ","g": 0.7}
            },
        }
```

Notice how the duplicated `sigma_t` and `to_world` data disappears, which ensures that no mistakes can be made from the user side.  This is even more beneficial for `sphericalcoordsvolume` which passes more parameters. The data is now passed to the extremum in two ways:
- The medium passes medium-related data i.e. domain AABB, scale, volume.
- The volume exposes parametrization data through a new `parametrization` function which exposes a new`VolumeParametrization` object (see `volume_utils.h`).

Two limitations:
- Extremum structures can be in an invalid state if there has been no call to `build`.
- Because data is inferred after construction, we have to make sure that the object is not merged at parsing (see change to parser.cpp).

## Testing

Modified the test suite to adapt the new interface, run the test suite and eradiate test suite.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)