### PR TITLE
Add test interface to `ExtremumStructure`'s `traverse_extremum`.

### DIFF
--- a/src/eradiate_plugins/media/eoheterogeneous.cpp
+++ b/src/eradiate_plugins/media/eoheterogeneous.cpp
@@ -131,6 +131,8 @@ public:
             ScalarPoint3f aabb_min = props.get<ScalarPoint3f>("aabb_min");
             ScalarPoint3f aabb_max = props.get<ScalarPoint3f>("aabb_max");
             m_aabb = ScalarBoundingBox3f(aabb_min, aabb_max);
+        } else {
+            m_aabb = m_sigmat->bbox();
         }
 
         m_extremum_structure->update_extremum(

--- a/src/eradiate_plugins/tests/extremum/test_extremum_global.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_global.py
@@ -15,7 +15,7 @@ def _make_grid_volume(values, n):
     )
 
 
-def test_build(variant_scalar_mono_double):
+def test_build(variant_scalar_mono):
     volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
     extremum = mi.load_dict({"type": "extremum_global"})
     extremum.update_extremum(volume.bbox(), volume)
@@ -25,7 +25,7 @@ def test_build(variant_scalar_mono_double):
     assert np.allclose(extremum.eval_1(it), (1.0, 4.0))
 
 
-def test_set_scale(variant_scalar_mono_double):
+def test_set_scale(variant_scalar_mono):
     volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
     extremum = mi.load_dict({"type": "extremum_global"})
     extremum.update_extremum(volume.bbox(), volume, 2.0)
@@ -38,7 +38,7 @@ def test_set_scale(variant_scalar_mono_double):
 @pytest.mark.parametrize(
     "medium_type", ["heterogeneous", "eoheterogeneous", "piecewise", "homogeneous"]
 )
-def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
+def test_update_on_sigma_t_change(variant_scalar_mono, medium_type):
     n = 4
     before = [1.0, 2.0, 3.0, 4.0]
     after = [5.0, 6.0, 7.0, 8.0]
@@ -67,7 +67,7 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
 @pytest.mark.parametrize(
     "medium_type", ["heterogeneous", "eoheterogeneous", "piecewise", "homogeneous"]
 )
-def test_update_on_scale_change(variant_scalar_mono_double, medium_type):
+def test_update_on_scale_change(variant_scalar_mono, medium_type):
     # A scale-only update must go through `set_scale()` without building
     # the extremum structure from `sigma_t`.
     volume = _make_grid_volume([1.0, 2.0, 3.0, 4.0], 4)
@@ -84,3 +84,31 @@ def test_update_on_scale_change(variant_scalar_mono_double, medium_type):
 
     got = np.array(medium.extremum_structure().eval_1(it))
     assert np.allclose(got, (2.0, 8.0))
+
+
+def test_sample_test_sampled(variant_scalar_mono):
+    # Homogeneous majorant of 3.0 over [1, 4]: segment_ot = 3 * 3 = 9.
+    volume = _make_grid_volume([3.0, 3.0], 2)
+    extremum = mi.load_dict({"type": "extremum_global"})
+    extremum.update_extremum(volume.bbox(), volume)
+
+    ray = mi.Ray3f(o=[0.5, 0.5, 0], d=[0, 0, 1])
+    distance, leftover_ot = extremum.sample_test(ray, 1.0, 4.0, target_ot=6.0)
+
+    # target_ot < segment_ot: interaction sampled inside the segment.
+    assert np.allclose(distance, 3.0)
+    assert np.allclose(leftover_ot, 6.0)
+
+
+def test_sample_test_escapes(variant_scalar_mono):
+    # Homogeneous majorant of 3.0 over [1, 4]: segment_ot = 3 * 3 = 9.
+    volume = _make_grid_volume([3.0, 3.0], 2)
+    extremum = mi.load_dict({"type": "extremum_global"})
+    extremum.update_extremum(volume.bbox(), volume)
+
+    ray = mi.Ray3f(o=[0.5, 0.5, 0], d=[0, 0, 1])
+    distance, leftover_ot = extremum.sample_test(ray, 1.0, 4.0, target_ot=12.0)
+
+    # target_ot > segment_ot: ray exits the medium before sampling.
+    assert np.isinf(distance)
+    assert np.allclose(leftover_ot, 3.0)

--- a/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
@@ -310,7 +310,7 @@ def _make_medium(medium_type, volume, extremum):
 
 
 @pytest.mark.parametrize("medium_type", ["heterogeneous", "eoheterogeneous"])
-def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
+def test_update_on_sigma_t_change(variant_scalar_mono, medium_type):
     n = 4
     resolution = mi.ScalarVector3i(1, 1, n)
     before = [1.0, 2.0, 3.0, 4.0]
@@ -333,3 +333,141 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
 
     got = np.array(mi.traverse(medium.extremum_structure())["data"])
     assert np.allclose(got, expected)
+
+
+def _make_x_volume(values, n, wrap_mode="clamp", to_world=None):
+    # Radial/X resolution must be the grid's fastest (last) axis.
+    data = np.array(values, dtype=float).reshape(1, 1, n)
+    d = {
+        "type": "gridvolume",
+        "grid": mi.VolumeGrid(data),
+        "filter_type": "nearest",
+        "accel": False,
+        "wrap_mode": wrap_mode,
+    }
+    if to_world is not None:
+        d["to_world"] = to_world
+    return mi.load_dict(d)
+
+
+def _make_x_extremum(bbox, volume, n, wrap_mode="clamp"):
+    extremum = mi.load_dict(
+        {
+            "type": "extremum_grid",
+            "resolution": mi.ScalarVector3i(n, 1, 1),
+            "wrap_mode": wrap_mode,
+        }
+    )
+    extremum.update_extremum(bbox, volume)
+    return extremum
+
+
+def test_sample_tight_sampled(variant_scalar_mono):
+    # 4 cells of width 0.25 along x, values [1, 2, 3, 4], domain == volume
+    # bbox. Sampled inside the 4th cell: ot(cell1..3) = 0.25 + 0.5 + 0.75,
+    # leaving 0.1 of the 1.6 target.
+    volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4)
+    extremum = _make_x_extremum(volume.bbox(), volume, 4)
+
+    ray = mi.Ray3f(o=[0, 0.5, 0.5], d=[1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.0, target_ot=1.6)
+
+    assert np.allclose(distance, 0.775)
+    assert np.allclose(leftover_ot, 0.1)
+
+
+def test_sample_tight_escapes(variant_scalar_mono):
+    # Same setup as `test_sample_tight_sampled`,
+    # total ot = 0.25 * (1 + 2 + 3 + 4) = 2.5, never reached.
+    volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4)
+    extremum = _make_x_extremum(volume.bbox(), volume, 4)
+
+    ray = mi.Ray3f(o=[0, 0.5, 0.5], d=[1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.0, target_ot=3.0)
+
+    assert np.isinf(distance)
+    assert np.allclose(leftover_ot, 0.5)
+
+
+@pytest.mark.parametrize(
+    "wrap_mode,expected_distance,expected_leftover",
+    [
+        # repeat: cells [1,2,3,4] tile again past x=1, so the target is
+        # spent reaching the 3rd repeated cell (value 3) before landing
+        # 0.1 into the 4th (value 4).
+        ("repeat", 1.775, 0.1),
+        # mirror: past x=1 the pattern reflects to [4,3,2,1], so the
+        # target lands directly in the first (value 4) mirrored cell.
+        ("mirror", 1.45, 0.6),
+        # clamp: past x=1 the whole remainder is one constant segment at
+        # the edge value (4), so the target lands within that segment.
+        ("clamp", 1.4, 0.6),
+    ],
+)
+def test_sample_non_tight_sampled(
+    variant_scalar_mono, wrap_mode, expected_distance, expected_leftover
+):
+    # Domain twice as wide as the volume's own [0, 1] bbox along x: the
+    # second half is only reachable through wrap_mode-driven indexing.
+    volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode)
+    domain = mi.BoundingBox3f([0, 0, 0], [2, 2, 2])
+    extremum = _make_x_extremum(domain, volume, 4, wrap_mode=wrap_mode)
+
+    ray = mi.Ray3f(o=[0, 0.5, 0.5], d=[1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 2.0, target_ot=4.1)
+
+    assert np.allclose(distance, expected_distance)
+    assert np.allclose(leftover_ot, expected_leftover)
+
+
+@pytest.mark.parametrize("wrap_mode", ["clamp", "repeat", "mirror"])
+def test_sample_rotated_axis_aligned(variant_scalar_mono, wrap_mode):
+    # Volume rotated 90 degrees about z: its local x-variation now runs
+    # along world y. Domain is volume.bbox(), so the ray never leaves it and
+    # wrap_mode has no effect.
+    to_world = mi.ScalarAffineTransform4f.rotate([0, 0, 1], 90)
+    volume = _make_x_volume(
+        [1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode, to_world=to_world
+    )
+    extremum = _make_x_extremum(volume.bbox(), volume, 4, wrap_mode=wrap_mode)
+
+    ray = mi.Ray3f(o=[-0.5, 0, 0.5], d=[0, 1, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.0, target_ot=1.6)
+
+    assert np.allclose(distance, 0.775)
+    assert np.allclose(leftover_ot, 0.1)
+
+
+@pytest.mark.parametrize(
+    "wrap_mode,expected_distance,expected_leftover",
+    [
+        # The 2 gap cells both clip to cell 0 into one 0.75-long segment.
+        ("clamp", 1.0 + 0.35 / 3.0, 0.35),
+        # The gap cells wrap to the last 2 real cells (values 3, 4).
+        ("repeat", 0.4625, 0.85),
+        # The gap cells reflect to values (2, 1).
+        ("mirror", 1.0 + 0.1 / 3.0, 0.1),
+    ],
+)
+def test_sample_rotated(
+    variant_scalar_mono, wrap_mode, expected_distance, expected_leftover
+):
+    # Rotated 45 degrees about z, so the local x-variation runs diagonally
+    # in world space. The domain is the tightest axis-aligned box around the
+    # leaving a triangular gap between the box and the volume's actual footprint.
+    # Start on the domain edge, at local x=-0.5, 2 cells before the real
+    # data starts at x=0 heading inward.
+    to_world = mi.ScalarAffineTransform4f.rotate([0, 0, 1], 45)
+    volume = _make_x_volume(
+        [1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode, to_world=to_world
+    )
+    extremum = _make_x_extremum(volume.bbox(), volume, 4, wrap_mode=wrap_mode)
+
+    ray = mi.Ray3f(
+        o=to_world @ mi.ScalarPoint3f(-0.5, 0.5, 0.5),
+        d=to_world @ mi.ScalarVector3f(1, 0, 0),
+    )
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.5, target_ot=1.6)
+
+    assert np.allclose(distance, expected_distance)
+    assert np.allclose(leftover_ot, expected_leftover)

--- a/src/eradiate_plugins/tests/extremum/test_extremum_spherical.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_spherical.py
@@ -81,8 +81,9 @@ def test_radial_build_half_res(variant_scalar_rgb):
     assert np.allclose(data[1::2, 1::2, 1::2], extremum_grid[:, :, :, 1])
 
 
-def _make_spherical_volume(values, n, rmin, rmax):
-    data = np.array(values, dtype=float).reshape(n, 1, 1)
+def _make_spherical_volume(values, n, rmin, rmax, fillmin=1.0, fillmax=0.0):
+    # Radial resolution must be the grid's fastest (last) axis.
+    data = np.array(values, dtype=float).reshape(1, 1, n)
     grid = mi.load_dict(
         {
             "type": "gridvolume",
@@ -97,10 +98,18 @@ def _make_spherical_volume(values, n, rmin, rmax):
             "volume": grid,
             "rmin": rmin,
             "rmax": rmax,
-            "fillmin": 1.0,
-            "fillmax": 0.0,
+            "fillmin": fillmin,
+            "fillmax": fillmax,
         }
     )
+
+
+def _make_extremum(volume, n):
+    extremum = mi.load_dict(
+        {"type": "extremum_spherical", "resolution": mi.ScalarVector3i(n, 1, 1)}
+    )
+    extremum.update_extremum(volume.bbox(), volume)
+    return extremum
 
 
 def _make_medium(medium_type, volume, extremum):
@@ -115,7 +124,7 @@ def _make_medium(medium_type, volume, extremum):
 
 
 @pytest.mark.parametrize("medium_type", ["heterogeneous", "eoheterogeneous"])
-def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
+def test_update_on_sigma_t_change(variant_scalar_mono, medium_type):
     n = 4
     rmin, rmax = 0.5, 1.0
     resolution = mi.ScalarVector3i(n, 1, 1)
@@ -141,3 +150,68 @@ def test_update_on_sigma_t_change(variant_scalar_mono_double, medium_type):
 
     got = np.array(mi.traverse(medium.extremum_structure())["data"])
     assert np.allclose(got, expected)
+
+
+def test_sample_multi_layer(variant_scalar_mono):
+    # Radial ray entering exactly at rmax, heading to the center. 4 shells of
+    # width 0.2, values [1, 2, 3, 4] from rmin=0.2 outward. Sampled inside the
+    # 3rd layer (COT per layer: 0.8, 1.4, 1.8) at mid-distance.
+    volume = _make_spherical_volume([1.0, 2.0, 3.0, 4.0], 4, rmin=0.2, rmax=1.0)
+    extremum = _make_extremum(volume, 4)
+
+    ray = mi.Ray3f(o=[1, 0, 0], d=[-1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 2.0, target_ot=1.6)
+
+    assert np.allclose(distance, 0.5)
+    assert np.allclose(leftover_ot, 0.2)
+
+
+def test_sample_escapes(variant_scalar_mono):
+    # Same setup as `test_sample_mutli_layer`, but the ray escapes the structure.
+    volume = _make_spherical_volume([1.0, 2.0, 3.0, 4.0], 4, rmin=0.2, rmax=1.0)
+    extremum = _make_extremum(volume, 4)
+
+    ray = mi.Ray3f(o=[1, 0, 0], d=[-1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 3.0, target_ot=6.0)
+
+    assert np.isinf(distance)
+    assert np.allclose(leftover_ot, 1.6)
+
+
+def test_sample_tangent_shell(variant_scalar_mono):
+    # Single shell [0.6, 1.0] (value 2.0). Ray tangent to rmin. Samples past
+    # tangent point.
+    volume = _make_spherical_volume([2.0], 1, rmin=0.6, rmax=1.0)
+    extremum = _make_extremum(volume, 1)
+
+    ray = mi.Ray3f(o=[0.6, 0, -3], d=[0, 0, 1])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 10.0, target_ot=2.4)
+
+    assert np.allclose(distance, 3.4, rtol=0.001)
+    assert np.allclose(leftover_ot, 0.8)
+
+
+def test_sample_through_origin(variant_scalar_mono):
+    # Ray straight through the origin is tangent to the degenerate r=0
+    # boundary. Sampled past the origin.
+    volume = _make_spherical_volume([5.0], 1, rmin=0.0, rmax=1.0)
+    extremum = _make_extremum(volume, 1)
+
+    ray = mi.Ray3f(o=[0, 0, -3], d=[0, 0, 1])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 10.0, target_ot=7.5)
+
+    assert np.allclose(distance, 3.5)
+    assert np.allclose(leftover_ot, 7.5)
+
+
+def test_sample_fillmax_sampled(variant_scalar_mono):
+    # fillmax=0.5: the region outside rmax is not vacuum, so an interaction
+    # can be sampled there before the ray ever reaches the shell.
+    volume = _make_spherical_volume([2.0], 1, rmin=0.5, rmax=1.0, fillmax=0.5)
+    extremum = _make_extremum(volume, 1)
+
+    ray = mi.Ray3f(o=[3, 0, 0], d=[-1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 10.0, target_ot=0.6)
+
+    assert np.allclose(distance, 1.2)
+    assert np.allclose(leftover_ot, 0.6)

--- a/src/render/python/eradiate/extremum_v.cpp
+++ b/src/render/python/eradiate/extremum_v.cpp
@@ -1,4 +1,5 @@
 #include <mitsuba/core/properties.h>
+#include <mitsuba/render/medium.h>
 #include <mitsuba/render/eradiate/extremum.h>
 #include <mitsuba/render/eradiate/extremum_segment.h>
 #include <mitsuba/python/python.h>
@@ -8,6 +9,7 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 #include <drjit/python.h>
+
 
 MI_PY_EXPORT(ExtremumSegment) {
     MI_PY_IMPORT_TYPES()
@@ -81,6 +83,57 @@ template <typename Ptr, typename Cls> void bind_extremum_structure_generic(Cls &
             },
             "it"_a, "active"_a = true,
             D(ExtremumStructure, eval_1));
+
+
+    // Test utility: deterministic delta tracking driven by a fixed target
+    // optical thickness.
+    cls.def("sample_test",
+            [](Ptr ptr, const Ray3f &ray, Float mint, Float maxt,
+               Float target_ot, UInt32 channel, Mask active) {
+                using TrackingStateType = TrackingState<Float, Spectrum>;
+
+                TrackingStateType state = dr::zeros<TrackingStateType>();
+                state.ray       = ray;
+                state.target_ot = target_ot;
+                state.mei       = dr::zeros<MediumInteraction3f>();
+
+                state = ptr->traverse_extremum(
+                    ray, mint, maxt, channel, state,
+                    [](const ExtremumSegment &segment, TrackingStateType &state,
+                       const UInt32 &, Mask active) {
+                        Float mint = dr::select(
+                            state.mei.is_valid(),
+                            dr::maximum(segment.mint, state.mei.t),
+                            segment.mint);
+                        Float segment_ot =
+                            (segment.maxt - mint) * segment.majorant();
+                        Mask sampled = (state.target_ot < segment_ot) && active;
+
+                        Float maxt = dr::select(
+                            sampled,
+                            mint + state.target_ot /
+                                       dr::maximum(segment.majorant(),
+                                                   dr::Epsilon<Float>),
+                            segment.maxt);
+
+                        dr::masked(state.mei.t, sampled)  = maxt;
+                        dr::masked(state.mei.t, !sampled) = dr::Infinity<Float>;
+                        dr::masked(state.target_ot, !sampled && active) -=
+                            segment_ot;
+
+                        return std::pair<Mask, Mask>(/*advance=*/!sampled,
+                                                     active && !sampled);
+                    },
+                    active);
+
+                return std::make_tuple(state.mei.t, state.target_ot);
+            },
+            "ray"_a, "mint"_a, "maxt"_a, "target_ot"_a, "channel"_a = 0u,
+            "active"_a = true,
+            "Deterministic delta-tracking test utility. Traverses the extremum "
+            "structure's segments, until an interaction is sampled based on "
+            "`target_ot`. Returns (distance, leftover_ot); `distance` is "
+            "infinite if `target_ot` is not reached before `maxt`.");
 }
 
 


### PR DESCRIPTION
## Description

Hello,
This PR adds binding to `sample_test`, a function added with the sole purpose of testing the traversal algorithm of various extremum structures. It performs simple delta tracking with using a deterministic `target_ot`. 
With this were added unit tests for all three extremum structure implementations: `extremum_global`, `extremum_grid`, and `extremum_spherical`.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- x ] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)