### PR TITLE
[enhancement] Refactor `extremum_grid` wrap interface and traversal. 

### DIFF
--- a/include/mitsuba/render/eradiate/volume_utils.h
+++ b/include/mitsuba/render/eradiate/volume_utils.h
@@ -26,20 +26,37 @@ struct VolumeParametrization {
     using BoundingBox3f = BoundingBox<Point3f>;
     using AffineTransform4f = Transform<Point<Float, 4>, true>;
 
+    /// The volume transform
     AffineTransform4f to_world;
-    BoundingBox3f uv_range; // e.g. dim 0 -> [rmin, rmax] in spherical coords.
-    VolumeCoordFlag flag; // defaults to Grid.
+
+    /// The local space range spanned by the volume e.g. dim 0 -> [rmin, rmax] in spherical coords.
+    BoundingBox3f uv_range;
+
+    /// The volume coordinate flag, default to grid.
+    VolumeCoordFlag flag;
+
+    /// Specifies if the volume wraps.
+    bool wrap;
+
+    /// The wrapping behaviour when exiting the volume boundaries.
+    dr::WrapMode wrap_mode;
 
     VolumeParametrization():
         to_world(AffineTransform4f()),
         uv_range(BoundingBox3f(Point3f(0.f), Point3f(1.f))),
-        flag(VolumeCoordFlag::Grid) {}
+        flag(VolumeCoordFlag::Grid),
+        wrap(false),
+        wrap_mode(dr::WrapMode::Clamp) {}
 
     VolumeParametrization(
-        AffineTransform4f to_world, BoundingBox3f uv_range, VolumeCoordFlag flag):
+        AffineTransform4f to_world, BoundingBox3f uv_range,
+        VolumeCoordFlag flag, bool wrap = false,
+        dr::WrapMode wrap_mode = dr::WrapMode::Clamp):
         to_world(to_world),
         uv_range(uv_range),
-        flag(flag) {}
+        flag(flag),
+        wrap(wrap),
+        wrap_mode(wrap_mode) {}
 };
 
 /**

--- a/src/eradiate_plugins/extremum/extremum_grid.cpp
+++ b/src/eradiate_plugins/extremum/extremum_grid.cpp
@@ -22,17 +22,6 @@ Extremum grid structure (:monosp:`extremum_grid`)
      the underlying volume. Set to [0,0,0] to trigger an adaptive resolution
      routine. Default: [1,1,1]
 
- * - wrap_mode
-   - |string|
-   - **EXPERIMENTAL** Specifies how to handle extremum queries and traversal
-     outside its data definition. Values should be one of :monosp:`clamp`,
-     :monosp:`repeat`, :monosp:`mirror`. Should match the underlying volume to
-     ensure consistent extremum representation. Note that this is experimental
-     until proper periodic boundary conditions are defined for media.
-     **WARNING**: This is leftover for now, kept for proper function, will
-     soon change.
-     Default: :monosp:`clamp`
-
 This plugin creates a regular grid structure storing local extremum values for
 efficient delta tracking in heterogeneous media. The grid is constructed
 by querying the extinction volume's extrema over each grid cell.
@@ -58,18 +47,6 @@ public:
     using ScalarMask3          = dr::mask_t<ScalarVector3i>;
 
     ExtremumGrid(const Properties &props) : Base(props) {
-
-        std::string_view wrap_mode_str = props.get<std::string_view>("wrap_mode", "clamp");
-        if (wrap_mode_str == "repeat")
-            m_wrap_mode = dr::WrapMode::Repeat;
-        else if (wrap_mode_str == "mirror")
-            m_wrap_mode = dr::WrapMode::Mirror;
-        else if (wrap_mode_str == "clamp")
-            m_wrap_mode = dr::WrapMode::Clamp;
-        else
-            Throw("Invalid wrap_mode \"%s\", must be one of: \"repeat\", "
-                  "\"mirror\", or \"clamp\"!", wrap_mode_str);
-
         // Resolution Parameters
         m_resolution = props.get<ScalarVector3i>("resolution", ScalarVector3i(1,1,1));
 
@@ -77,10 +54,14 @@ public:
     }
 
     void build(const Volume *volume) override {
-
+        // initialize volume specific parameters.
         VolumeParametrization<ScalarFloat> volume_param = volume->parametrization();
+        m_to_local  = volume_param.to_world.inverse();
+        m_wrap      = volume_param.wrap;
+        m_wrap_mode = volume_param.wrap_mode;
 
-        m_to_local = volume_param.to_world.inverse();
+        // enforce wrap mode to clamp if wrap is set to false to assist traversal.
+        dr::masked(m_wrap_mode, !m_wrap) = dr::WrapMode::Clamp;
 
         if (dr::any(m_adaptive_dims))
             m_resolution = find_resolution(volume);
@@ -123,10 +104,12 @@ public:
     std::tuple<Float, Float> eval_1(const Interaction3f &it,
                                     Mask active) const override {
         Point3f po = m_to_local * it.p;
-        Vector3i piw = wrap<Vector3i>(
-            dr::floor2int<Vector3i>(po * m_resolution), m_resolution,
-            m_inv_resolution, m_wrap_mode);
+        Vector3i pi = dr::floor2int<Vector3i>(po * m_resolution);
 
+        active &= m_wrap || !dr::any((pi < 0) || (pi >= m_resolution));
+
+        Vector3i piw = wrap<Vector3i>(pi, m_resolution, m_inv_resolution,
+                                      m_wrap_mode);
         UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
                                m_resolution.x(), piw.x());
         Vector2f extremum = dr::gather<Vector2f>(m_extremum_grid, idx, active);
@@ -439,6 +422,23 @@ private:
         // Integer grid coordinates
         Vector3i pi = dr::floor2int<Vector3i>(local_ray.o);
 
+        Mask clamped_bounds = !m_wrap || m_wrap_mode == dr::WrapMode::Clamp;
+
+        if (dr::any_or<true>(clamped_bounds)) {
+            auto below    = pi < 0;
+            auto above    = pi >= m_resolution;
+            auto entering = (below && d_pos) || (above && !d_pos);
+
+            // Set position index one unit outside boundary
+            // Forces computation of dt_v to the boundary instead of the next cell.
+            // Also ensures correct traversal when stepping through the DDA.
+            dr::masked(pi, below && clamped_bounds) = -1;
+            dr::masked(pi, above && clamped_bounds) = m_resolution;
+
+            // exiting dimensions set to infinity.
+            inf_t |= clamped_bounds && (below || above) && !entering;
+        }
+
         // Fractional entry position
         Vector3f p0 = local_ray.o - Vector3f(pi);
         // Step size to next interaction
@@ -470,7 +470,7 @@ private:
         dr::tie(ls) = dr::while_loop(
             dr::make_tuple(ls),
             [](const LoopState& ls) { return ls.active; },
-            [this, func, step, abs_rcp_d, t_max, mint, channel](LoopState& ls) {
+            [this, func, step, abs_rcp_d, t_max, mint, channel, clamped_bounds](LoopState& ls) {
 
             ExtremumSegment& segment = ls.segment;
             StateD& state = ls.state;
@@ -485,14 +485,15 @@ private:
             Float dt  = dr::minimum(dr::min(dt_v), t_rem);
             auto mask = dt_v == dt;
 
-            // Note: not multiplying the index by 2 because we gather using
-            // Vector2f.
+            // Not multiplying the index by 2 because we gather using Vector2f.
             Vector3i piw = wrap<Vector3i>(pi, m_resolution, m_inv_resolution, m_wrap_mode);
             UInt32 idx = dr::fmadd(dr::fmadd(piw.z(), m_resolution.y(), piw.y()),
                                    m_resolution.x(), piw.x());
 
+            // Non-wrapping volume evaluates to zero outside [0,res)
+            Mask inside = m_wrap || !dr::any((pi < 0) || (pi >= m_resolution));
             const Vector2f extremum =
-                m_scale * dr::gather<Vector2f>(m_extremum_grid, idx);
+                m_scale * dr::gather<Vector2f>(m_extremum_grid, idx, inside);
 
             // Store segment for lanes that reached target
             Float t_curr = mint + t_max - t_rem;
@@ -504,9 +505,15 @@ private:
 
             std::tie(advance, active) = func( segment, state, channel, active);
 
-            // Advance
-            dr::masked(dt_v, advance) = dr::select(mask, abs_rcp_d, dt_v - dt);
             dr::masked(pi, mask && advance) += step;
+
+            // Dimensions that leave clamped/non_wrapping [0,res] range are set to infinity.
+            Vector3f reset = abs_rcp_d;
+            if (dr::any_or<true>(clamped_bounds))
+                dr::masked(reset, clamped_bounds && ((pi < 0) || (pi >= m_resolution))) =
+                    dr::Infinity<Float>;
+
+            dr::masked(dt_v, advance) = dr::select(mask, reset, dt_v - dt);
             dr::masked(t_rem, advance) -= dt;
 
             active &= t_rem > 0.f;
@@ -523,6 +530,7 @@ private:
     ScalarMask3 m_adaptive_dims;
     ScalarVector3i m_resolution;
     dr::divisor<int32_t> m_inv_resolution[3];
+    bool m_wrap;
     dr::WrapMode m_wrap_mode;
 
     ScalarAffineTransform4f m_to_local;

--- a/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
+++ b/src/eradiate_plugins/tests/extremum/test_extremum_grid.py
@@ -335,7 +335,7 @@ def test_update_on_sigma_t_change(variant_scalar_mono, medium_type):
     assert np.allclose(got, expected)
 
 
-def _make_x_volume(values, n, wrap_mode="clamp", to_world=None):
+def _make_x_volume(values, n, wrap_mode="clamp", wrap=True, to_world=None):
     # Radial/X resolution must be the grid's fastest (last) axis.
     data = np.array(values, dtype=float).reshape(1, 1, n)
     d = {
@@ -343,6 +343,7 @@ def _make_x_volume(values, n, wrap_mode="clamp", to_world=None):
         "grid": mi.VolumeGrid(data),
         "filter_type": "nearest",
         "accel": False,
+        "wrap": wrap,
         "wrap_mode": wrap_mode,
     }
     if to_world is not None:
@@ -350,12 +351,11 @@ def _make_x_volume(values, n, wrap_mode="clamp", to_world=None):
     return mi.load_dict(d)
 
 
-def _make_x_extremum(bbox, volume, n, wrap_mode="clamp"):
+def _make_x_extremum(bbox, volume, n):
     extremum = mi.load_dict(
         {
             "type": "extremum_grid",
             "resolution": mi.ScalarVector3i(n, 1, 1),
-            "wrap_mode": wrap_mode,
         }
     )
     extremum.update_extremum(bbox, volume)
@@ -392,16 +392,16 @@ def test_sample_tight_escapes(variant_scalar_mono):
 @pytest.mark.parametrize(
     "wrap_mode,expected_distance,expected_leftover",
     [
-        # repeat: cells [1,2,3,4] tile again past x=1, so the target is
-        # spent reaching the 3rd repeated cell (value 3) before landing
-        # 0.1 into the 4th (value 4).
+        # Cells [1,2,3,4] tile again past x=1, so the target is spent reaching the
+        # 3rd repeated cell (value 3) before landing 0.1 into the 4th (value 4).
         ("repeat", 1.775, 0.1),
-        # mirror: past x=1 the pattern reflects to [4,3,2,1], so the
+        # Past x=1 the pattern reflects to [4,3,2,1], so the
         # target lands directly in the first (value 4) mirrored cell.
         ("mirror", 1.45, 0.6),
-        # clamp: past x=1 the whole remainder is one constant segment at
-        # the edge value (4), so the target lands within that segment.
-        ("clamp", 1.4, 0.6),
+        # Past x=1 the whole remainder is one merged constant-majorant segment
+        # segment at the edge value (4). Leftover ot reported is the full amount
+        # needed when entering that merged segment, i.e. (4.1 - 2.5 = 1.6).
+        ("clamp", 1.4, 1.6),
     ],
 )
 def test_sample_non_tight_sampled(
@@ -411,13 +411,27 @@ def test_sample_non_tight_sampled(
     # second half is only reachable through wrap_mode-driven indexing.
     volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode)
     domain = mi.BoundingBox3f([0, 0, 0], [2, 2, 2])
-    extremum = _make_x_extremum(domain, volume, 4, wrap_mode=wrap_mode)
+    extremum = _make_x_extremum(domain, volume, 4)
 
     ray = mi.Ray3f(o=[0, 0.5, 0.5], d=[1, 0, 0])
     distance, leftover_ot = extremum.sample_test(ray, 0.0, 2.0, target_ot=4.1)
 
     assert np.allclose(distance, expected_distance)
     assert np.allclose(leftover_ot, expected_leftover)
+
+
+def test_sample_non_tight_no_wrap(variant_scalar_mono):
+    # Same as above with no wrap, segment's majorant evaluates to 0. past the
+    # volume and ray escapes once the 4 cells are traversed.
+    volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4, wrap=False)
+    domain = mi.BoundingBox3f([0, 0, 0], [2, 2, 2])
+    extremum = _make_x_extremum(domain, volume, 4)
+
+    ray = mi.Ray3f(o=[0, 0.5, 0.5], d=[1, 0, 0])
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 2.0, target_ot=3.0)
+
+    assert np.isinf(distance)
+    assert np.allclose(leftover_ot, 0.5)
 
 
 @pytest.mark.parametrize("wrap_mode", ["clamp", "repeat", "mirror"])
@@ -429,7 +443,7 @@ def test_sample_rotated_axis_aligned(variant_scalar_mono, wrap_mode):
     volume = _make_x_volume(
         [1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode, to_world=to_world
     )
-    extremum = _make_x_extremum(volume.bbox(), volume, 4, wrap_mode=wrap_mode)
+    extremum = _make_x_extremum(volume.bbox(), volume, 4)
 
     ray = mi.Ray3f(o=[-0.5, 0, 0.5], d=[0, 1, 0])
     distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.0, target_ot=1.6)
@@ -461,7 +475,7 @@ def test_sample_rotated(
     volume = _make_x_volume(
         [1.0, 2.0, 3.0, 4.0], 4, wrap_mode=wrap_mode, to_world=to_world
     )
-    extremum = _make_x_extremum(volume.bbox(), volume, 4, wrap_mode=wrap_mode)
+    extremum = _make_x_extremum(volume.bbox(), volume, 4)
 
     ray = mi.Ray3f(
         o=to_world @ mi.ScalarPoint3f(-0.5, 0.5, 0.5),
@@ -471,3 +485,20 @@ def test_sample_rotated(
 
     assert np.allclose(distance, expected_distance)
     assert np.allclose(leftover_ot, expected_leftover)
+
+
+def test_sample_rotated_no_wrap(variant_scalar_mono):
+    # Same 45-degree setup as test_sample_rotated, but wrap=False: the gap
+    # contributes zero ot.
+    to_world = mi.ScalarAffineTransform4f.rotate([0, 0, 1], 45)
+    volume = _make_x_volume([1.0, 2.0, 3.0, 4.0], 4, wrap=False, to_world=to_world)
+    extremum = _make_x_extremum(volume.bbox(), volume, 4)
+
+    ray = mi.Ray3f(
+        o=to_world @ mi.ScalarPoint3f(-0.5, 0.5, 0.5),
+        d=to_world @ mi.ScalarVector3f(1, 0, 0),
+    )
+    distance, leftover_ot = extremum.sample_test(ray, 0.0, 1.5, target_ot=1.6)
+
+    assert np.allclose(distance, 1.275)
+    assert np.allclose(leftover_ot, 0.1)

--- a/src/volumes/grid.cpp
+++ b/src/volumes/grid.cpp
@@ -591,6 +591,14 @@ public:
 
         return { min_val, max_val };
     }
+
+    virtual VolumeParametrization<ScalarFloat> parametrization() const override {
+        VolumeParametrization<ScalarFloat> param;
+        param.to_world = m_to_local.inverse();
+        param.wrap = m_wrap;
+        param.wrap_mode = m_texture.wrap_mode();
+        return param;
+    }
 // #ERADIATE_CHANGE_END
 
     ScalarVector3i resolution() const override {


### PR DESCRIPTION
## Description

This PR extends `VolumeParametrization` to include wrap parameters. This allows  to remove the `wrap_mode` parameter from the `extremum_grid` interface, ensuring that it is always aligned to the settings of the volume.

The PR also modifies `traverse_extremum` to optimize traversal of clamped grids and grids with no wrapping policy. Previously, the DDA would continue traversing cell by cell outside the local [0,1] range. This is correct and required for repeat and mirror wrap policies but, while required, wastes a lot of time for clamp and no wrap policies. 
The traversal now accounts for this by skipping dimensions that are out of [0,1].

## Testing

Tests were added to cover no wrapping policies, which could not be properly be tested before this. A small fix had to be added to the clamp tests to account for merged clamped cells.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)