### PR TITLE
Ocean BSDFs invalid samples fix

### DIFF
--- a/docs_eradiate/conf.py
+++ b/docs_eradiate/conf.py
@@ -117,7 +117,7 @@ html_theme_options = {
     "light_logo": "_static/eradiate-mitsuba-logo-typo_simple-black.svg",
     "dark_logo": "_static/eradiate-mitsuba-logo-typo_simple-white.svg",
     "accent_color": "teal",
-    "github_url": "https://github.com/eradiate/eradiate-mitsuba",
+    "github_url": "https://github.com/eradiate/mitsuba3",
     "navigation_with_keys": True,
     "nav_links_align": "center",
     "nav_links": [

--- a/src/eradiate_plugins/bsdfs/ocean_grasp.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_grasp.cpp
@@ -239,7 +239,7 @@ public:
      * @param sigma Root Mean square slope.
      */
     Float lambda(const Vector3f &v, const Float sigma) const {
-        Float sigma_tan = sigma * dr::sqrt(1.f - v.z() * v.z()) / v.z();
+        Float sigma_tan = sigma * dr::safe_sqrt(1.f - v.z() * v.z()) / v.z();
         Float result =
             0.5f * (dr::sqrt(2.f / dr::Pi<Float>) * sigma_tan *
                         dr::exp(-dr::rcp(2.f * sigma_tan * sigma_tan)) -

--- a/src/eradiate_plugins/bsdfs/ocean_legacy.cpp
+++ b/src/eradiate_plugins/bsdfs/ocean_legacy.cpp
@@ -454,7 +454,7 @@ public:
         Point2f uv;
         Float t;
 
-        uv.x() = (dr::acos(cos_theta) * (dr::InvPi<Float> * 2.f));
+        uv.x() = (dr::acos(dr::clip(cos_theta, -0.999999999f, 0.999999999f)) * (dr::InvPi<Float> * 2.f));
         uv.y() =
             (dr::atan2(v.y(), v.x()) - m_wind_direction) * dr::InvTwoPi<Float>;
         uv.y() = uv.y() - (1.f * dr::floor(uv.y())); // equivalent to uv.y % 1.f


### PR DESCRIPTION
[bugfix]

## Description

We were having an issue with both the `ocean_legacy` and `ocean_grasp` BSDFs in S2GOS due to floating points precision issues. From a nadir looking mpdistant sensor we got some hits on a masked area of the buffer terrain where the  opacity is 0,  missing guards in these two BSDFs meant that they could get a vector where z is just outside [-1,1]. Also fixed the link to our mitsuba fork.

## Testing

On the S2GOS side the issue is gone when using this branch.

## Checklist

<!-- Please make sure to complete this checklist before requesting a review. -->

- [ x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [ x] My changes generate no new warnings
- [ x] My code also compiles for `cuda_*` and `llvm_*` variants. If you can't test this, please leave below
- [ ] I have commented my code
- [ x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I cleaned the commit history and removed any "Merge" commits
- [ x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)