### PR TITLE
Minor fixes to the multiphase plugin

### DIFF
--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -234,8 +234,8 @@ public:
             weight_values.push_back(eval_weight(mi, i, active));
             weight_sum += weight_values.back();
         }
-
-        Float inv_weight_sum = dr::rcp(weight_sum);
+        
+        Float inv_weight_sum = dr::select(weight_sum < dr::Epsilon<Float>, 1.0f, dr::rcp(weight_sum));
 
         if (unlikely(ctx.component != (uint32_t) -1)) {
             PhaseFunctionContext ctx2(ctx);

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -187,6 +187,10 @@ public:
                     for (size_t j = 0; j < m_nested_phases.size(); ++j) {
                         if (j == i) continue;
 
+                        // Ensure phases with zero weights are not called at all
+                        Mask mask_j = mask_i && (weight_values[j] > dr::Epsilon<Float>);
+                        if (!dr::any_or<true>(mask_j)) continue;
+                        
                         auto [val_j, pdf_j] = m_nested_phases[j]->eval_pdf(
                             ctx, mi, wo_i, mask_i
                         );
@@ -196,7 +200,7 @@ public:
                     }
 
                     Spectrum w_mis = dr::select(
-                        pdf_mixture > 1e-8f,
+                        pdf_mixture > dr::Epsilon<Float>,
                         phase_value_sum / pdf_mixture,
                         Spectrum(0.f)
                     );
@@ -259,6 +263,11 @@ public:
         Float pdf = 0.f;
 
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
+
+            //Ensure zero weighted phases are never called
+            Mask mask_i = active && (weight_values[i] > dr::Epsilon<Float>);
+            if (!dr::any_or<true>(mask_i)) continue;
+            
             auto [val_i, pdf_i] = m_nested_phases[i]->eval_pdf(ctx, mi, wo, active);
 
             Float phase_weight = weight_values[i] * inv_weight_sum;

--- a/src/eradiate_plugins/phase/multiphase.cpp
+++ b/src/eradiate_plugins/phase/multiphase.cpp
@@ -52,29 +52,29 @@ multiple populations of scattering elements.
 
         <phase type="multiphase">
             <boolean name="use_mis" value="true"/>
-
-            <phase name="phase0" type="isotropic"/>
-            <float name="weight0" value="1.0"/>
-            <phase name="phase1" type="hg">
+            
+            <phase name="phase_0" type="isotropic"/>
+            <float name="weight_0" value="1.0"/>
+            <phase name="phase_1" type="hg">
                 <float name="g" value="0.5"/>
             </phase>
-            <float name="weight1" value="1.0"/>
-            <phase name="phase2" type="hg">
+            <float name="weight_1" value="1.0"/>
+            <phase name="phase_2" type="hg">
                 <float name="g" value="0.2"/>
             </phase>
-            <float name="weight2" value="1.0"/>
+            <float name="weight_2" value="1.0"/>
         </phase>
 
     .. code-tab:: python
 
         'type': 'multiphase',
         'use_mis': True,
-        'phase0': {'type': 'isotropic'},
-        'weight0': 1.0,
-        'phase1': {'type': 'hg', 'g': 0.5},
-        'weight1': 1.0,
-        'phase2': {'type': 'hg', 'g': 0.2},
-        'weight2': 1.0
+        'phase_0': {'type': 'isotropic'},
+        'weight_0': 1.0,
+        'phase_1': {'type': 'hg', 'g': 0.5},
+        'weight_1': 1.0,
+        'phase_2': {'type': 'hg', 'g': 0.2},
+        'weight_2': 1.0
 
 */
 
@@ -94,7 +94,7 @@ public:
         for (auto &prop : props.objects()) {
             if (Base *phase = prop.try_get<Base>()) {
                 m_nested_phases.push_back(phase);
-                m_weights.push_back(props.get_volume<Volume>("weight" + std::to_string(phase_count)));
+                m_weights.push_back(props.get_volume<Volume>("weight_" + std::to_string(phase_count)));
                 phase_count++;
             }
         }
@@ -119,8 +119,8 @@ public:
 
     void traverse(TraversalCallback *cb) override {
         for (size_t i = 0; i < m_nested_phases.size(); ++i) {
-            cb->put("phase" + std::to_string(i), m_nested_phases[i], ParamFlags::Differentiable);
-            cb->put("weight" + std::to_string(i), m_weights[i], ParamFlags::Differentiable);
+            cb->put("phase_" + std::to_string(i), m_nested_phases[i], ParamFlags::Differentiable);
+            cb->put("weight_" + std::to_string(i), m_weights[i], ParamFlags::Differentiable);
         }
     }
 


### PR DESCRIPTION
## Description

Ensure the multiphase plugin handles cases where ssa is null.

Sampling phases whose component have a null ssa is correct in theory, but can result in issues in these component's phases if they are not defined at the interaction. This PR addresses these corner cases.

## Checklist

- [x] My code follows the [style guidelines](https://mitsuba.readthedocs.io/en/latest/src/developer_guide.html#coding-style) of this project
- [x] My changes generate no new warnings
- [x] My code also compiles for and `llvm_*` variants. If you can't test this, please leave below
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I cleaned the commit history and removed any "Merge" commits
- [x] I give permission that the Mitsuba 3 project may redistribute my contributions under the terms of its [license](https://github.com/mitsuba-renderer/mitsuba/blob/master/LICENSE)